### PR TITLE
Bump cms-editor version

### DIFF
--- a/bower.json.erb
+++ b/bower.json.erb
@@ -8,7 +8,7 @@
   "dependencies": {
     "dough": "<%= gem_path('dough-ruby') %>",
     "requirejs": "2.1.11",
-    "mas-cms-editor": "git://github.com/moneyadviceservice/cms-editor.git#e52134e7826da6045551282ad1dbb630034625fe",
+    "mas-cms-editor": "git://github.com/moneyadviceservice/cms-editor.git#07f9355b1b646a4b18572a1e5db575d7fa02467f",
     "components-font-awesome": "4.1.0",
     "chosen-build": "1.1.0",
     "taggle.js":"1.4",


### PR DESCRIPTION
Stops tables being converted from Markdown to HTML 
https://github.com/moneyadviceservice/cms-editor/commits/master
