### PR TITLE
add Page#publishable?

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -82,4 +82,8 @@ class Comfy::Cms::Page < ActiveRecord::Base
   def ever_been_published?
     revisions.map {|revision| revision.data[:event]}.include?('published')
   end
+
+  def publishable?
+    keywords.all?(&:publishable?)
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -20,4 +20,8 @@ class Tag < ActiveRecord::Base
   def in_use?
     taggings.exists?
   end
+
+  def publishable?
+    value != 'do-not-publish'
+  end
 end

--- a/app/views/pages/_form.html.haml
+++ b/app/views/pages/_form.html.haml
@@ -114,8 +114,9 @@
                   %span.button__text
                     = state_event[:label]
                 - unless page_state_buttons(@page.current_state).empty?
-                  %span{:data => {:'dough-component' => 'Collapsable', :'dough-collapsable-trigger' => 1, :'dough-collapsable-config' => '{"hideOnBlur": "true"}'}}
-                    %span.button__icon.fa.fa-caret-up
+                  - if @page.publishable?
+                    %span{:data => {:'dough-component' => 'Collapsable', :'dough-collapsable-trigger' => 1, :'dough-collapsable-config' => '{"hideOnBlur": "true"}'}}
+                      %span.button__icon.fa.fa-caret-up
 
             .popover.popover--options.popover--top{:data => { :'dough-collapsable-target' => 1 }}
               .popover__inner

--- a/spec/models/comfy/cms/page_spec.rb
+++ b/spec/models/comfy/cms/page_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe Comfy::Cms::Page do
-
   describe '#suppress_from_links_recirculation' do
     let(:english_site) { create :site, is_mirrored: true }
     let(:welsh_site) { create :site, :welsh, is_mirrored: true }
@@ -278,4 +277,17 @@ RSpec.describe Comfy::Cms::Page do
     end
   end
 
+  describe '#publishable?' do
+    context 'when tagged with do-not-publish' do
+      it 'returns false' do
+        allow(subject).to receive(:keywords) { [Tag.new(value: 'do-not-publish')] }
+        expect(subject).to_not be_publishable
+      end
+    end
+
+    it 'returns true' do
+      allow(subject).to receive(:keywords) { [Tag.new(value: 'a-tag')] }
+      expect(subject).to be_publishable
+    end
+  end
 end


### PR DESCRIPTION
by default a page is publishable unless tagged with do-not-publish
when not publishable admin UI to publish a page is removed

this feature will be used to provide content to engines
where we do not want articles to be published but still available
this is done by using the preview functionality as a back door