### PR TITLE
Popular links

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,1 +1,3 @@
 FRONTEND_URL="localhost:5000"
+GA_API_EMAIL_ADDRESS="google.service.account@example.com"
+GA_PRIVATE_KEY_PATH="path/to/private.key"

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,10 @@ gem 'devise'
 gem 'reverse_markdown'
 gem 'active_model_serializers'
 
+gem 'oauth2', '1.0.0'
+gem 'google-api-client', '0.7.1'
+gem 'legato', '0.4.0'
+
 group :development do
   gem 'spring'
   gem 'spring-commands-cucumber'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'active_model_serializers'
 gem 'oauth2', '1.0.0'
 gem 'google-api-client', '0.7.1'
 gem 'legato', '0.4.0'
+gem 'whenever', '0.9.4', require: false
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
     autoprefixer-rails (3.1.2.20141016)
       execjs
     bcrypt (3.1.7)
@@ -191,6 +195,7 @@ GEM
       dotenv (= 1.0.2)
     erubis (2.7.0)
     execjs (2.2.2)
+    extlib (0.9.16)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.4.1)
@@ -198,8 +203,21 @@ GEM
       railties (>= 3.0.0)
     faker (1.4.3)
       i18n (~> 0.5)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
     gherkin (2.12.2)
       multi_json (~> 1.3)
+    google-api-client (0.7.1)
+      addressable (>= 2.3.2)
+      autoparse (>= 0.3.3)
+      extlib (>= 0.9.15)
+      faraday (>= 0.9.0)
+      jwt (>= 0.1.5)
+      launchy (>= 2.1.1)
+      multi_json (>= 1.0.0)
+      retriable (>= 1.4)
+      signet (>= 0.5.0)
+      uuidtools (>= 2.1.0)
     haml (4.0.5)
       tilt
     haml-rails (0.5.3)
@@ -220,6 +238,7 @@ GEM
     jquery-ui-rails (5.0.2)
       railties (>= 3.2.16)
     json (1.8.1)
+    jwt (1.2.0)
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -227,6 +246,8 @@ GEM
     kramdown (1.5.0)
     launchy (2.4.2)
       addressable (~> 2.3)
