### PR TITLE
Fix Advanced mode textarea resize issues

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
@@ -1,19 +1,19 @@
 define([
   'jquery',
   'DoughBaseComponent',
-  'editor-plugin-auto-resize-textarea',
   'editor',
   'scribe-plugin-mastalk',
   'scribe-plugin-linkeditor',
-  'scribe-plugin-image-inserter'
+  'scribe-plugin-image-inserter',
+  'autogrow'
 ], function(
   $,
   DoughBaseComponent,
-  editorPluginAutoResizeTextarea,
   Editor,
   scribePluginMastalk,
   scribePluginLinkEditor,
-  scribePluginImageInserter
+  scribePluginImageInserter,
+  autogrow
 ) {
   'use strict';
 
@@ -87,7 +87,6 @@ define([
       this.$htmlToolbar[0],
       this.editorOptions
     );
-    this.editorLib.use(editorPluginAutoResizeTextarea(this.$markdownContent[0]));
     this.editorLib.editor.use(scribePluginLinkEditor('add-link'));
     this.editorLib.editor.use(scribePluginImageInserter('insert-image'));
     this.editorLib.editor.use(scribePluginMastalk('collapsible'));
@@ -101,6 +100,12 @@ define([
     this.editorLib.editor.use(scribePluginMastalk('table'));
     this.editorLib.editor.use(scribePluginMastalk('bullets'));
     this.editorLib.editor.use(scribePluginMastalk('promoBlock'));
+
+    this.$markdownContent.autogrow({
+      animate: false,
+      speed: 0
+    });
+
     this._initialisedSuccess(initialised);
   };
 
@@ -188,6 +193,7 @@ define([
         this.enableToolbar('markdown');
         this.disableToolbar('html');
         this.show(this.$markdownContainer).hide(this.$htmlContainer);
+        this.$markdownContent.trigger('keyup');
         break;
       default:
         this.enableToolbar('html');

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -19,10 +19,6 @@ requirejs.config({
      // Editor Shims
     'mutationobserver-shim': '<%= requirejs_path("mas-cms-editor/src/app/shims/mutationobserver.min") %>',
 
-    // Editor plugins
-    'editor-plugin-sticky-toolbar': '<%= requirejs_path("mas-cms-editor/src/app/plugins/editor-sticky-toolbar/editor-sticky-toolbar") %>',
-    'editor-plugin-auto-resize-textarea': '<%= requirejs_path("mas-cms-editor/src/app/plugins/editor-auto-resize-textarea/editor-auto-resize-textarea") %>',
-
     // Application modules
     'URLToggler': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/URLToggler") %>',
     'MASEditor': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/MASEditor") %>',
@@ -94,7 +90,8 @@ requirejs.config({
 	'rangy-selectionsaverestore': '<%= requirejs_path("rangy-official/rangy-selectionsaverestore") %>',
     'filament-sticky': '<%= requirejs_path("filament-sticky/fixedsticky") %>',
     'filament-fixed': '<%= requirejs_path("filament-fixed/fixedfixed") %>',
-	'html-sortable': '<%= requirejs_path("html.sortable/dist/html.sortable") %>'
+    'html-sortable': '<%= requirejs_path("html.sortable/dist/html.sortable") %>',
+    'autogrow': '<%= requirejs_path("autogrow.js/autogrow") %>'
   },
   shim: {
     'to-markdown' : {

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_editor.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_editor.scss
@@ -21,7 +21,6 @@
 
 .editor--markdown .editor__content {
   font-family: monospace;
-  resize: none;
 
   &:focus {
     outline: none;

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -18,6 +18,7 @@
     "dialog-polyfill": "0.2.0",
     "rangy-official": "1.3",
     "filament-sticky": "0.1.3",
-    "html.sortable": "0.1.8"
+    "html.sortable": "0.1.8",
+    "autogrow.js": "git@github.com:ultimatedelman/autogrow.git#1.0.3"
   }
 }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -56,5 +56,6 @@ Rails.application.configure do
                                   rangy-official/rangy-selectionsaverestore.js
                                   filament-sticky/fixedsticky.js
                                   filament-fixed/fixedfixed.js
-                                  html.sortable/dist/html.sortable.js)
+                                  html.sortable/dist/html.sortable.js
+                                  autogrow.js/autogrow.js)
 end

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -31,10 +31,6 @@ requirejs.config({
     'editor-lib-wrapper': bowerPath + 'mas-cms-editor/src/app/modules/editor-lib-wrapper/editor-lib-wrapper',
     'source-converter': bowerPath + 'mas-cms-editor/src/app/modules/source-converter/source-converter',
 
-    // Editor plugins
-    'editor-plugin-sticky-toolbar': bowerPath + 'mas-cms-editor/src/app/plugins/editor-sticky-toolbar/editor-sticky-toolbar',
-    'editor-plugin-auto-resize-textarea': bowerPath + 'mas-cms-editor/src/app/plugins/editor-auto-resize-textarea/editor-auto-resize-textarea',
-
     // Editor Shims
     'mutationobserver-shim': bowerPath + 'mas-cms-editor/src/app/shims/mutationobserver.min',
 
@@ -96,7 +92,8 @@ requirejs.config({
     'dialog-polyfill': bowerPath + 'dialog-polyfill/dialog-polyfill',
     'rangy-core': bowerPath + 'rangy-official/rangy-core',
     'rangy-selectionsaverestore': bowerPath + 'rangy-official/rangy-selectionsaverestore',
-    'html-sortable': bowerPath + 'html.sortable/dist/html.sortable'
+    'html-sortable': bowerPath + 'html.sortable/dist/html.sortable',
+    'autogrow': bowerPath + 'autogrow.js/autogrow'
   },
   shim : {
     'to-markdown' : {


### PR DESCRIPTION
This implements [Autogrow](https://github.com/ultimatedelman/autogrow) to automatically resize the Advanced mode textarea. This fixes the scrolling issues caused by editor-plugin-auto-resize-textarea when the box resized.

There are still some issues regarding the overlapping of the top and bottom fixed navigations, which I'll try to address on a future PR.

TP#6089