### PR TITLE
Use require_dependency for comfy

### DIFF
--- a/app/models/comfy/cms/category.rb
+++ b/app/models/comfy/cms/category.rb
@@ -1,4 +1,4 @@
-require ComfortableMexicanSofa::Engine.root.join('app', 'models', 'comfy', 'cms', 'category')
+require_dependency ComfortableMexicanSofa::Engine.root.join('app', 'models', 'comfy', 'cms', 'category')
 
 class Comfy::Cms::Category < ActiveRecord::Base
   validates_presence_of :label, :title_en, :title_cy


### PR DESCRIPTION
Use require_dependency in order to stop errors in development mode, when rails reload the code.