### PR TITLE
Make UpdatePageViews take a passed-in logfile, log to right levels.

### DIFF
--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -4,8 +4,10 @@ require './config/environment'
 require './lib/cms/update_page_views_task'
 
 module Clockwork
-  handler do |job|
-    puts "Running #{job}"
+  Rails.logger = Logger.new(ENV.fetch('LOG_FILE', STDOUT))
+
+  configure do |config|
+    config[:logger] = Rails.logger
   end
 
   every(1.day, 'update_page_views.job', at: '03:00') do

--- a/lib/cms/update_page_views_task.rb
+++ b/lib/cms/update_page_views_task.rb
@@ -2,20 +2,21 @@ require_relative '../google_analytics/api'
 
 class UpdatePageViewsTask
   def self.run
-    log('Starting UpdatePageViewsTask')
+    logger.info('Starting UpdatePageViewsTask')
     google_analytics_results = GoogleAnalytics::API.fetch_article_page_views
 
     Comfy::Cms::Page.all_english_articles.each do |article|
       begin
+        logger.info("Updating article: #{article.id}")
         article.update_page_views(google_analytics_results)
       rescue
-        log("Error updating article: #{article.id} (#{$ERROR_INFO.message})")
+        logger.error("Could not update article: #{article.id} (#{$ERROR_INFO.message})")
       end
     end
-    log('Completed UpdatePageViewsTask')
+    logger.info('Completed UpdatePageViewsTask')
   end
 
-  def self.log(message)
-    Rails.logger.info("#{Time.now}: #{message}")
+  def self.logger
+    Rails.logger
   end
 end


### PR DESCRIPTION
I decided this wasn't getting logged anywhere because:

* Clockwork outputs to `STDOUT` by default.
* :sparkles:For some reason:sparkles: Rails.logger was doing the same.
* The init.d script in `scripts` pipes `STDOUT` to `/dev/null` by default.

I've reconfigured Clockwork to output to a logfile provided in a env variable, or STDOUT otherwise.

I've also added some more logging, and made the existing logging use the right logging levels.

Scripts PR here: https://github.com/moneyadviceservice/scripts/pull/160