### PR TITLE
Don't require spec_helper file

### DIFF
--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe FilesController do
   before do
     sign_in create(:user)

--- a/spec/controllers/notes_controller_spec.rb
+++ b/spec/controllers/notes_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe NotesController do
   let(:current_user) { create(:user) }
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe PagesController do
   let(:site) { page.site }
   let(:current_user) { create(:user) }

--- a/spec/controllers/word_documents_controller_spec.rb
+++ b/spec/controllers/word_documents_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe WordDocumentsController, type: :controller do
   include_context 'cms'
 
@@ -14,5 +12,4 @@ RSpec.describe WordDocumentsController, type: :controller do
       # expect(assigns(:page).blocks.first.content).to_not be_nil
     end
   end
-
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe PagesHelper do
   class Tester
     include PagesHelper

--- a/spec/lib/cms/view_methods_spec.rb
+++ b/spec/lib/cms/view_methods_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe '#highlighted_terms' do
   class TestHelper
     include ActionView::Helpers

--- a/spec/lib/hippo_import_spec.rb
+++ b/spec/lib/hippo_import_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require_relative '../../lib/cms/hippo_import'
 
 describe HippoImport do

--- a/spec/models/activity_log_spec.rb
+++ b/spec/models/activity_log_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe ActivityLog do
   describe '.fetch' do
     subject(:fetch) { ActivityLog.fetch(from: page) }

--- a/spec/models/revision_data_spec.rb
+++ b/spec/models/revision_data_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe RevisionData do
   describe '.load' do
     let(:revision) { double }

--- a/spec/presenters/activity_log_presenter_spec.rb
+++ b/spec/presenters/activity_log_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe ActivityLogPresenter do
   subject(:presenter) do
     described_class.new(object)

--- a/spec/presenters/page_presenter_spec.rb
+++ b/spec/presenters/page_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe PagePresenter do
   subject(:presenter) do
     described_class.new(object)
@@ -12,5 +10,4 @@ RSpec.describe PagePresenter do
       expect(presenter.last_update).to eq("01/08/2014, 14:45")
     end
   end
-
 end


### PR DESCRIPTION
- The spec_helper file is required in .rspec setting file.
