### PR TITLE
Always save the blocks attributes last revision

### DIFF
--- a/app/models/page_register.rb
+++ b/app/models/page_register.rb
@@ -36,7 +36,7 @@ class PageRegister
       data[:event]          = page.state
     end
 
-    data[:blocks_attributes] = @blocks_attributes_was if page.blocks_attributes_changed
+    data[:blocks_attributes] = @blocks_attributes_was
 
     RevisionData.dump(data.merge(current_user: current_user))
   end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe PagesController do
           expect(last_revision.data).to eq(
             event: 'draft',
             previous_event: nil,
+            blocks_attributes: [],
             author: {
               id: current_user.id,
               name: current_user.name
@@ -182,6 +183,7 @@ RSpec.describe PagesController do
           expect(last_revision.data.symbolize_keys).to eq(
             event: 'published',
             previous_event: 'draft',
+            blocks_attributes: [],
             author: {
               id: current_user.id,
               name: current_user.name


### PR DESCRIPTION
- The BlockSerializer are expecting the last revision in the blocks
  attributes. And in the frontend site are verifying if content is empty or not.
