### PR TITLE
Fix textarea autoresize in Advanced mode

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
@@ -5,7 +5,7 @@ define([
   'scribe-plugin-mastalk',
   'scribe-plugin-linkeditor',
   'scribe-plugin-image-inserter',
-  'autogrow'
+  'autosize'
 ], function(
   $,
   DoughBaseComponent,
@@ -13,7 +13,7 @@ define([
   scribePluginMastalk,
   scribePluginLinkEditor,
   scribePluginImageInserter,
-  autogrow
+  autosize
 ) {
   'use strict';
 
@@ -83,7 +83,7 @@ define([
     this.enableToolbar('html');
     this.editorLib = new Editor(
       this.$htmlContent[0],
-      this.$markdownContent[0],
+      this.markdownContent,
       this.$htmlToolbar[0],
       this.editorOptions
     );
@@ -101,10 +101,7 @@ define([
     this.editorLib.editor.use(scribePluginMastalk('bullets'));
     this.editorLib.editor.use(scribePluginMastalk('promoBlock'));
 
-    this.$markdownContent.autogrow({
-      animate: false,
-      speed: 0
-    });
+    this.setupMarkdownContentResize();
 
     this._initialisedSuccess(initialised);
   };
@@ -118,6 +115,7 @@ define([
     this.$htmlContent = this.$el.find(this.config.selectors.htmlContent);
     this.$markdownContainer = this.$el.find(this.config.selectors.markdownContainer);
     this.$markdownContent = this.$el.find(this.config.selectors.markdownContent);
+    this.markdownContent = this.$markdownContent[0];
     this.$markdownToolbar = this.$el.find(this.config.selectors.markdownToolbar);
     this.$switchModeContainer = this.$el.find(this.config.selectors.switchModeContainer);
 
@@ -128,7 +126,7 @@ define([
   };
 
   MASEditorProto._stripEditorWhitespace = function() {
-    this.$markdownContent[0].value = this.$markdownContent[0].value.split('\n').map(function(e) {
+    this.markdownContent.value = this.markdownContent.value.split('\n').map(function(e) {
       return e.trim();
     }).join('\n');
   };
@@ -153,6 +151,25 @@ define([
     if(this.mode === this.editorLib.constants.MODES.HTML) {
       this.editorLib.changeEditingMode(this.editorLib.constants.MODES.MARKDOWN);
     }
+  };
+
+  /**
+   * Setups the autosize library and triggers initial resize
+   * @return {Object} this
+   */
+  MASEditorProto.setupMarkdownContentResize = function() {
+    autosize(this.$markdownContent);
+    this.resizeMarkdownContent();
+    return this;
+  };
+
+  /**
+   * Triggers resize event on autosize library
+   * @return {Object} this
+   */
+  MASEditorProto.resizeMarkdownContent = function() {
+    this.markdownContent.dispatchEvent(new Event('autosize.update'));
+    return this;
   };
 
   /**
@@ -182,6 +199,7 @@ define([
     if(mode === this.mode) return;
 
     this.mode = mode;
+    this.editorLib.changeEditingMode(this.mode);
 
     switch(mode) {
       case this.editorLib.constants.MODES.HTML:
@@ -193,7 +211,7 @@ define([
         this.enableToolbar('markdown');
         this.disableToolbar('html');
         this.show(this.$markdownContainer).hide(this.$htmlContainer);
-        this.$markdownContent.trigger('keyup');
+        this.resizeMarkdownContent();
         break;
       default:
         this.enableToolbar('html');
@@ -201,7 +219,6 @@ define([
         this.show(this.$htmlContainer).hide(this.$markdownContainer);
         break;
     }
-    this.editorLib.changeEditingMode(this.mode);
 
     return this;
   };

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -91,7 +91,7 @@ requirejs.config({
     'filament-sticky': '<%= requirejs_path("filament-sticky/fixedsticky") %>',
     'filament-fixed': '<%= requirejs_path("filament-fixed/fixedfixed") %>',
     'html-sortable': '<%= requirejs_path("html.sortable/dist/html.sortable") %>',
-    'autogrow': '<%= requirejs_path("autogrow.js/autogrow") %>'
+    'autosize': '<%= requirejs_path("autosize/src/autosize") %>'
   },
   shim: {
     'to-markdown' : {

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_editor.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_editor.scss
@@ -21,6 +21,7 @@
 
 .editor--markdown .editor__content {
   font-family: monospace;
+  resize: none;
 
   &:focus {
     outline: none;

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -19,6 +19,6 @@
     "rangy-official": "1.3",
     "filament-sticky": "0.1.3",
     "html.sortable": "0.1.8",
-    "autogrow.js": "git@github.com:ultimatedelman/autogrow.git#1.0.3"
+    "autosize": "2.0"
   }
 }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -57,5 +57,5 @@ Rails.application.configure do
                                   filament-sticky/fixedsticky.js
                                   filament-fixed/fixedfixed.js
                                   html.sortable/dist/html.sortable.js
-                                  autogrow.js/autogrow.js)
+                                  autosize/src/autosize.js)
 end

--- a/spec/javascripts/helpers/shims/event.js
+++ b/spec/javascripts/helpers/shims/event.js
@@ -1,0 +1,10 @@
+// Shims Event()
+// Taken from https://github.com/Raynos/DOM-shim/blob/master/src/all/interfaces/Event.js
+window.Event = function(type, dict) {
+  var e = document.createEvent("Events");
+  dict = dict || {};
+  dict.bubbles = dict.bubbles || false;
+  dict.catchable = dict.catchable || false;
+  e.initEvent(type, dict.bubbles, dict.catchable);
+  return e;
+};

--- a/spec/javascripts/helpers/shims/phantom-shims.js
+++ b/spec/javascripts/helpers/shims/phantom-shims.js
@@ -1,6 +1,6 @@
 define('phantom-shims', [
-  'spec/javascripts/helpers/shims/bind'
-], function (
-    bind
-  ) {}
-);
+  'spec/javascripts/helpers/shims/bind',
+  'spec/javascripts/helpers/shims/event'
+], function (bind, Event) {
+
+});

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -93,7 +93,7 @@ requirejs.config({
     'rangy-core': bowerPath + 'rangy-official/rangy-core',
     'rangy-selectionsaverestore': bowerPath + 'rangy-official/rangy-selectionsaverestore',
     'html-sortable': bowerPath + 'html.sortable/dist/html.sortable',
-    'autogrow': bowerPath + 'autogrow.js/autogrow'
+    'autosize': bowerPath + 'autosize/src/autosize'
   },
   shim : {
     'to-markdown' : {


### PR DESCRIPTION
This replaces https://github.com/ultimatedelman/autogrow which proved to be buggy when resizing.

An `Event()` shim has been added to allow tests to run in PhantomJS until it arrives in v2.1.