### PR TITLE
Content API separated by page type

### DIFF
--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,19 +1,24 @@
 module API
-  class ContentController < Comfy::Cms::ContentController
+  class ContentController < APIController
+    before_action :find_site, only: [:show, :preview]
+    before_action :find_page, only: [:show, :preview]
+
     def show
-      respond_with(@cms_page) do |format|
-        format.json { render json: @cms_page }
-        format.html { render_html }
-      end
+      render json: page
     end
 
     def preview
-      @cms_page = @cms_site.pages.with_slug("#{params[:cms_path]}")
+      render json: page, scope: 'preview'
+    end
 
-      respond_with(@cms_page) do |format|
-        format.json { render json: @cms_page, scope: 'preview' }
-        format.html { render_html }
-      end
+    private
+
+    def find_page
+      render json: { message: 'Page not found' }, status: 404 if page.blank?
+    end
+
+    def page
+      @page ||= current_site.pages.find_by(slug: params[:slug])
     end
   end
 end

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -18,7 +18,22 @@ module API
     end
 
     def page
-      @page ||= current_site.pages.find_by(slug: params[:slug])
+      @page ||= if page_type.present? && page_type_supported?
+                  current_site.pages
+                    .published
+                    .joins(:layout)
+                    .find_by(slug: params[:slug], 'comfy_cms_layouts.identifier' => page_type)
+                else
+                  current_site.pages.find_by(slug: params[:slug])
+                end
+    end
+
+    def page_type_supported?
+      page_type.in?(current_site.layouts.pluck(:identifier))
+    end
+
+    def page_type
+      @page_type ||= params[:page_type].to_s.singularize
     end
   end
 end

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,31 +1,39 @@
 module API
   class ContentController < APIController
     before_action :find_site, only: [:show, :preview]
-    before_action :find_page, only: [:show, :preview]
+    before_action :verify_page_type, only: :show, if: -> { slug.present? }
 
     def show
-      render json: page
+      page = if slug.present?
+               current_site.pages
+                 .published
+                 .joins(:layout)
+                 .find_by(slug: slug, 'comfy_cms_layouts.identifier' => page_type)
+             else
+               current_site.pages.published.find_by(slug: page_type)
+             end
+
+      render_page(page)
     end
 
     def preview
-      render json: page, scope: 'preview'
+      page = current_site.pages.find_by(slug: params[:slug])
+
+      render_page(page, scope: 'preview')
     end
 
     private
 
-    def find_page
-      render json: { message: 'Page not found' }, status: 404 if page.blank?
+    def render_page(page, scope: nil)
+      if page
+        render json: page, scope: scope
+      else
+        render json: { message: 'Page not found' }, status: 404
+      end
     end
 
-    def page
-      @page ||= if page_type.present? && page_type_supported?
-                  current_site.pages
-                    .published
-                    .joins(:layout)
-                    .find_by(slug: params[:slug], 'comfy_cms_layouts.identifier' => page_type)
-                else
-                  current_site.pages.find_by(slug: params[:slug])
-                end
+    def verify_page_type
+      render json: { message: %(Page type "#{page_type}" not supported) }, status: 400 unless page_type_supported?
     end
 
     def page_type_supported?
@@ -34,6 +42,10 @@ module API
 
     def page_type
       @page_type ||= params[:page_type].to_s.singularize
+    end
+
+    def slug
+      @slug ||= params[:slug]
     end
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,3 +1,10 @@
 class APIController < ApplicationController
   respond_to :json
+  attr_reader :current_site
+
+  def find_site
+    @current_site = Comfy::Cms::Site.find_by(path: params[:locale])
+
+    render json: { message: 'Site not found' }, status: 404 if current_site.blank?
+  end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,6 +5,6 @@ class APIController < ApplicationController
   def find_site
     @current_site = Comfy::Cms::Site.find_by(path: params[:locale])
 
-    render json: { message: 'Site not found' }, status: 404 if current_site.blank?
+    render json: { message: %(Site "#{params[:locale]}" not found) }, status: 404 if current_site.blank?
   end
 end

