### PR TITLE
Remove snippet insertion point validation

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/scribe-plugin-mastalk.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/scribe-plugin-mastalk.js
@@ -47,19 +47,7 @@ define([
       };
 
       mastalkCommand.queryEnabled = function () {
-        var selection = new scribe.api.Selection();
-        return (selection.selection.anchorNode === scribe.el) || !!selection.getContaining(function (node) {
-          var innerText;
-          if(node.innerText){
-            innerText = node.innerText;
-          }
-          else {
-            if(node !== document) {
-              innerText = node.parentElement.innerText;
-            }
-          }
-          return node.nodeName === this.nodeName && !innerText.replace('\n','').length;
-        }.bind(this));
+        return true;
       };
 
       scribe.commands[commandName] = mastalkCommand;


### PR DESCRIPTION
Before, we would check to see if a snippet was in another tag/element and disable the insertion.
