### PR TITLE
Remove whenever gem and config. Cron is managed by puppet scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'active_model_serializers'
 gem 'oauth2', '1.0.0'
 gem 'google-api-client', '0.7.1'
 gem 'legato', '0.4.0'
-gem 'whenever', '0.9.4', require: false
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,6 @@ GEM
       capybara (>= 1.0, < 3)
       colored
       launchy
-    chronic (0.10.2)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -426,8 +425,6 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket-driver (0.3.5)
-    whenever (0.9.4)
-      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -473,5 +470,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn-rails
   valid_attribute
-  whenever (= 0.9.4)
   word-to-markdown!

--- a/README.md
+++ b/README.md
@@ -56,5 +56,3 @@ The rake task
 
 is to retrieve page views from Google Analytics for articles.
 This allows us to generate the Popular links section that is displayed in the frontend application.
-
-The rake task is setup by whenever in config/schedule.rb

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,0 @@
-every 1.day, at: '3:00 am' do
-  rake 'cms:update_page_views'
-end


### PR DESCRIPTION
There was a decision to not use whenever for managing the cron. This is cleanup of the whenever gem and associated configuration