### PR TITLE
Search bar improvements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,9 +14,9 @@ GIT
 
 GIT
   remote: https://github.com/moneyadviceservice/dough.git
-  revision: 0ac46cd40174744f9e87ba97bf4311a094c77ad7
+  revision: 49702dc1bbe729f56077f8b99053b2f7df935ba1
   specs:
-    dough-ruby (5.1.0)
+    dough-ruby (5.4.0)
       activesupport
       rails (>= 3.2)
       sass-rails (~> 4.0.0)

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SearchBar.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SearchBar.js
@@ -1,0 +1,55 @@
+define([
+  'jquery',
+  'DoughBaseComponent',
+  'Collapsable',
+  'eventsWithPromises'
+], function (
+  $,
+  DoughBaseComponent,
+  Collapsable,
+  eventsWithPromises
+) {
+  'use strict';
+
+  var SearchBarProto,
+      defaultConfig = {
+        selectors: {
+          searchBarInput: '[data-dough-search-bar-input]'
+        }
+      };
+
+  function SearchBar($el, config) {
+    SearchBar.baseConstructor.call(this, $el, config, defaultConfig);
+    this.context = this.$el.data('dough-search-bar-context');
+  }
+
+  DoughBaseComponent.extend(SearchBar);
+
+  SearchBarProto = SearchBar.prototype;
+
+  SearchBarProto.init = function(initialised) {
+    this._cacheComponentElements();
+    this._setupAppEvents();
+    this.collapsable = new Collapsable(this.$el).init();
+    this._initialisedSuccess(initialised);
+  };
+
+  SearchBarProto._setupAppEvents = function() {
+    eventsWithPromises.subscribe('toggler:toggled', $.proxy(function(evt) {
+      if(evt.visible && evt.emitter === this.collapsable) {
+        this.focusInput();
+      }
+    }, this));
+  };
+
+  SearchBarProto.focusInput = function() {
+    this.$searchBarInput.focus();
+  };
+
+  SearchBarProto._cacheComponentElements = function() {
+    this.$searchBarInput = $('body').find(this.config.selectors.searchBarInput)
+                                    .filter('[data-dough-search-bar-context="' + this.context + '"]');
+  };
+
+  return SearchBar;
+});

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -43,6 +43,7 @@ requirejs.config({
     'ListSorter': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/ListSorter") %>',
     'WordCount': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/WordCount") %>',
     'URLFormatter': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/URLFormatter") %>',
+    'SearchBar': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/SearchBar") %>',
 
     // Utils
     'filter-event': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/utils/filterEvent") %>',

--- a/app/views/layouts/comfy/admin/cms/_nav_main.html.haml
+++ b/app/views/layouts/comfy/admin/cms/_nav_main.html.haml
@@ -18,7 +18,7 @@
 
           %li.nav-primary__item
           %li.nav-primary__item.nav-primary__item--right
-            = link_to "#{content_tag(:span, '', class: 'nav-primary__icon fa fa-search')}".html_safe, '#', class: 'nav-primary__text nav-primary__text--button', data: { dough_component: 'Collapsable', dough_collapsable_trigger: 'search' }
+            = link_to "#{content_tag(:span, '', class: 'nav-primary__icon fa fa-search')}".html_safe, '#', class: 'nav-primary__text nav-primary__text--button', data: { dough_component: 'SearchBar', dough_search_bar_context: 'search', dough_collapsable_trigger: 'search' }
           %li.nav-primary__item.nav-primary__item--right
             = link_to "#{current_user.name} #{content_tag(:span, '', class: 'nav-primary__icon fa fa-user')}".html_safe, edit_user_path(current_user), class: 'nav-primary__text'
           %li.nav-primary__item.nav-primary__item--right
@@ -29,7 +29,7 @@
         .l-constrained
           .l-search-bar__input
             = label_tag(:search, nil, class: 'visually-hidden')
-            = text_field_tag(:search, params[:search], placeholder: 'Search pages', class: 'form__input')
+            = text_field_tag(:search, params[:search], placeholder: 'Search pages', class: 'form__input', data: { dough_search_bar_input: true, dough_search_bar_context: 'search' })
           .l-search-bar__button
             = button_tag('Search', type: 'submit', name: nil, class: 'button--action button--search-action') do
               %span.button__text.fa.fa-search

--- a/spec/javascripts/fixtures/SearchBar.html
+++ b/spec/javascripts/fixtures/SearchBar.html
@@ -1,0 +1,4 @@
+<div>
+  <div data-dough-component="SearchBar" data-dough-search-bar-context="search"></div>
+  <input type="text" data-dough-search-bar-input data-dough-search-bar-context="search">
+</div>

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -54,6 +54,7 @@ requirejs.config({
     'ListSorter': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ListSorter',
     'WordCount': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/WordCount',
     'URLFormatter': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/URLFormatter',
+    'SearchBar': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SearchBar',
 
     // Utils
     'filter-event': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/utils/filterEvent',

--- a/spec/javascripts/tests/SearchBar_spec.js
+++ b/spec/javascripts/tests/SearchBar_spec.js
@@ -1,0 +1,53 @@
+describe('SearchBar', function() {
+  'use strict';
+
+  var sandbox;
+
+  beforeEach(function(done) {
+    var self = this;
+
+    requirejs([
+      'phantom-shims',
+      'jquery',
+      'eventsWithPromises',
+      'SearchBar'
+    ],
+    function(
+      phantomShims,
+      $,
+      eventsWithPromises,
+      SearchBar
+    ) {
+      self.$html = $(window.__html__['spec/javascripts/fixtures/SearchBar.html']).appendTo('body');
+      self.$fixture = self.$html.find('[data-dough-component="SearchBar"]');
+      self.SearchBar = SearchBar;
+      self.eventsWithPromises = eventsWithPromises;
+      sandbox = sinon.sandbox.create();
+      done();
+    }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+    sandbox.restore();
+    this.eventsWithPromises.unsubscribeAll();
+  });
+
+  describe('when a toggled event is received from Collapsable', function () {
+    beforeEach(function(done) {
+      this.component = new this.SearchBar(this.$fixture);
+      done();
+    });
+
+    it('should shift focus to the search input', function() {
+      this.component.init();
+
+      this.eventsWithPromises.publish('toggler:toggled', {
+        emitter: this.component.collapsable,
+        visible: true
+      });
+
+      expect(document.activeElement).to.eq(this.component.$searchBarInput[0]);
+    });
+  });
+});


### PR DESCRIPTION
The search input is now focussed when the Search icon is clicked. 

`Collapsable` emits a `toggler:toggled` event when it is triggerd. This component listens for said event and focusses the input.

Also bumps dough-ruby.