### PR TITLE
adding latest blog post links (form Publify) to page_serializer for frontend

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,5 @@
 FRONTEND_URL="localhost:5000"
 GA_API_EMAIL_ADDRESS="google.service.account@example.com"
 GA_PRIVATE_KEY_PATH="path/to/private.key"
+PUBLIFY_HOSTNAME="blog.moneyadviceservice.org.uk"
+PUBLIFY_PORT="80"

--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -9,6 +9,7 @@ class PageSerializer < ActiveModel::Serializer
 
   def related_content
     {
+      latest_blog_post_links: latest_blog_post_links,
       popular_links: popular_links,
       previous_link: previous_link,
       next_link: next_link
@@ -19,6 +20,16 @@ class PageSerializer < ActiveModel::Serializer
 
   def current_locale
     object.site.label
+  end
+
+  def latest_blog_post_links
+    Publify::API.latest_links(3).map do |input_blog_post|
+      {
+        title: input_blog_post['title'],
+        path: input_blog_post['link'],
+        date: input_blog_post['pubDate']
+      }
+    end
   end
 
   def popular_links

--- a/lib/publify/api.rb
+++ b/lib/publify/api.rb
@@ -1,0 +1,14 @@
+require 'net/http'
+
+module Publify
+  class API
+    def self.latest_links(limit)
+      uri = URI("http://#{PUBLIFY_HOSTNAME}/articles.json")
+      response = Net::HTTP.get uri
+      JSON.parse(response).first(limit)
+    rescue => e
+      Rails.logger.error(e.message)
+      []
+    end
+  end
+end

--- a/lib/publify/api.rb
+++ b/lib/publify/api.rb
@@ -3,7 +3,7 @@ require 'net/http'
 module Publify
   class API
     def self.latest_links(limit)
-      uri = URI("http://#{PUBLIFY_HOSTNAME}/articles.json")
+      uri = URI("http://#{ENV['PUBLIFY_HOSTNAME']}/articles.json")
       response = Net::HTTP.get uri
       JSON.parse(response).first(limit)
     rescue => e

--- a/lib/publify/api.rb
+++ b/lib/publify/api.rb
@@ -3,9 +3,11 @@ require 'net/http'
 module Publify
   class API
     def self.latest_links(limit)
-      uri = URI("http://#{ENV['PUBLIFY_HOSTNAME']}/articles.json")
-      response = Net::HTTP.get uri
-      JSON.parse(response).first(limit)
+      connection = Net::HTTP.new(ENV['PUBLIFY_HOSTNAME'], ENV['PUBLIFY_PORT'].to_i)
+      connection.open_timeout = 2
+      connection.read_timeout = 2
+      response = connection.get('/articles.json')
+      JSON.parse(response.body).first(limit)
     rescue => e
       Rails.logger.error(e.message)
       []

--- a/spec/lib/publify/api_spec.rb
+++ b/spec/lib/publify/api_spec.rb
@@ -1,0 +1,48 @@
+describe Publify::API do
+
+  describe 'latest links' do
+    PUBLIFY_HOSTNAME = 'example.com'
+
+    context 'when successfully getting a response from Publify' do
+      let(:expected_uri) { URI('http://example.com/articles.json') }
+      let(:json) { '[{"title": "newest blog post"}, {"title": "oldest blog post"}]' }
+
+      before do
+        allow(Net::HTTP).to receive(:get).with(expected_uri).and_return(json)
+      end
+
+      it 'provides the latest blog posts' do
+        result = described_class.latest_links(2)
+        expect(result.length).to eq(2)
+      end
+
+      it 'maintains order of blog posts from publify' do
+        result = described_class.latest_links(2)
+        expect(result.first['title']).to eq('newest blog post')
+      end
+
+      it 'restricts the limit of blog posts requested' do
+        result = described_class.latest_links(1)
+        expect(result.length).to eq(1)
+      end
+    end
+
+    context 'when there has been an exception' do
+
+      it 'gracefully returns an empty array' do
+        allow(Net::HTTP).to receive(:get).and_raise('Failed to reach Publify')
+        expect(described_class.latest_links(2)).to be_empty
+      end
+
+      it 'gracefully returns an empty array when there has been an exception' do
+        allow(Net::HTTP).to receive(:get).and_raise('Failed to reach Publify')
+        expect(Rails.logger).to receive(:error).with('Failed to reach Publify')
+
+        described_class.latest_links(2)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/lib/publify/api_spec.rb
+++ b/spec/lib/publify/api_spec.rb
@@ -1,14 +1,21 @@
 describe Publify::API do
 
   describe 'latest links' do
-    PUBLIFY_HOSTNAME = 'example.com'
 
     context 'when successfully getting a response from Publify' do
-      let(:expected_uri) { URI('http://example.com/articles.json') }
       let(:json) { '[{"title": "newest blog post"}, {"title": "oldest blog post"}]' }
+      let(:response) { double(body: json) }
 
       before do
-        allow(Net::HTTP).to receive(:get).with(expected_uri).and_return(json)
+        ENV['PUBLIFY_HOSTNAME'] = 'example.com'
+        ENV['PUBLIFY_PORT'] = '4000'
+
+        allow_any_instance_of(Net::HTTP).to receive(:get).with('/articles.json').and_return(response)
+      end
+
+      it 'connects to the specified server' do
+        expect(Net::HTTP).to receive(:new).with('example.com', 4000)
+        described_class.latest_links(2)
       end
 
       it 'provides the latest blog posts' do
@@ -25,17 +32,27 @@ describe Publify::API do
         result = described_class.latest_links(1)
         expect(result.length).to eq(1)
       end
+
+      it 'sets up the open timeout limit' do
+        expect_any_instance_of(Net::HTTP).to receive(:open_timeout=).with(2)
+        described_class.latest_links(2)
+      end
+
+      it 'sets up the read timeout limit' do
+        expect_any_instance_of(Net::HTTP).to receive(:read_timeout=).with(2)
+        described_class.latest_links(2)
+      end
     end
 
     context 'when there has been an exception' do
 
       it 'gracefully returns an empty array' do
-        allow(Net::HTTP).to receive(:get).and_raise('Failed to reach Publify')
+        allow_any_instance_of(Net::HTTP).to receive(:get).and_raise('Failed to reach Publify')
         expect(described_class.latest_links(2)).to be_empty
       end
 
       it 'gracefully returns an empty array when there has been an exception' do
-        allow(Net::HTTP).to receive(:get).and_raise('Failed to reach Publify')
+        allow_any_instance_of(Net::HTTP).to receive(:get).and_raise('Failed to reach Publify')
         expect(Rails.logger).to receive(:error).with('Failed to reach Publify')
 
         described_class.latest_links(2)

--- a/spec/serializers/page_serializer_spec.rb
+++ b/spec/serializers/page_serializer_spec.rb
@@ -34,11 +34,9 @@ describe PageSerializer do
         result = subject.related_content[:latest_blog_post_links]
 
         expect(result.first).to eq(
-          {
-            title: 'First post',
-            path: 'http://a.com',
-            date: 'Thu, 08 Jan 2015 10:39:43 +0000'
-          }
+          title: 'First post',
+          path: 'http://a.com',
+          date: 'Thu, 08 Jan 2015 10:39:43 +0000'
         )
       end
 

--- a/spec/serializers/page_serializer_spec.rb
+++ b/spec/serializers/page_serializer_spec.rb
@@ -6,9 +6,43 @@ describe PageSerializer do
   before do
     allow(article).to receive(:previous_article).and_return(nil)
     allow(article).to receive(:next_article).and_return(nil)
+    allow(Publify::API).to receive(:latest_links).and_return([])
   end
 
   describe '#related_content' do
+
+    context 'latest blog post links' do
+
+      let(:latest_links) do
+        [
+          { 'title' => 'First post', 'link' => 'http://a.com', 'pubDate' => 'Thu, 08 Jan 2015 10:39:43 +0000' },
+          { 'title' => 'Second post', 'link' => 'http://b.com', 'pubDate' => 'Wed, 07 Jan 2015 10:39:43 +0000' },
+          { 'title' => 'Third post', 'link' => 'http://c.com', 'pubDate' => 'Tue, 06 Jan 2015 10:39:43 +0000' }
+        ]
+      end
+
+      before do
+        allow(Publify::API).to receive(:latest_links).with(3).and_return(latest_links)
+      end
+
+      it 'maps the 3 latest links' do
+        result = subject.related_content[:latest_blog_post_links]
+        expect(result.length).to eq(3)
+      end
+
+      it 'maps the latest links correctly' do
+        result = subject.related_content[:latest_blog_post_links]
+
+        expect(result.first).to eq(
+          {
+            title: 'First post',
+            path: 'http://a.com',
+            date: 'Thu, 08 Jan 2015 10:39:43 +0000'
+          }
+        )
+      end
+
+    end
 
     context 'popular links' do
       let(:popular_links) do


### PR DESCRIPTION
Note: 
  'PUBLIFY_HOSTNAME' is set in .env for development.
  For QA & production we set this up in the Scripts repo.