### PR TITLE
Add unsaved changes prompt

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/AutoComplete.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/AutoComplete.js
@@ -13,11 +13,14 @@ define(['jquery','DoughBaseComponent','chosen'], function ($, DoughBaseComponent
 
   AutoCompleteProto.init = function(initialised) {
     var placeholderText = this.$el.attr('data-dough-placeholder-text');
+
     this.$el.chosen({
       placeholder_text_multiple: !!placeholderText? placeholderText : ' ',
       width: "100%",
       single_backstroke_delete: false,
       inherit_select_classes: true
+    }).change(function() {
+      $(this).closest('form').trigger('input');
     });
 
     this._initialisedSuccess(initialised);

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/UnsavedChangesPrompt.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/UnsavedChangesPrompt.js
@@ -30,15 +30,28 @@ define([
 
   UnsavedChangesPromptProto._setupUIEvents = function() {
     this.$el.on('input change', $.proxy(this._handleInput, this));
+    this.$el.on('submit', $.proxy(this._handleSubmit, this));
   };
 
   UnsavedChangesPromptProto._handleInput = function() {
-    $(window).on('beforeunload', $.proxy(this._handleUnload, this));
+    this._enablePrompt();
     this.$el.off('input change', this._handleInput);
+  };
+
+  UnsavedChangesPromptProto._handleSubmit = function() {
+    this._disablePrompt();
   };
 
   UnsavedChangesPromptProto._handleUnload = function() {
     return this.message;
+  };
+
+  UnsavedChangesPromptProto._enablePrompt = function() {
+    $(window).on('beforeunload', $.proxy(this._handleUnload, this));
+  };
+
+  UnsavedChangesPromptProto._disablePrompt = function() {
+    $(window).off('beforeunload', this._handleUnload);
   };
 
   return UnsavedChangesPrompt;

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/UnsavedChangesPrompt.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/UnsavedChangesPrompt.js
@@ -1,0 +1,45 @@
+define([
+  'jquery',
+  'DoughBaseComponent'
+], function (
+  $,
+  DoughBaseComponent
+) {
+  'use strict';
+
+  var UnsavedChangesPromptProto,
+      defaultConfig = {
+        defaultMessage: 'You have unsaved changes.'
+      };
+
+  function UnsavedChangesPrompt($el, config) {
+    UnsavedChangesPrompt.baseConstructor.call(this, $el, config, defaultConfig);
+  }
+
+  DoughBaseComponent.extend(UnsavedChangesPrompt);
+
+  UnsavedChangesPromptProto = UnsavedChangesPrompt.prototype;
+
+  UnsavedChangesPromptProto.init = function(initialised) {
+    var customMessage = this.$el.data('dough-unsavedchangesprompt-message');
+    this.message = customMessage? customMessage : this.config.defaultMessage;
+
+    this._setupUIEvents();
+    this._initialisedSuccess(initialised);
+  };
+
+  UnsavedChangesPromptProto._setupUIEvents = function() {
+    this.$el.on('input change', $.proxy(this._handleInput, this));
+  };
+
+  UnsavedChangesPromptProto._handleInput = function() {
+    $(window).on('beforeunload', $.proxy(this._handleUnload, this));
+    this.$el.off('input change', this._handleInput);
+  };
+
+  UnsavedChangesPromptProto._handleUnload = function() {
+    return this.message;
+  };
+
+  return UnsavedChangesPrompt;
+});

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -44,6 +44,7 @@ requirejs.config({
     'WordCount': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/WordCount") %>',
     'URLFormatter': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/URLFormatter") %>',
     'SearchBar': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/SearchBar") %>',
+    'UnsavedChangesPrompt': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/UnsavedChangesPrompt") %>',
 
     // Utils
     'filter-event': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/utils/filterEvent") %>',

--- a/app/views/pages/_form.html.haml
+++ b/app/views/pages/_form.html.haml
@@ -11,7 +11,7 @@
   = render 'comfy/admin/cms/files/index'
 
 %div{data:{dough_component: :StickyElements}}
-  = form_for @page, as: :page, url: form_url, class: 'form', html: { multipart: true, autocomplete: 'off'}, data: { dough_component: :MASEditor, dough_scheduler_form: true } do |form|
+  = form_for @page, as: :page, url: form_url, class: 'form', html: { multipart: true, autocomplete: 'off'}, data: { dough_component: 'MASEditor UnsavedChangesPrompt', dough_scheduler_form: true } do |form|
 
     = render 'comfy/admin/cms/partials/page_form_before', object: form
 


### PR DESCRIPTION
Adds a component which watches elements within a container for any user input on form fields and `contentEditable` elements within. If the user makes a change and tries to navigate away or reload the page, a confirmation prompt is shown:

![screen shot 2015-03-24 at 16 33 12](https://cloud.githubusercontent.com/assets/1579511/6806919/817c941c-d243-11e4-957d-fef23688ddc6.png)