--- a/app/controllers/category_contents_controller.rb
+++ b/app/controllers/category_contents_controller.rb
@@ -1,0 +1,13 @@
+class CategoryContentsController < ApplicationController
+  skip_before_action :load_cms_page
+
+  def index
+    @primary_navigation, @secondary_navigation = Comfy::Cms::Category.navigation_categories
+    render json: @primary_navigation, scope: params[:locale].to_sym
+  end
+
+  def show
+    @category = Comfy::Cms::Category.find_by(label: params[:id])
+    render json: @category, scope: params[:locale].to_sym
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,5 +53,8 @@ Rails.application.routes.draw do
     get '/:locale/:page_type/(*slug)(.:format)' => 'content#show', as: 'content'
   end
 
+  # Overwriten comfy route to hit the application.
+  get '/(*locale)(.:format)' => 'api/content#show'
+
   comfy_route :cms, sitemap: false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,8 +49,8 @@ Rails.application.routes.draw do
   namespace :api, path: '/' do
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
-    get '/preview(/*cms_path)(.:format)' => 'content#preview', as: 'preview_content'
-    get '/:locale/articles/(*slug)(.:format)' => 'content#show', as: 'content'
+    get '/preview/:locale/(*slug)(.:format)' => 'content#preview', as: 'preview_content'
+    get '/:locale/:page_type/(*slug)(.:format)' => 'content#show', as: 'content'
   end
 
   comfy_route :cms, sitemap: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
     get '/preview(/*cms_path)(.:format)' => 'content#preview', as: 'preview_content'
-    get '/(*cms_path)(.:format)' => 'content#show', as: 'content'
+    get '/:locale/articles/(*slug)(.:format)' => 'content#show', as: 'content'
   end
 
   comfy_route :cms, sitemap: false

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -12,8 +12,9 @@ Then(/^I should see the Draft Article$/) do
   expect(JSON.parse(preview_page.text)['blocks'].find {|b| b["identifier"] == 'content'}['content']).to eq('test')
 end
 
-When(/^I should not be able to see live draft article$/) do
-  expect{live_page.load(locale: cms_site.label, slug: cms_page.slug)}.to raise_error
+Then(/^I should not be able to see live draft article$/) do
+  live_page.load(locale: cms_site.label, slug: cms_page.slug)
+  expect(JSON.load(live_page.text).symbolize_keys).to eq(message: 'Page not found')
 end
 
 Given(/^I have an articles with unpublished changes$/) do

--- a/features/support/ui/pages/live.rb
+++ b/features/support/ui/pages/live.rb
@@ -2,6 +2,6 @@ require_relative '../page'
 
 module UI::Pages
   class Live < UI::Page
-    set_url '/{locale}/{slug}.json'
+    set_url '/{locale}/{page_type}/{slug}.json'
   end
 end

--- a/spec/controllers/api/content_controller_spec.rb
+++ b/spec/controllers/api/content_controller_spec.rb
@@ -2,15 +2,22 @@ RSpec.describe API::ContentController, type: :request do
   let!(:site) { create(:site, path: 'en', locale: 'en') }
   let(:response_body) { JSON.load(response.body).symbolize_keys }
 
+  before do
+    allow_any_instance_of(PageSerializer).to receive(:related_content).and_return({})
+  end
+
   describe 'GET /:locale/articles/:slug' do
-    let!(:page) { create(:page, label: 'Borrow', slug: 'borrow', site: site) }
+    let(:state) { 'published' }
+    let(:article_layout) { create(:layout, :article, site: site) }
+    let!(:page) do
+      create(:page, label: 'Borrow', slug: 'borrow', site: site, state: state, layout: article_layout)
+    end
 
     before do
-      allow_any_instance_of(PageSerializer).to receive(:related_content).and_return({})
       get article_url
     end
 
-    context 'when existing article' do
+    context 'when existing page' do
       let(:article_url) { '/en/articles/borrow' }
 
       it 'renders article resource' do
