### PR TITLE
Remove CI rspec config to the main file and move to CI test file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,9 +1,2 @@
 --color
 --require spec_helper
---format html
---out tmp/spec.html
---format RspecJunitFormatter
---out tmp/spec.xml
---format progress
---profile
---deprecation-out log/rspec_deprecations.txt

--- a/test.sh
+++ b/test.sh
@@ -23,6 +23,6 @@ fi
 CI_PIPELINE_COUNTER=${GO_PIPELINE_COUNTER-0}
 CI_EXECUTOR_NUMBER=${EXECUTOR_NUMBER-0}
 
-rake spec
+rspec spec --format html --out tmp/spec.html --format RspecJunitFormatter --out tmp/spec.xml --format progress --profile --deprecation-out log/rspec_deprecations.txt
 rake cucumber
 ./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js --single-run


### PR DESCRIPTION
Each time that you run the specs, they run with the build config and you need to overwrite. So let's move this config to the CI test script and add to .rspec only the config that the team uses.