+    legato (0.4.0)
+      multi_json
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -236,11 +257,19 @@ GEM
     minitest (5.4.3)
     multi_json (1.10.1)
     multi_test (0.1.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     mysql2 (0.3.16)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     nokogiri-styles (0.1.2)
       nokogiri
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
     orm_adapter (0.5.0)
     paperclip (4.2.0)
       activemodel (>= 3.0.0)
@@ -298,6 +327,7 @@ GEM
     remotipart (1.2.1)
     responders (1.1.1)
       railties (>= 3.2, < 4.2)
+    retriable (1.4.1)
     reverse_markdown (0.6.0)
       nokogiri
     rspec (3.1.0)
@@ -339,6 +369,12 @@ GEM
       sprockets-rails (~> 2.0)
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
+    signet (0.6.0)
+      addressable (~> 2.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      jwt (~> 1.0)
+      multi_json (~> 1.10)
     site_prism (2.6)
       addressable (~> 2.3.3)
       capybara (>= 2.1, < 3.0)
@@ -383,6 +419,7 @@ GEM
     unicorn-rails (2.2.0)
       rack
       unicorn
+    uuidtools (2.1.5)
     warden (1.2.3)
       rack (>= 1.0)
     websocket-driver (0.3.5)
@@ -405,12 +442,15 @@ DEPENDENCIES
   dough-ruby (~> 4.0)!
   factory_girl_rails (~> 4.0)
   faker
+  google-api-client (= 0.7.1)
   hippo_xml_parser!
   jbuilder (~> 2.0)
   jquery-rails
   jquery-ui-rails (~> 5.0)
+  legato (= 0.4.0)
   mas-development_dependencies!
   mysql2
+  oauth2 (= 1.0.0)
   pry-rails
   rails (= 4.1.1)
   remotipart (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
       capybara (>= 1.0, < 3)
       colored
       launchy
+    chronic (0.10.2)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -423,6 +424,8 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket-driver (0.3.5)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -467,4 +470,5 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   unicorn-rails
+  whenever (= 0.9.4)
   word-to-markdown!

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ bowndler update
 ```
 
 ## Configuration
-Make sure you set the HOSTNAME variable in the `.env` file appropriately.
+Make sure you set the HOSTNAME, GA_API_EMAIL_ADDRESS, GA_PRIVATE_KEY_PATH variables in the `.env` file appropriately.
 
 ## JavaScript testing
 
@@ -48,3 +48,13 @@ Any new components should be built here first, then integrated into the views.
 ## Environment variables
 
     cp .env.dev .env
+
+## Cron / Rake
+
+The rake task
+```bundle exec rake cms:update_page_views```
+
+is to retrieve page views from Google Analytics for articles.
+This allows us to generate the Popular links section that is displayed in the frontend application.
+
+The rake task is setup by whenever in config/schedule.rb

--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -8,7 +8,13 @@ class PageSerializer < ActiveModel::Serializer
   has_many :blocks, serializer: BlockSerializer
 
   def related_content
-    { popular_links: [{ title: 'Sharky', path: '/cheese' },
-                      { title: 'George', path: '/wine' }] }
+    popular_links = Comfy::Cms::Page.most_popular(3).map do |article|
+      {
+        title: article.label,
+        path: "/en/articles/#{article.slug}"
+      }
+    end
+
+    { popular_links: popular_links }
   end
 end

--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -9,9 +9,12 @@ class PageSerializer < ActiveModel::Serializer
 
   def related_content
     popular_links = Comfy::Cms::Page.most_popular(3).map do |article|
+      current_locale = object.site.label
+      article = article.mirrors.first if current_locale == 'cy'
+
       {
         title: article.label,
-        path: "/en/articles/#{article.slug}"
+        path: "/#{current_locale}/articles/#{article.slug}"
       }
     end
 

--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -3,7 +3,12 @@ require 'active_model_serializers'
 class PageSerializer < ActiveModel::Serializer
   attributes :label, :slug, :full_path,
              :meta_description, :meta_title, :category_names,
-             :layout_identifier
+             :layout_identifier, :related_content
 
   has_many :blocks, serializer: BlockSerializer
+
+  def related_content
+    { popular_links: [{ title: 'Sharky', path: '/cheese' },
+                      { title: 'George', path: '/wine' }] }
+  end
 end

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -110,3 +110,5 @@ ComfortableMexicanSofa::HttpAuth.password = 'password'
 # Enable page tagging!
 require_relative '../../lib/comfortable_mexican_sofa/extensions/is_taggable'
 Comfy::Cms::Page.send(:is_taggable)
+
+require_relative '../../lib/comfortable_mexican_sofa/extensions/page'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every 1.day, at: '3:00 am' do
+  rake 'cms:update_page_views'
+end

--- a/db/migrate/20141217154822_add_page_views_to_pages.rb
+++ b/db/migrate/20141217154822_add_page_views_to_pages.rb
@@ -1,0 +1,5 @@
+class AddPageViewsToPages < ActiveRecord::Migration
+  def change
+    add_column :comfy_cms_pages, :page_views, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141127120457) do
+ActiveRecord::Schema.define(version: 20141217154822) do
 
   create_table "comfy_cms_blocks", force: true do |t|
     t.string   "identifier",                      null: false
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20141127120457) do
     t.boolean  "regulated",                         default: false
     t.string   "meta_title"
     t.string   "translation_id"
+    t.integer  "page_views",                        default: 0
   end
 
   add_index "comfy_cms_pages", ["parent_id", "position"], name: "index_comfy_cms_pages_on_parent_id_and_position", using: :btree
@@ -139,17 +140,17 @@ ActiveRecord::Schema.define(version: 20141127120457) do
   add_index "comfy_cms_snippets", ["site_id", "position"], name: "index_comfy_cms_snippets_on_site_id_and_position", using: :btree
 
   create_table "comfy_cms_users", force: true do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.string   "name",                   default: "", null: false
+    t.string   "name",                   default: "",    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "admin",                  default: false

--- a/lib/cms/update_page_views_task.rb
+++ b/lib/cms/update_page_views_task.rb
@@ -2,10 +2,18 @@ require_relative '../google_analytics/api'
 
 class UpdatePageViewsTask
   def self.run
+    log('Starting UpdatePageViewsTask')
     google_analytics_results = GoogleAnalytics::API.fetch_article_page_views
 
     Comfy::Cms::Page.all_english_articles.each do |article|
-      article.update_page_views google_analytics_results
+      unless article.update_page_views google_analytics_results
+        log("Error updating article: #{article.id}")
+      end
     end
+    log('Completed UpdatePageViewsTask')
+  end
+
+  def self.log(message)
+    Rails.logger.info("#{Time.now}: #{message}")
   end
 end

--- a/lib/cms/update_page_views_task.rb
+++ b/lib/cms/update_page_views_task.rb
@@ -1,0 +1,11 @@
+require_relative '../google_analytics/api'
+
+class UpdatePageViewsTask
+  def self.run
+    google_analytics_results = GoogleAnalytics::API.fetch_article_page_views
+
+    Comfy::Cms::Page.all_english_articles.each do |article|
+      article.update_page_views google_analytics_results
+    end
+  end
+end

--- a/lib/comfortable_mexican_sofa/extensions/page.rb
+++ b/lib/comfortable_mexican_sofa/extensions/page.rb
@@ -1,0 +1,16 @@
+class Comfy::Cms::Page
+  def self.all_english_articles
+    joins(:layout)
+    .joins(:site)
+    .where(
+      comfy_cms_sites: { label: 'en' },
+      comfy_cms_layouts: { identifier: 'article' }
+    )
+  end
+
+  def update_page_views(analytics)
+    matching_analytic = analytics.find { |analytic| analytic[:label] == slug }
+    new_page_views = matching_analytic.present? ? matching_analytic[:page_views] : 0
+    update_attribute(:page_views, new_page_views)
+  end
+end

--- a/lib/comfortable_mexican_sofa/extensions/page.rb
+++ b/lib/comfortable_mexican_sofa/extensions/page.rb
@@ -1,4 +1,6 @@
 class Comfy::Cms::Page
+  scope :most_popular, -> (number_of_items) { unscoped.order('page_views desc').limit(number_of_items) }
+
   def self.all_english_articles
     joins(:layout)
     .joins(:site)

--- a/lib/google_analytics/api.rb
+++ b/lib/google_analytics/api.rb
@@ -1,0 +1,31 @@
+require_relative 'page'
+require 'google/api_client'
+
+module GoogleAnalytics
+  class API
+    def self.fetch_article_page_views
+      user = Legato::User.new new_oauth2_token
+      profile = user.profiles.first
+
+      GoogleAnalytics::Page.popular_articles(profile)
+    end
+
+    def self.new_oauth2_token
+      scope = 'https://www.googleapis.com/auth/analytics.readonly'
+      client = Google::APIClient.new(
+        application_name:    'GA Test',
+        application_version: '1.0.0'
+      )
+      key = Google::APIClient::PKCS12.load_key(ENV['GA_PRIVATE_KEY_PATH'], 'notasecret')
+      service_account = Google::APIClient::JWTAsserter.new(ENV['GA_API_EMAIL_ADDRESS'], scope, key)
+      client.authorization = service_account.authorize
+      OAuth2::AccessToken.new(oauth_client, client.authorization.access_token, expires_in: 1.hour)
+    end
+
+    def self.oauth_client
+      OAuth2::Client.new('', '',
+                         authorize_url: 'https://accounts.google.com/o/oauth2/auth',
+                         token_url: 'https://accounts.google.com/o/oauth2/token')
+    end
+  end
+end

--- a/lib/google_analytics/page.rb
+++ b/lib/google_analytics/page.rb
@@ -1,0 +1,20 @@
+module GoogleAnalytics
+  class Page
+    extend Legato::Model
+
+    metrics :pageviews
+    dimensions :page_path
+
+    def self.popular_articles(profile)
+      popular_pages = results(profile, start_date: 1.week.ago, end_date: Time.now, sort: '-pageviews', limit: 10_000)
+      popular_pages
+        .select { |page| page.pagePath =~ /\A\/en\/articles\/[\w-]+/i }
+        .map { |p| { page_views: p.pageviews.to_i, label: label(p.pagePath) } }
+    end
+
+    def self.label(url)
+      match_data = url.match(/\A\/en\/articles\/([\w-]+)/i)
+      match_data.captures.first
+    end
+  end
+end

--- a/lib/tasks/update_page_views.rake
+++ b/lib/tasks/update_page_views.rake
@@ -1,0 +1,8 @@
+require_relative '../cms/update_page_views_task'
+
+namespace :cms do
+  desc 'Updates articles page views from Google Analytics'
+  task update_page_views: :environment do
+    UpdatePageViewsTask.run
+  end
+end

--- a/spec/lib/cms/update_page_views_task_spec.rb
+++ b/spec/lib/cms/update_page_views_task_spec.rb
@@ -1,0 +1,29 @@
+require Rails.root.join('lib/cms/update_page_views_task')
+
+RSpec.describe UpdatePageViewsTask do
+
+  describe 'run' do
+
+    it 'updates each english article with google analytics results' do
+      google_analytics_results = double('analytics results')
+      first_article = Comfy::Cms::Page.new
+      second_article = Comfy::Cms::Page.new
+      articles = [first_article, second_article]
+
+      allow(GoogleAnalytics::API)
+        .to receive(:fetch_article_page_views)
+        .and_return(google_analytics_results)
+
+      allow(Comfy::Cms::Page)
+        .to receive(:all_english_articles)
+        .and_return(articles)
+
+      expect(first_article).to receive(:update_page_views).with(google_analytics_results)
+      expect(second_article).to receive(:update_page_views).with(google_analytics_results)
+
+      UpdatePageViewsTask.run
+    end
+
+  end
+
+end

--- a/spec/lib/comfortable_mexican_sofa/extensions/page_spec.rb
+++ b/spec/lib/comfortable_mexican_sofa/extensions/page_spec.rb
@@ -1,0 +1,54 @@
+require Rails.root.join('lib/comfortable_mexican_sofa/extensions/page')
+
+RSpec.describe Comfy::Cms::Page do
+  describe 'all_english_articles' do
+    it 'does not return english news pages' do
+      english_site = FactoryGirl.create :site, label: 'en'
+      news_layout = FactoryGirl.create :layout, identifier: 'news'
+      FactoryGirl.create :page, site: english_site, layout: news_layout
+
+      expect(Comfy::Cms::Page.all_english_articles).to be_empty
+    end
+
+    it 'does not return welsh article pages' do
+      welsh_site = FactoryGirl.create :site, :welsh
+      article_layout = FactoryGirl.create :layout, identifier: 'article'
+      FactoryGirl.create :page, site: welsh_site, layout: article_layout
+
+      expect(Comfy::Cms::Page.all_english_articles).to be_empty
+    end
+
+    it 'provides english article pages' do
+      english_site = FactoryGirl.create :site, label: 'en'
+      article_layout = FactoryGirl.create :layout, identifier: 'article'
+      article_page = FactoryGirl.create :page, site: english_site, layout: article_layout
+
+      expect(Comfy::Cms::Page.all_english_articles.all).to eq([article_page])
+    end
+
+  end
+
+  describe '#update_page_views' do
+
+    let(:analytics) do
+      [
+        { label: 'first label', page_views: 1000 },
+        { label: 'how-to-become-a-millionaire', page_views: 500 }
+      ]
+    end
+
+    it 'updates page with views from analytics' do
+      subject = Comfy::Cms::Page.new(page_views: 200, slug: 'how-to-become-a-millionaire')
+      expect(subject).to receive(:update_attribute).with(:page_views, 500)
+
+      subject.update_page_views(analytics)
+    end
+
+    it 'zeros page_views when not in analytics' do
+      subject = Comfy::Cms::Page.new(page_views: 300, slug: 'not-in-analytics')
+      expect(subject).to receive(:update_attribute).with(:page_views, 0)
+
+      subject.update_page_views(analytics)
+    end
+  end
+end

--- a/spec/lib/comfortable_mexican_sofa/extensions/page_spec.rb
+++ b/spec/lib/comfortable_mexican_sofa/extensions/page_spec.rb
@@ -51,4 +51,22 @@ RSpec.describe Comfy::Cms::Page do
       subject.update_page_views(analytics)
     end
   end
+
+  describe '#most_popular scope' do
+
+    it 'has the three most popular articles' do
+      FactoryGirl.create :page, page_views: 100, position: 1
+      FactoryGirl.create :page, page_views: 5,   position: 2
+      FactoryGirl.create :page, page_views: 200, position: 3
+      FactoryGirl.create :page, page_views: 1,   position: 4
+      FactoryGirl.create :page, page_views: 152, position: 5
+      FactoryGirl.create :page, page_views: 50,  position: 6
+
+      results = Comfy::Cms::Page.most_popular(3)
+
+      expect(results.map(&:page_views)).to eq([200, 152, 100])
+    end
+
+  end
+
 end

--- a/spec/lib/google_analytics/page_spec.rb
+++ b/spec/lib/google_analytics/page_spec.rb
@@ -1,0 +1,40 @@
+module GoogleAnalytics
+  RSpec.describe Page do
+    describe 'popular_articles' do
+      let(:profile) { double('profile') }
+
+      let(:google_results) do
+        [
+          OpenStruct.new(pagePath: '/en/articles/help-with-debt', pageviews: '270'),
+          OpenStruct.new(pagePath: '/en/articles/how-to-save-money', pageviews: '180'),
+          OpenStruct.new(pagePath: '/en/articles/a-new-advice-article/preview', pageviews: '80'),
+          OpenStruct.new(pagePath:  "/en/articles/{\"title\":\"Win Money\",\"desc\":\"Online casinoPlay now\"}&cost=0",
+                         pageviews: '80'),
+          OpenStruct.new(pagePath: '/en/news/ignore-news', pageviews: '70'),
+          OpenStruct.new(pagePath: '/en/tools/ignore-tools', pageviews: '60'),
+          OpenStruct.new(pagePath: '/cy/articles/ignore-welsh-article', pageviews: '50'),
+          OpenStruct.new(pagePath:  'http://google.com/http://moneyadviceservice.org.uk/en/articles/ignore-embedded-english-article',
+                         pageviews: '40')
+        ]
+      end
+
+      before(:each) do
+        allow(GoogleAnalytics::Page).to receive(:results).and_return(google_results)
+        @results = Page.popular_articles(profile)
+      end
+
+      it { expect(@results).to contain_article_label('help-with-debt', 270) }
+      it { expect(@results).to contain_article_label('how-to-save-money', 180) }
+      it { expect(@results).to contain_article_label('a-new-advice-article', 80) }
+      it { expect(@results).to_not contain_article_label('ignore-news') }
+      it { expect(@results).to_not contain_article_label('ignore-tools') }
+      it { expect(@results).to_not contain_article_label('ignore-welsh-article') }
+      it { expect(@results).to_not contain_article_label('ignore-embedded-english-article') }
+
+      it 'handles strange JSON url' do
+        # From real analytics
+        expect(@results).to_not contain_article_label('{"title":"Win Money","desc":"Online casinoPlay now"}&cost=0')
+      end
+    end
+  end
+end

--- a/spec/serializers/page_serializer_spec.rb
+++ b/spec/serializers/page_serializer_spec.rb
@@ -1,5 +1,6 @@
 describe PageSerializer do
-  let(:article) { Comfy::Cms::Page.new }
+  let(:site) { Comfy::Cms::Site.new(label: 'en') }
+  let(:article) { Comfy::Cms::Page.new(site: site) }
   subject { described_class.new(article) }
 
   describe '#related_content' do
@@ -7,6 +8,8 @@ describe PageSerializer do
     context 'popular_links' do
 
       it 'has the three most popular articles' do
+
+        site.label = 'en'
         pages =  [Comfy::Cms::Page.new(slug: 'first-article', label: 'First Article'),
                   Comfy::Cms::Page.new(slug: 'second-article', label: 'Second Article')]
 
@@ -19,6 +22,24 @@ describe PageSerializer do
         expect(popular_links).to eq([
           { title: 'First Article', path: '/en/articles/first-article' },
           { title: 'Second Article', path: '/en/articles/second-article' }
+        ])
+      end
+
+      it 'has the three most popular articles in welsh' do
+        site.label = 'cy'
+        english_article = Comfy::Cms::Page.new(slug: 'first-article-in_english', label: 'First Article in English')
+        welsh_article = Comfy::Cms::Page.new(slug: 'first-article-in-welsh', label: 'First Article in Welsh')
+
+        allow(english_article).to receive(:mirrors).and_return([welsh_article])
+
+        allow(Comfy::Cms::Page)
+          .to receive(:most_popular)
+          .with(3)
+          .and_return([english_article])
+
+        popular_links = subject.related_content[:popular_links]
+        expect(popular_links).to eq([
+          { title: 'First Article in Welsh', path: '/cy/articles/first-article-in-welsh' }
         ])
       end
 

--- a/spec/serializers/page_serializer_spec.rb
+++ b/spec/serializers/page_serializer_spec.rb
@@ -1,0 +1,29 @@
+describe PageSerializer do
+  let(:article) { Comfy::Cms::Page.new }
+  subject { described_class.new(article) }
+
+  describe '#related_content' do
+
+    context 'popular_links' do
+
+      it 'has the three most popular articles' do
+        pages =  [Comfy::Cms::Page.new(slug: 'first-article', label: 'First Article'),
+                  Comfy::Cms::Page.new(slug: 'second-article', label: 'Second Article')]
+
+        allow(Comfy::Cms::Page)
+          .to receive(:most_popular)
+          .with(3)
+          .and_return(pages)
+
+        popular_links = subject.related_content[:popular_links]
+        expect(popular_links).to eq([
+          { title: 'First Article', path: '/en/articles/first-article' },
+          { title: 'Second Article', path: '/en/articles/second-article' }
+        ])
+      end
+
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,5 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require_relative '../config/environment'
 require_relative 'support/cms'
+require_relative 'support/contain_article_label_matcher'
 require 'mas/development_dependencies/rspec/spec_helper'

--- a/spec/support/contain_article_label_matcher.rb
+++ b/spec/support/contain_article_label_matcher.rb
@@ -1,0 +1,13 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :contain_article_label do |expected_label, expected_page_views = nil|
+  match do |actual|
+    actual.each do |google_result_hash|
+      label_matches = expected_label == google_result_hash[:label]
+      page_views_matches = expected_page_views.present? ? expected_page_views == google_result_hash[:page_views] : true
+      return true if label_matches && page_views_matches
+    end
+
+    false
+  end
+end


### PR DESCRIPTION
Making popular links available through the service call from frontend.
Essentially we expose the 3 most popular articles over the last week in the JSON response.

For this to be deployed we'll need to have a private key (for google analytics api access) setup on the deployment machine. Once deployed, we will want to update the deploy script to invoke `whenever -w` on each deploy to update the cron for the deployment server.