@@ -19,6 +26,19 @@ RSpec.describe API::ContentController, type: :request do
 
       it 'returns successful response' do
         expect(response.status).to be 200
+      end
+    end
+
+    context 'when draft page' do
+      let(:state) { 'draft' }
+      let(:article_url) { '/en/articles/borrow' }
+
+      it 'renders error message' do
+        expect(response_body).to eq(message: 'Page not found')
+      end
+
+      it 'responds not found' do
+        expect(response.status).to be 404
       end
     end
 
@@ -34,7 +54,7 @@ RSpec.describe API::ContentController, type: :request do
       end
     end
 
-    context 'when inexistent article' do
+    context 'when inexistent page' do
       let(:article_url) { '/en/articles/inexistent-slug' }
 
       it 'renders error message' do
@@ -47,15 +67,51 @@ RSpec.describe API::ContentController, type: :request do
     end
   end
 
+  describe 'GET /:locale/corporate/:slug' do
+    let(:corporate) { create(:layout, :corporate, site: site) }
+    let!(:corporate_page) { create(:page, layout: corporate, site: site, slug: 'debt') }
+    let!(:article_page) { create(:page, site: site, slug: 'borrow') }
+
+    before do
+      get page_url
+    end
+
+    context 'when "corporate" page' do
+      let(:page_url) { '/en/corporate/debt' }
+
+      it 'renders corporate page' do
+        expect(response_body).to include(slug: 'debt')
+      end
+
+      it 'responds successfully' do
+        expect(response.status).to be 200
+      end
+    end
+
+    context 'when "article" page' do
+      let(:page_url) { '/en/corporate/borrow' }
+
+      it 'responds page not found' do
+        expect(response_body).to eq(message: 'Page not found')
+      end
+
+      it 'responds not found' do
+        expect(response.status).to be 404
+      end
+    end
+  end
+
+  describe 'GET /:locale/action_plans/:slug' do
+  end
+
   describe 'GET /preview/:locale/:slug' do
     let!(:page) { create(:page, label: 'Borrow', slug: 'borrow', site: site) }
 
     before do
-      allow_any_instance_of(PageSerializer).to receive(:related_content).and_return({})
       get preview_url
     end
 
-    context 'when existent article' do
+    context 'when existent page' do
       let(:preview_url) { '/preview/en/borrow' }
 
       it 'renders article resource' do
@@ -67,7 +123,7 @@ RSpec.describe API::ContentController, type: :request do
       end
     end
 
-    context 'when inexistent article' do
+    context 'when inexistent page' do
       let(:preview_url) { '/preview/en/inexistent-article' }
 
       it 'renders error message' do

--- a/spec/controllers/api/content_controller_spec.rb
+++ b/spec/controllers/api/content_controller_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe API::ContentController, type: :request do
+  let!(:site) { create(:site, path: 'en', locale: 'en') }
+  let(:response_body) { JSON.load(response.body).symbolize_keys }
+
+  describe 'GET /:locale/articles/:slug' do
+    let!(:page) { create(:page, label: 'Borrow', slug: 'borrow', site: site) }
+
+    before do
+      allow_any_instance_of(PageSerializer).to receive(:related_content).and_return({})
+      get article_url
+    end
+
+    context 'when existing article' do
+      let(:article_url) { '/en/articles/borrow' }
+
+      it 'renders article resource' do
+        expect(response_body).to include(label: 'Borrow', slug: 'borrow')
+      end
+
+      it 'returns successful response' do
+        expect(response.status).to be 200
+      end
+    end
+
+    context 'when inexistent site' do
+      let(:article_url) { '/br/articles/borrow' }
+
+      it 'renders error message' do
+        expect(response_body).to eq(message: 'Site not found')
+      end
+
+      it 'responds not found' do
+        expect(response.status).to be 404
+      end
+    end
+
+    context 'when inexistent article' do
+      let(:article_url) { '/en/articles/inexistent-slug' }
+
+      it 'renders error message' do
+        expect(response_body).to eq(message: 'Page not found')
+      end
+
+      it 'responds not found' do
+        expect(response.status).to be 404
+      end
+    end
+  end
+
+  describe 'GET /preview/:locale/:slug' do
+    let!(:page) { create(:page, label: 'Borrow', slug: 'borrow', site: site) }
+
+    before do
+      allow_any_instance_of(PageSerializer).to receive(:related_content).and_return({})
+      get preview_url
+    end
+
+    context 'when existent article' do
+      let(:preview_url) { '/preview/en/borrow' }
+
+      it 'renders article resource' do
+        expect(response_body).to include(label: 'Borrow', slug: 'borrow')
+      end
+
+      it 'returns successful response' do
+        expect(response.status).to be 200
+      end
+    end
+
+    context 'when inexistent article' do
+      let(:preview_url) { '/preview/en/inexistent-article' }
+
+      it 'renders error message' do
+        expect(response_body).to eq(message: 'Page not found')
+      end
+
+      it 'responds not found' do
+        expect(response.status).to be 404
+      end
+    end
+  end
+end

