### PR TITLE
Fix image aspect ratios on content grid

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/scribe/scribe-plugin-image-inserter.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/scribe/scribe-plugin-image-inserter.js
@@ -16,7 +16,7 @@ function (eventsWithPromises, rangy, rangySelectionSaveRestore, filterEvent) {
 
       insertImageCommand.nodeName = 'IMG';
 
-      insertImageCommand.execute = function (url) {
+      insertImageCommand.execute = function () {
         return true;
       };
 

--- a/app/views/links/images/_listing.html.haml
+++ b/app/views/links/images/_listing.html.haml
@@ -4,5 +4,5 @@
       = label_tag "image_link_#{file.id}", class: 'content-grid__label' do
         = radio_button_tag "image_link", file.full_path, false, id: "image_link_#{file.id}", class: 'content-grid__item__radio', data: { 'dough-insertmanager-value-trigger' => true, 'dough-insertmanager-insert-type' => 'image' }
         %span.content-grid__media-wrapper
-          = image_tag file.file.url, class: 'content-grid__media'
+          = image_tag nil, class: 'content-grid__media', style: "background-image: url(#{file.file.url})"
         %span.content-grid__outline


### PR DESCRIPTION
Previously the images were being stretched to fit a 1:1 aspect ratio. This fix makes them fit to their native aspect ratios within the content grid.