### PR TITLE
Allow placing of cursor in URL field

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/FieldDisabledStateToggler.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/FieldDisabledStateToggler.js
@@ -26,15 +26,18 @@ define([
   FieldDisabledStateTogglerProto = FieldDisabledStateToggler.prototype;
 
   FieldDisabledStateTogglerProto.init = function(initialised) {
-    this._initialisedSuccess(initialised);
+    this.$form = this.$el.closest('form');
+
     this._setupHotSpot();
     this._setupUIEvents();
+
+    this._initialisedSuccess(initialised);
   };
 
   FieldDisabledStateTogglerProto._setupUIEvents = function() {
     $(document).on('keyup', $.proxy(this._handleKeyPress, this));
     this.$hotspot.on('dblclick', $.proxy(this._handleDblClick, this));
-    this.$el.on('blur', $.proxy(this._handleBlur, this));
+    this.$form.on('click keyup', $.proxy(this._handleFocusChange, this));
   };
 
   FieldDisabledStateTogglerProto._setupHotSpot = function() {
@@ -63,16 +66,22 @@ define([
     }
   };
 
-  FieldDisabledStateTogglerProto._handleBlur = function() {
-    this.setDisabledState(true);
+  FieldDisabledStateTogglerProto._handleFocusChange = function(e) {
+    if(e.currentTarget === this.$hotspot[0] || e.keyCode && e.keyCode !== 9) return;
+
+    if(!$(e.target).is(this.$el)) {
+      this.setDisabledState(true);
+    }
   };
 
   FieldDisabledStateTogglerProto.setDisabledState = function(disabled) {
     if(disabled) {
       this.$el.attr(this.disabledAttr, true);
+      this.$hotspot.show();
     }
     else {
       this.$el.removeAttr(this.disabledAttr);
+      this.$hotspot.hide();
     }
   };
 

--- a/spec/javascripts/fixtures/FieldDisabledStateToggler.html
+++ b/spec/javascripts/fixtures/FieldDisabledStateToggler.html
@@ -1,3 +1,3 @@
-<div>
+<form>
    <input name="url" id="url" type="text" data-dough-component="FieldDisabledStateToggler" data-dough-field-disabled-state-toggler-attribute="readonly">
-</div>
+</form>

--- a/spec/javascripts/tests/FieldDisabledStateToggler_spec.js
+++ b/spec/javascripts/tests/FieldDisabledStateToggler_spec.js
@@ -39,6 +39,7 @@ describe('FieldDisabledStateToggler', function() {
       this.component.init();
       this.component.$el.attr(this.component.disabledAttr, true);
       this.component.$hotspot.trigger('dblclick');
+
       expect(!!this.component.$el.attr(this.component.disabledAttr)).to.be.false;
     });
   });
@@ -50,8 +51,14 @@ describe('FieldDisabledStateToggler', function() {
     });
 
     it('should disable the field', function() {
+      var $dummyField = $('<input type="text" />');
+
       this.component.init();
-      this.component.$el.trigger('blur');
+      this.component.$form.append($dummyField);
+
+      this.component.$el.focus();
+      $dummyField.click();
+
       expect(this.component.$el).to.have.attr(this.component.disabledAttr);
     });
   });


### PR DESCRIPTION
Fixes a bug where users were unable to set the cursor position within the URL field.

@moneyadviceservice/team-bee 

id:6214