### PR TITLE
[DO NOT MERGE] - Change file stored path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ capybara-*.html
 /public/a/*
 /public/assets/*
 /public/system/*
+/public/files/*
 /coverage/
 /spec/tmp/*
 **.orig

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -33,7 +33,10 @@ ComfortableMexicanSofa.configure do |config|
   # filesystem see: http://rdoc.info/gems/paperclip/2.3.8/Paperclip/Storage/Filesystem
   # If you are using S3 and HTTPS, pass :s3_protocol => '' to have URLs that use the protocol of the page
   #   config.upload_file_options = {:url => '/system/:class/:id/:attachment/:style/:filename'}
-  config.upload_file_options = { styles: { cms_medium: '160x160' } }
+  config.upload_file_options = {
+    styles: { cms_medium: '160x160' },
+    url: '/files/:filename'
+  }
 
   # Sofa allows you to setup entire site from files. Database is updated with each
   # request (if necessary). Please note that database entries are destroyed if there's


### PR DESCRIPTION
Change the file stored path.

The product manager request to change the old file path: /system/:class/:id/:attachment/:style/:filename

To the new one: /files/:filename

After merge will need some work in migrate the old files to the new structure. Unfortunately, this was priority and now is not priority anymore. Don't merge until the P.O make this a priority again.