### PR TITLE
Whitelist ID attributes in heading and a tags

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
@@ -57,15 +57,15 @@ define([
             ol: {},
             ul: {},
             li: {},
-            a: { href: true },
+            a: { href: true, id: true },
             h2: {},
             h3: {},
             h4: {},
             h5: {},
             sub: {},
             sup: {},
-            span: { 'class': true, id: true},
-            img: { 'class': true, src: true}
+            span: { 'class': true, id: true },
+            img: { 'class': true, src: true }
           }
         }
       }


### PR DESCRIPTION
Proposal...

[Revised] To allow the use of anchor links within the editor will need to specify an anchor using `<a id=“foo”></a>`. To link to the anchor in Markdown is simple: `[Show me foo](#foo)`.
