### PR TITLE
Suppress related and popular links

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/layout/_editor.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/layout/_editor.scss
@@ -5,3 +5,11 @@
 .l-editor {
   margin-bottom: $baseline-unit*20;
 }
+
+.inline_checkboxes {
+  .checkbox {
+    display: inline;
+    padding-right: 10px;
+  }
+}
+

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,6 +13,7 @@ class PagesController < Comfy::Admin::Cms::PagesController
 
   def save_page
     PageRegister.new(@page, params: params, current_user: current_user).save
+    @page.suppress_mirrors_from_links_recirculation
   end
 
   def set_activity_log

--- a/app/serializers/page_link/base.rb
+++ b/app/serializers/page_link/base.rb
@@ -1,6 +1,5 @@
 module PageLink
   class Base
-
     def initialize(page)
       @page = page
     end
@@ -50,6 +49,5 @@ module PageLink
       return nil if page_index < 0 || page_index >= pages.length
       pages[page_index]
     end
-
   end
 end

--- a/app/views/pages/_form.html.haml
+++ b/app/views/pages/_form.html.haml
@@ -32,11 +32,14 @@
     = form.text_field :meta_title, data: {'dough-mirrorinputvalue-target' => ''}
     = form.hidden_field :scheduled_on, data: {'dough-scheduler-on' => ''}
 
-    .form-group
-      .form__label-heading
-        &nbsp;
-      .form__input-wrapper
-        = form.check_box :regulated_box, label: 'Regulated Content'
+
+    .inline_checkboxes
+      .form-group
+        .form__label-heading
+          &nbsp;
+        .form__input-wrapper
+          = form.check_box :suppress_from_links_recirculation, label: 'Suppress from links recirculation'
+          = form.check_box :regulated_box, label: 'Regulated Content'
 
 = render partial: 'form_blocks'
 = render 'scheduler', object: form

--- a/db/migrate/20150121145709_add_suppress_from_links_recirculation.rb
+++ b/db/migrate/20150121145709_add_suppress_from_links_recirculation.rb
@@ -1,0 +1,5 @@
+class AddSuppressFromLinksRecirculation < ActiveRecord::Migration
+  def change
+    add_column :comfy_cms_pages, :suppress_from_links_recirculation, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141217154822) do
+ActiveRecord::Schema.define(version: 20150121145709) do
 
   create_table "comfy_cms_blocks", force: true do |t|
     t.string   "identifier",                      null: false
@@ -78,28 +78,29 @@ ActiveRecord::Schema.define(version: 20141217154822) do
   add_index "comfy_cms_layouts", ["site_id", "identifier"], name: "index_comfy_cms_layouts_on_site_id_and_identifier", unique: true, using: :btree
 
   create_table "comfy_cms_pages", force: true do |t|
-    t.integer  "site_id",                                           null: false
+    t.integer  "site_id",                                                            null: false
     t.integer  "layout_id"
     t.integer  "parent_id"
     t.integer  "target_page_id"
-    t.string   "label",                                             null: false
+    t.string   "label",                                                              null: false
     t.string   "slug"
-    t.string   "full_path",                                         null: false
-    t.text     "content_cache",    limit: 16777215
-    t.integer  "position",                          default: 0,     null: false
-    t.integer  "children_count",                    default: 0,     null: false
-    t.boolean  "is_published",                      default: true,  null: false
-    t.boolean  "is_shared",                         default: false, null: false
+    t.string   "full_path",                                                          null: false
+    t.text     "content_cache",                     limit: 16777215
+    t.integer  "position",                                           default: 0,     null: false
+    t.integer  "children_count",                                     default: 0,     null: false
+    t.boolean  "is_published",                                       default: true,  null: false
+    t.boolean  "is_shared",                                          default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "state"
     t.string   "meta_description"
     t.string   "preview_cache"
-    t.boolean  "regulated",                         default: false
+    t.boolean  "regulated",                                          default: false
     t.string   "meta_title"
     t.string   "translation_id"
-    t.integer  "page_views",                        default: 0
+    t.integer  "page_views",                                         default: 0
     t.datetime "scheduled_on"
+    t.boolean  "suppress_from_links_recirculation",                  default: false
   end
 
   add_index "comfy_cms_pages", ["parent_id", "position"], name: "index_comfy_cms_pages_on_parent_id_and_position", using: :btree


### PR DESCRIPTION
This PR involves providing a checkbox in the Contento UI to suppress and article from being returned in the Related and Popular Links json.

When marking an article as suppressed, it's mirror in other languages should also be suppressed.