--- a/spec/controllers/api/content_controller_spec.rb
+++ b/spec/controllers/api/content_controller_spec.rb
@@ -42,6 +42,30 @@ RSpec.describe API::ContentController, type: :request do
       end
     end
 
+    context 'when does not pass any page type (API backwards compatibility)' do
+      let(:article_url) { '/en/borrow' }
+
+      it 'renders article resource' do
+        expect(response_body).to include(label: 'Borrow', slug: 'borrow')
+      end
+
+      it 'returns successful response' do
+        expect(response.status).to be 200
+      end
+    end
+
+    context 'when does not pass any page type and slug' do
+      let(:article_url) { '/en' }
+
+      it 'renders error message' do
+        expect(response_body).to eq(message: 'Page not found')
+      end
+
+      it 'responds not found' do
+        expect(response.status).to be 404
+      end
+    end
+
     context 'when inexistent site' do
       let(:article_url) { '/br/articles/borrow' }
 
@@ -63,6 +87,18 @@ RSpec.describe API::ContentController, type: :request do
 
       it 'responds not found' do
         expect(response.status).to be 404
+      end
+    end
+
+    context 'when inexistent page type' do
+      let(:article_url) { '/en/inexistent_page_type/borrow' }
+
+      it 'renders error message' do
+        expect(response_body).to eq(message: 'Page type "inexistent_page_type" not supported')
+      end
+
+      it 'responds bad request' do
+        expect(response.status).to be 400
       end
     end
   end

--- a/spec/controllers/api/content_controller_spec.rb
+++ b/spec/controllers/api/content_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe API::ContentController, type: :request do
       let(:article_url) { '/br/articles/borrow' }
 
       it 'renders error message' do
-        expect(response_body).to eq(message: 'Site not found')
+        expect(response_body).to eq(message: 'Site "br" not found')
       end
 
       it 'responds not found' do

--- a/spec/controllers/api/content_controller_spec.rb
+++ b/spec/controllers/api/content_controller_spec.rb
@@ -137,9 +137,6 @@ RSpec.describe API::ContentController, type: :request do
     end
   end
 
-  describe 'GET /:locale/action_plans/:slug' do
-  end
-
   describe 'GET /preview/:locale/:slug' do
     let!(:page) { create(:page, label: 'Borrow', slug: 'borrow', site: site) }
 

--- a/spec/factories/layouts.rb
+++ b/spec/factories/layouts.rb
@@ -19,6 +19,10 @@ FactoryGirl.define do
       identifier 'article'
     end
 
+    trait :corporate do
+      identifier 'corporate'
+    end
+
     trait :nested do
       label 'Nested Layout'
       identifier 'nested'


### PR DESCRIPTION
With this PR is possible make GET requests to:

* /en/slug.json # Will see all pages
* /en/articles/slug.json # Only article page type
* /en/corporate/slug.json # Only corporate page type
* /en/action_plans/slug.json # Only action plan page type
* /en/videos/slug.json # Only videos page type

etc for all page types.

**Do not merge because it needs implement the client code on the frontend repository to requests for this resources.**