### PR TITLE
Simple version - Hippo report tool

### DIFF
--- a/app/controllers/hippo/diffs_controller.rb
+++ b/app/controllers/hippo/diffs_controller.rb
@@ -1,0 +1,21 @@
+class Hippo::DiffsController < Comfy::Admin::Cms::BaseController
+  before_action :check_admin
+
+  def show
+    @hippo_diff = Cms::HippoDiff.new(data: data)
+  end
+
+  private
+
+  def data
+    File.read(Rails.root.join('tmp', filename))
+  end
+
+  def filename
+    if params[:welsh].blank?
+      'contentauthoringwebsite.xml'
+    else
+      'contentauthoringwebsite-welsh.xml'
+    end
+  end
+end

--- a/app/views/hippo/diffs/show.html.haml
+++ b/app/views/hippo/diffs/show.html.haml
@@ -1,0 +1,13 @@
+.l-panel-content.l-panel-content--form
+  .l-constrained
+    %h1 Hippo Pages that are not in Contento
+
+.table-wrapper
+  %table.datatable-default.table
+    %thead
+      %tr
+        %th Slug
+    %tbody
+      - @hippo_diff.each do |hippo_page|
+        %tr
+          %td= hippo_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   scope '/admin' do
     get 'links/(*id)(.:format)' => 'links#show', as: 'admin_link'
 
-    resource :hippo, only: [:new, :create]
+    resource :hippo, only: [:new, :create] do
+      resource :diff, module: 'hippo', only: :show
+    end
 
     resources :sites do
       resources :files

--- a/lib/cms/hippo_diff.rb
+++ b/lib/cms/hippo_diff.rb
@@ -1,0 +1,28 @@
+module Cms
+  class HippoDiff
+    attr_reader :parser, :data
+
+    HIPPO_TYPES = [
+      'contentauthoringwebsite:Guide',
+      'contentauthoringwebsite:ActionPlan',
+      'contentauthoringwebsite:ToolPage',
+      'contentauthoringwebsite:StaticPage',
+      'contentauthoringwebsite:VideoPage',
+      'contentauthoringwebsite:News',
+      'contentauthoringwebsite:Campaign'
+    ]
+
+    def initialize(data:, parser: HippoXmlParser)
+      @parser = parser
+      @data = data
+    end
+
+    def slugs
+      @slugs ||= parser.parse(data, HIPPO_TYPES).map(&:id)
+    end
+
+    def contento_slugs
+      Comfy::Cms::Page.pluck(:slug)
+    end
+  end
+end

--- a/lib/cms/hippo_diff.rb
+++ b/lib/cms/hippo_diff.rb
@@ -1,6 +1,7 @@
 module Cms
   class HippoDiff
     attr_reader :parser, :data
+    delegate :each, to: :collection
 
     HIPPO_TYPES = [
       'contentauthoringwebsite:Guide',
@@ -17,12 +18,16 @@ module Cms
       @data = data
     end
 
+    def collection
+      @collection ||= slugs - contento_slugs
+    end
+
     def slugs
       @slugs ||= parser.parse(data, HIPPO_TYPES).map(&:id)
     end
 
     def contento_slugs
-      Comfy::Cms::Page.pluck(:slug)
+      @contento_slugs ||= Comfy::Cms::Page.pluck(:slug)
     end
   end
 end

--- a/spec/controllers/hippo/diffs_controller_spec.rb
+++ b/spec/controllers/hippo/diffs_controller_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Hippo::DiffsController do
+  let(:current_user) { create(:user) }
+  let!(:site) { create(:site) }
+
+  before do
+    sign_in current_user
+  end
+
+  describe 'GET /hippo/diff' do
+    let(:hippo_diff) { double }
+    let(:data) { double }
+
+    before do
+      expect(controller).to receive(:data).and_return(data)
+      expect(Cms::HippoDiff).to receive(:new).with(data: data).and_return(hippo_diff)
+    end
+
+    it 'assigns hippo pages' do
+      get :show
+      expect(assigns[:hippo_diff]).to eq(hippo_diff)
+    end
+  end
+end

--- a/spec/lib/cms/hippo_diff_spec.rb
+++ b/spec/lib/cms/hippo_diff_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Cms::HippoDiff do
+  let(:data) { File.read(Rails.root.join('spec', 'fixtures', 'example.xml')) }
+  subject(:hippo_diff) { described_class.new(data: data) }
+
+  describe '#slugs' do
+    it 'returns slugs from content file' do
+      expect(hippo_diff.slugs).to eq(['do-you-need-to-borrow-money'])
+    end
+  end
+
+  describe '#contento_slugs' do
+    let!(:page) { create(:page, slug: 'about-us') }
+
+    it 'returns all slugs from the CMS' do
+      expect(hippo_diff.contento_slugs).to eq(['about-us'])
+    end
+  end
+end

--- a/spec/lib/cms/hippo_diff_spec.rb
+++ b/spec/lib/cms/hippo_diff_spec.rb
@@ -2,6 +2,34 @@ RSpec.describe Cms::HippoDiff do
   let(:data) { File.read(Rails.root.join('spec', 'fixtures', 'example.xml')) }
   subject(:hippo_diff) { described_class.new(data: data) }
 
+  describe '#collection' do
+    subject(:collection) { hippo_diff.collection }
+    let(:slugs) do
+      %w(
+        partners
+        debt
+        about-us
+        media-centre
+      )
+    end
+
+    let(:contento_slugs) do
+      %w(
+        partners
+        debt
+      )
+    end
+
+    before do
+      expect(hippo_diff).to receive(:slugs).and_return(slugs)
+      expect(hippo_diff).to receive(:contento_slugs).and_return(contento_slugs)
+    end
+
+    it 'returns the difference between hippo slugs and contento slugs' do
+      expect(collection).to eq(%w(about-us media-centre))
+    end
+  end
+
   describe '#slugs' do
     it 'returns slugs from content file' do
       expect(hippo_diff.slugs).to eq(['do-you-need-to-borrow-money'])


### PR DESCRIPTION
This is the simple version of the hippo diff page between hippo and Contento :tm: 

The perfect solution will be scraping the content xml file from Hippo instead expecting on the  tmp dir. Will do this in a separate PR.