### PR TITLE
Move linkable object to page model

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -1,0 +1,10 @@
+require ComfortableMexicanSofa::Engine.root.join('app', 'models', 'comfy', 'cms', 'page.rb')
+
+class Comfy::Cms::Page < ActiveRecord::Base
+  def self.find_by_url(url)
+    paths = Comfy::Cms::Site.pluck(:path).reject(&:blank?)
+    slug = url.sub(/#{paths.join('|')}/, '').sub('articles', '').squeeze('/').gsub(/\A\//, '')
+
+    Comfy::Cms::Page.where(slug: slug).take
+  end
+end

--- a/app/models/linkable_object.rb
+++ b/app/models/linkable_object.rb
@@ -8,10 +8,7 @@ class LinkableObject
   end
 
   def self.find_page(url)
-    paths = Comfy::Cms::Site.pluck(:path).reject(&:blank?)
-    slug = url.sub(/#{paths.join('|')}/, '').sub('articles', '').squeeze('/').gsub(/\A\//, '')
-
-    Comfy::Cms::Page.where(slug: slug).take
+    Comfy::Cms::Page.find_by_url(url)
   end
 
   def self.find_file(url)

--- a/spec/models/comfy/cms/page_spec.rb
+++ b/spec/models/comfy/cms/page_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe Comfy::Cms::Page do
+  describe '.find_by_url' do
+    context 'when page' do
+      let!(:page) { create(:page, site: site, slug: 'investing-money') }
+      let(:site) { create(:site, path: 'en') }
+
+      context 'when site has path' do
+        it 'returns page' do
+          expect(described_class.find_by_url('/en/investing-money')).to eq(page)
+        end
+      end
+
+      context 'when site does not have path' do
+        let(:site) { create(:site, path: nil) }
+
+        it 'returns page' do
+          expect(described_class.find_by_url('/investing-money')).to eq(page)
+        end
+      end
+
+      context 'when url has the "articles" word between path and slug' do
+        it 'returns page' do
+          expect(described_class.find_by_url('/en/articles/investing-money')).to eq(page)
+        end
+      end
+
+      context 'when url has the site path included in the slug' do
+        let!(:page) { create(:page, site: site, slug: 'investing-money-en') }
+
+        it 'returns page' do
+          expect(described_class.find_by_url('/en/articles/investing-money-en')).to eq(page)
+        end
+      end
+    end
+
+    context 'when file' do
+      let(:url) { 'system/file.pdf' }
+
+      it 'returns nil' do
+        expect(described_class.find_by_url(url)).to be_nil
+      end
+    end
+
+    context 'when external url' do
+      let(:url) { 'http://moneysite.com/' }
+
+      it 'returns nil' do
+        expect(described_class.find_by_url(url)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/linkable_object_spec.rb
+++ b/spec/models/linkable_object_spec.rb
@@ -36,57 +36,6 @@ RSpec.describe LinkableObject do
     end
   end
 
-  describe '.find_page' do
-    context 'when page' do
-      let!(:page) { create(:page, site: site, slug: 'investing-money') }
-      let(:site) { create(:site, path: 'en') }
-
-      context 'when site has path' do
-        it 'returns page' do
-          expect(described_class.find_page('/en/investing-money')).to eq(page)
-        end
-      end
-
-      context 'when site does not have path' do
-        let(:site) { create(:site, path: nil) }
-
-        it 'returns page' do
-          expect(described_class.find_page('/investing-money')).to eq(page)
-        end
-      end
-
-      context 'when url has the "articles" word between path and slug' do
-        it 'returns page' do
-          expect(described_class.find_page('/en/articles/investing-money')).to eq(page)
-        end
-      end
-
-      context 'when url has the site path included in the slug' do
-        let!(:page) { create(:page, site: site, slug: 'investing-money-en') }
-
-        it 'returns page' do
-          expect(described_class.find_page('/en/articles/investing-money-en')).to eq(page)
-        end
-      end
-    end
-
-    context 'when file' do
-      let(:url) { 'system/file.pdf' }
-
-      it 'returns nil' do
-        expect(described_class.find_page(url)).to be_nil
-      end
-    end
-
-    context 'when external url' do
-      let(:url) { 'http://moneysite.com/' }
-
-      it 'returns nil' do
-        expect(described_class.find_page(url)).to be_nil
-      end
-    end
-  end
-
   describe '#find_file' do
     before do
       expect(Comfy::Cms::File).to receive(:find_by).with(file_file_name: file_name).and_return(object)


### PR DESCRIPTION
Refactor LinkableObject.find_page method and move to the right object.

* Here we are reopening the comfortable mexican sofa code to extend
  rather than modifying it.