### PR TITLE
Add componentNames to JS modules

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/AutoComplete.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/AutoComplete.js
@@ -9,6 +9,9 @@ define(['jquery','DoughBaseComponent','chosen'], function ($, DoughBaseComponent
   }
 
   DoughBaseComponent.extend(AutoComplete);
+
+  AutoComplete.componentName = 'AutoComplete';
+
   AutoCompleteProto = AutoComplete.prototype;
 
   AutoCompleteProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/CharacterCounter.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/CharacterCounter.js
@@ -27,6 +27,8 @@ define([
 
   DoughBaseComponent.extend(CharacterCounter);
 
+  CharacterCounter.componentName = 'CharacterCounter';
+
   CharacterCounterProto = CharacterCounter.prototype;
 
   CharacterCounterProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Dialog.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Dialog.js
@@ -35,6 +35,8 @@ define([
 
   DoughBaseComponent.extend(Dialog);
 
+  Dialog.componentName = 'Dialog';
+
   DialogProto = Dialog.prototype;
 
   DialogProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ElementFilter.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ElementFilter.js
@@ -27,6 +27,8 @@ define([
 
   DoughBaseComponent.extend(ElementFilter);
 
+  ElementFilter.componentName = 'ElementFilter';
+
   ElementFilterProto = ElementFilter.prototype;
 
   ElementFilterProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ElementHider.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ElementHider.js
@@ -17,6 +17,9 @@ define(['jquery','DoughBaseComponent'], function ($, DoughBaseComponent) {
   }
 
   DoughBaseComponent.extend(ElementHider);
+
+  ElementHider.componentName = 'ElementHider';
+
   ElementHiderProto = ElementHider.prototype;
 
   ElementHiderProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/FieldDisabledStateToggler.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/FieldDisabledStateToggler.js
@@ -23,6 +23,8 @@ define([
 
   DoughBaseComponent.extend(FieldDisabledStateToggler);
 
+  FieldDisabledStateToggler.componentName = 'FieldDisabledStateToggler';
+
   FieldDisabledStateTogglerProto = FieldDisabledStateToggler.prototype;
 
   FieldDisabledStateTogglerProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/FileInputSubmit.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/FileInputSubmit.js
@@ -18,6 +18,8 @@ define([
 
     DoughBaseComponent.extend(FileInputSubmit);
 
+    FileInputSubmit.componentName = 'FileInputSubmit';
+
     FileInputSubmitProto = FileInputSubmit.prototype;
 
     FileInputSubmitProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ImageManager.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ImageManager.js
@@ -22,6 +22,8 @@ define([
 
   DoughBaseComponent.extend(ImageManager, InsertManager);
 
+  ImageManager.componentName = 'ImageManager';
+
   ImageManagerProto = ImageManager.prototype;
 
   ImageManagerProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/InsertManager.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/InsertManager.js
@@ -33,6 +33,8 @@ define([
 
   DoughBaseComponent.extend(InsertManager);
 
+  InsertManager.componentName = 'InsertManager';
+
   InsertManagerProto = InsertManager.prototype;
 
   InsertManagerProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/LinkManager.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/LinkManager.js
@@ -31,6 +31,8 @@ define([
 
   DoughBaseComponent.extend(LinkManager, InsertManager);
 
+  LinkManager.componentName = 'LinkManager';
+
   LinkManagerProto = LinkManager.prototype;
 
   LinkManagerProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ListSorter.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ListSorter.js
@@ -23,6 +23,8 @@ define([
 
   DoughBaseComponent.extend(ListSorter);
 
+  ListSorter.componentName = 'ListSorter';
+
   ListSorterProto = ListSorter.prototype;
 
   ListSorterProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
@@ -75,6 +75,9 @@ define([
   }
 
   DoughBaseComponent.extend(MASEditor);
+
+  MASEditor.componentName = 'MASEditor';
+
   MASEditorProto = MASEditor.prototype;
 
   MASEditorProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MirrorInputValue.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MirrorInputValue.js
@@ -25,6 +25,8 @@ define([
 
   DoughBaseComponent.extend(MirrorInputValue);
 
+  MirrorInputValue.componentName = 'MirrorInputValue';
+
   MirrorInputValueProto = MirrorInputValue.prototype;
 
   MirrorInputValueProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Popover.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Popover.js
@@ -23,6 +23,8 @@ define(['jquery', 'DoughBaseComponent', 'Collapsable'], function($, DoughBaseCom
    */
   DoughBaseComponent.extend(Popover, Collapsable);
 
+  Popover.componentName = 'Popover';
+
   Popover.prototype.init = function(initialised) {
     Popover.superclass.init.call(this);
 

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Scheduler.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Scheduler.js
@@ -21,9 +21,11 @@ define([
 
   function Scheduler($el, config) {
     Scheduler.baseConstructor.call(this, $el, config, defaultConfig);
-  };
+  }
 
   DoughBaseComponent.extend(Scheduler);
+
+  Scheduler.componentName = 'Scheduler';
 
   SchedulerProto = Scheduler.prototype;
 

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SearchBar.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SearchBar.js
@@ -25,6 +25,8 @@ define([
 
   DoughBaseComponent.extend(SearchBar);
 
+  SearchBar.componentName = 'SearchBar';
+
   SearchBarProto = SearchBar.prototype;
 
   SearchBarProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SelectSubmitter.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SelectSubmitter.js
@@ -13,6 +13,9 @@ define(['jquery','DoughBaseComponent'], function ($, DoughBaseComponent) {
   }
 
   DoughBaseComponent.extend(SelectSubmitter);
+
+  SelectSubmitter.componentName = 'SelectSubmitter';
+
   SelectSubmitterProto = SelectSubmitter.prototype;
 
   SelectSubmitterProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SnippetInserter.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SnippetInserter.js
@@ -28,6 +28,8 @@ define([
 
   DoughBaseComponent.extend(SnippetInserter);
 
+  SnippetInserter.componentName = 'SnippetInserter';
+
   SnippetInserterProto = SnippetInserter.prototype;
 
   SnippetInserterProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/StickyElements.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/StickyElements.js
@@ -21,6 +21,8 @@ define([
 
   DoughBaseComponent.extend(StickyElements);
 
+  StickyElements.componentName = 'StickyElements';
+
   StickyElementsProto = StickyElements.prototype;
 
   StickyElementsProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/TagManager.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/TagManager.js
@@ -28,6 +28,8 @@ define([
 
   DoughBaseComponent.extend(TagManager);
 
+  TagManager.componentName = 'TagManager';
+
   TagManagerProto = TagManager.prototype;
 
   TagManagerProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Tags.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/Tags.js
@@ -23,6 +23,9 @@ define([
   }
 
   DoughBaseComponent.extend(Tags);
+
+  Tags.componentName = 'Tags';
+
   TagsProto = Tags.prototype;
 
   TagsProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/URLFormatter.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/URLFormatter.js
@@ -23,6 +23,8 @@ define([
 
   DoughBaseComponent.extend(URLFormatter);
 
+  URLFormatter.componentName = 'URLFormatter';
+
   URLFormatterProto = URLFormatter.prototype;
 
   URLFormatterProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/URLToggler.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/URLToggler.js
@@ -20,6 +20,8 @@ define([
 
   DoughBaseComponent.extend(URLToggler);
 
+  URLToggler.componentName = 'URLToggler';
+
   URLTogglerProto = URLToggler.prototype;
 
   URLTogglerProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/UnsavedChangesPrompt.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/UnsavedChangesPrompt.js
@@ -18,6 +18,8 @@ define([
 
   DoughBaseComponent.extend(UnsavedChangesPrompt);
 
+  UnsavedChangesPrompt.componentName = 'UnsavedChangesPrompt';
+
   UnsavedChangesPromptProto = UnsavedChangesPrompt.prototype;
 
   UnsavedChangesPromptProto.init = function(initialised) {

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/WordCount.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/WordCount.js
@@ -25,6 +25,8 @@ define([
 
   WordCountProto = WordCount.prototype;
 
+  WordCount.componentName = 'WordCount';
+
   WordCountProto.init = function(initialised) {
     this._cacheComponentElements();
     this.$el.on('input keydown', $.proxy(this._handleInput, this));


### PR DESCRIPTION
Pending changes in Dough use `componentName` to stamp the attribute on the component element when it is initialised https://github.com/moneyadviceservice/dough/pull/219