### PR TITLE
add third_level_navigation to categories

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -52,6 +52,7 @@ class CategoriesController < Comfy::Admin::Cms::BaseController
       :description_cy,
       :ordinal,
       :navigation,
+      :third_level_navigation,
       :site_id,
       :categorized_type
     )

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,5 +1,5 @@
 class CategorySerializer < ActiveModel::Serializer
-  attributes :id, :type, :title, :description, :parent_id
+  attributes :id, :type, :title, :description, :parent_id, :third_level_navigation
 
   has_many :contents
 
@@ -34,5 +34,9 @@ class CategorySerializer < ActiveModel::Serializer
   def parent_id
     return '' unless object.parent_id.present?
     Comfy::Cms::Category.find(object.parent_id).label
+  end
+
+  def third_level_navigation
+    object.third_level_navigation
   end
 end

--- a/app/views/categories/_form.html.haml
+++ b/app/views/categories/_form.html.haml
@@ -15,6 +15,7 @@
       .form-group
         .form__input-wrapper
           = f.check_box :navigation, label: t('categories.edit.show_in_navigation')
+          = f.check_box :third_level_navigation, label: t('categories.edit.third_level_navigation')
 
       .form-group
         .form__input-wrapper

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -34,6 +34,7 @@
             .form-group
               .form__input-wrapper
                 = f.check_box :navigation, label: t('categories.edit.show_in_navigation')
+                = f.check_box :third_level_navigation, label: t('categories.edit.third_level_navigation')
 
             = hidden_field_tag 'list_order_sub_categories', nil , data: { dough_listsorter_order_field: true, dough_listsorter_context: 'category-manager-sub-categories'}
             = hidden_field_tag 'list_order_pages_en', nil , data: { dough_listsorter_order_field: true, dough_listsorter_context: 'category-manager-pages-en'}

--- a/config/locales/categories.yml
+++ b/config/locales/categories.yml
@@ -7,6 +7,7 @@ en:
       go_to_parent: Up
     edit:
       show_in_navigation: Show in Primary navigation
+      third_level_navigation: Third level navigation
       submit:
         create: Create category
         update: Update category

--- a/db/migrate/20150428091610_add_third_level_nav_to_categories.rb
+++ b/db/migrate/20150428091610_add_third_level_nav_to_categories.rb
@@ -1,0 +1,5 @@
+class AddThirdLevelNavToCategories < ActiveRecord::Migration
+  def change
+    add_column :comfy_cms_categories, :third_level_navigation, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150129120103) do
+ActiveRecord::Schema.define(version: 20150428091610) do
 
   create_table "comfy_cms_blocks", force: true do |t|
     t.string   "identifier",                      null: false
@@ -26,9 +26,9 @@ ActiveRecord::Schema.define(version: 20150129120103) do
   add_index "comfy_cms_blocks", ["identifier"], name: "index_comfy_cms_blocks_on_identifier", using: :btree
 
   create_table "comfy_cms_categories", force: true do |t|
-    t.integer "site_id",          null: false
-    t.string  "label",            null: false
-    t.string  "categorized_type", null: false
+    t.integer "site_id",                                null: false
+    t.string  "label",                                  null: false
+    t.string  "categorized_type",                       null: false
     t.string  "title_en"
     t.string  "title_cy"
     t.string  "description_en"
@@ -36,10 +36,11 @@ ActiveRecord::Schema.define(version: 20150129120103) do
     t.string  "title_tag_en"
     t.string  "title_tag_cy"
     t.integer "parent_id"
-    t.integer "ordinal",          default: 999
+    t.integer "ordinal",                default: 999
     t.boolean "navigation"
     t.string  "image"
     t.string  "preview_image"
+    t.boolean "third_level_navigation", default: false
   end
 
   add_index "comfy_cms_categories", ["parent_id"], name: "index_comfy_cms_categories_on_parent_id", using: :btree
@@ -110,10 +111,9 @@ ActiveRecord::Schema.define(version: 20150129120103) do
     t.string   "preview_cache"
     t.boolean  "regulated",                                          default: false
     t.string   "meta_title"
-    t.boolean  "regulated",                         default: false
     t.string   "translation_id"
-    t.integer  "page_views",                                         default: 0
     t.datetime "scheduled_on"
+    t.integer  "page_views",                                         default: 0
     t.boolean  "suppress_from_links_recirculation",                  default: false
   end
 

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe CategoriesController, type: :controller do
       'id' => "#{category.id}",
       'list_order_sub_categories' => "#{sub_category_2.id}, #{sub_category_1.id}",
       'comfy_cms_category' => {
-        'title_en' => 'Debt and borrowing'
+        'title_en' => 'Debt and borrowing',
+        'third_level_navigation' => '1'
       }
     }
   end
@@ -25,7 +26,11 @@ RSpec.describe CategoriesController, type: :controller do
     end
 
     it 'updates the order of the sub categories' do
-      expect(category.child_categories.map(&:label)).to eq(['Sub Category 2', 'Sub Category 1'])
+      expect(category.reload.child_categories.map(&:label)).to eq(['Sub Category 2', 'Sub Category 1'])
+    end
+
+    it 'updates third_level_navigation' do
+      expect(category.reload.third_level_navigation).to eq(true)
     end
   end
 end

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -11,7 +11,8 @@ describe CategorySerializer do
       description_en: 'description_en',
       description_cy: 'description_cy',
       parent_id: nil,
-      child_categories: [child_categories])
+      child_categories: [child_categories],
+      third_level_navigation: true)
   end
 
   subject { described_class.new(category, scope: scope) }
@@ -25,6 +26,7 @@ describe CategorySerializer do
         title: 'en_title',
         description: 'description_en',
         parent_id: '',
+        third_level_navigation: true,
         contents: []
       }
     end
@@ -43,6 +45,7 @@ describe CategorySerializer do
         title: 'cy_title',
         description: 'description_cy',
         parent_id: '',
+        third_level_navigation: true,
         contents: []
       }
     end


### PR DESCRIPTION
- add migration for third_level_navigation boolean to categories table
- this adds a tick box for third_level_navigation on category create and
edit page.
- expose third_level_navigation as part of the category show json

cc @darokel @tomas-stefano 