### PR TITLE
Add a fix to avoid select boxes affecting the layout

### DIFF
--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/base/_forms.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/base/_forms.scss
@@ -210,3 +210,7 @@ table th select {
     outline-color: $color-select-focus-outline;
   }
 }
+
+.form__select--fill-width {
+  width: 100%;
+}

--- a/app/views/links/documents/_form.html.haml
+++ b/app/views/links/documents/_form.html.haml
@@ -18,7 +18,7 @@
       .choose-sort-by
         = label_tag(:sort_by, nil, class: 'form__label-heading visually-hidden')
         .form__input-wrapper
-          = select_tag(:order, options_to_sort_files(selected_option: @order),  prompt: I18n.t('files.index.sort_by.placeholder'), data: { dough_component: 'SelectSubmitter' })
+          = select_tag(:order, options_to_sort_files(selected_option: @order), prompt: I18n.t('files.index.sort_by.placeholder'), data: { dough_component: 'SelectSubmitter' }, class: 'form__select--fill-width')
 
     .form-group.js-linkable-documents
 

--- a/app/views/links/pages/_form.html.haml
+++ b/app/views/links/pages/_form.html.haml
@@ -21,7 +21,7 @@
             include_blank: false,
             multiple:      false,
             id:            'categories',
-            class:         'pages-categories-select',
+            class:         'pages-categories-select form__select--fill-width',
             prompt:        t('links.page.category.placeholder'),
             data:          { dough_component: 'SelectSubmitter' })
 


### PR DESCRIPTION
@moneyadviceservice/frontend

TP#5869

When we have an `<option>` with a long text label it is causing it to interfere with the layout ...
![screen shot 2015-02-19 at 10 21 34](https://cloud.githubusercontent.com/assets/1579511/6265050/930b8ea4-b821-11e4-9de7-b70bda2297a3.png)

