### PR TITLE
Add meta_description to pages

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,3 +27,10 @@ categories.each do |parent, children|
   labels = children.nil? ? [parent] : children
   labels.each { |label| Comfy::Cms::Category.create(site_id: site.id, label: label, categorized_type: "Comfy::Cms::Page") }
 end
+
+puts "Seeding layouts..."
+default_content = <<-END
+{{ cms:page:meta_description:string }}
+{{ cms:page:content:rich_text }}
+END
+Comfy::Cms::Layout.find_or_create_by(site: site, content: default_content, label: "default", identifier: "default")

--- a/features/page_meta_data.feature
+++ b/features/page_meta_data.feature
@@ -1,0 +1,10 @@
+Feature: Page meta data
+  As a content editor
+  I can setup a Meta Description Tag
+  so I can make my content successful within Search Engines
+
+  Scenario: Editing meta decription
+    When I create a new article
+    And I fill in "description" as the meta_description
+    And I save the article page
+    Then the article's "meta_description" content should be "description"

--- a/features/step_definitions/new_page_steps.rb
+++ b/features/step_definitions/new_page_steps.rb
@@ -19,3 +19,18 @@ end
 Then(/^I should see its contents inside the CMS editor$/) do
   pending
 end
+
+When(/^I fill in "(.*?)" as the meta_description$/) do |value|
+  new_page.meta_description.set(value)
+end
+
+When(/^I save the article page$/) do
+  new_page.page_name.set('New page')
+  new_page.create_page.click
+end
+
+Then(/^the article's "(.*?)" content should be "(.*?)"$/) do |indentifier, value|
+  content = Comfy::Cms::Page.last.blocks.detect {|b| b.identifier == indentifier }.content
+  expect(content).to eq(value)
+end
+

--- a/features/support/ui/pages/new.rb
+++ b/features/support/ui/pages/new.rb
@@ -10,5 +10,8 @@ module UI::Pages
 
     element :publish, '#new_page input.btn-primary'
     element :upload_word, '#upload-word-doc'
+    element :page_name, '#page_label'
+    element :meta_description, '#page_blocks_attributes_0_content'
+    element :create_page, "input[value='Create Page']"
   end
 end

--- a/features/support/world/cms.rb
+++ b/features/support/world/cms.rb
@@ -7,7 +7,7 @@ module World
     end
 
     def cms_layout
-      self.layout ||= cms_site.layouts.create(identifier: identifier, content: '{{ cms:page:content:rich_text }}')
+      self.layout ||= cms_site.layouts.create(identifier: identifier, content: '{{ cms:page:meta_description:string }}\n{{ cms:page:content:rich_text }}')
     end
 
     def cms_root


### PR DESCRIPTION
Uses Comfy's tags to create a new field for meta_description, and seeds the DB with a default layout. 
