### PR TITLE
Fix country flag image layout

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_images.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_images.scss
@@ -1,8 +1,10 @@
 .image-flag {
   background-size: contain;
   display: block;
+  float: right;
   height: 25px;
   margin-left: 20px;
+  margin-right: 8px;
   position: relative;
   width: 25px;
 


### PR DESCRIPTION
The country toggle was wrapping beneath the country flag image. This floats it to the right of the toggle.