### PR TITLE
CMS api now serves HTML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'google-api-client', '0.7.1'
 gem 'legato', '0.4.0'
 gem 'clockwork'
 
+gem 'mastalk'
+
 group :development do
   gem 'spring'
   gem 'spring-commands-cucumber'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,6 +348,9 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    mastalk (0.3.5)
+      htmlentities (~> 4.3.2, >= 4.3.2)
+      kramdown (~> 1.5.0, >= 1.5.0)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)
@@ -554,6 +557,7 @@ DEPENDENCIES
   jquery-ui-rails (~> 5.0)
   legato (= 0.4.0)
   mas-development_dependencies!
+  mastalk
   mysql2
   oauth2 (= 1.0.0)
   pry-rails

--- a/app/models/block_composer.rb
+++ b/app/models/block_composer.rb
@@ -1,0 +1,25 @@
+class BlockComposer
+  class Block < OpenStruct
+    delegate :to_s, to: :content
+  end
+
+  attr_reader :blocks, :id, :parser
+
+  def initialize(blocks = [], id = 'content', parser = Mastalk::Document)
+    @blocks = Array(blocks)
+    @parser = parser
+    @id = id
+  end
+
+  def find(id)
+    Block.new(blocks.find { |block| block['identifier'] == id })
+  end
+
+  def to_html
+    parser.new(to_s).to_html
+  end
+
+  def to_s
+    find(id).to_s
+  end
+end

--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -6,8 +6,13 @@ class BlockSerializer < ActiveModel::Serializer
   private
 
   def content
-    return object.content if render_content_directly?
-    published_content.fetch(:content, '')
+    blocks = if render_content_directly?
+      [{ "identifier" => "content", "content" => object.content}]
+    else
+      [{ "identifier" => "content", "content" => published_content.fetch(:content, '') }]
+    end
+
+    BlockComposer.new(blocks).to_html
   end
 
   def published_content

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -9,7 +9,7 @@ When(/^I preview the article$/) do
 end
 
 Then(/^I should see the Draft Article$/) do
-  expect(JSON.parse(preview_page.text)['blocks'].find {|b| b["identifier"] == 'content'}['content']).to eq('test')
+  expect(JSON.parse(preview_page.text)['blocks'].find {|b| b["identifier"] == 'content'}['content']).to include('test')
 end
 
 Then(/^I should not be able to see live draft article$/) do
@@ -30,7 +30,7 @@ When(/^I view the live published article$/) do
 end
 
 Then(/^I should see the published Article content$/) do
-  expect(JSON.parse(live_page.text)['blocks'].find {|b| b["identifier"] == 'content'}['content']).to eq('New Published Content')
+  expect(JSON.parse(live_page.text)['blocks'].find {|b| b["identifier"] == 'content'}['content']).to include('New Published Content')
 end
 
 When(/^I am working on a Draft Article$/) do

--- a/spec/models/block_composer_spec.rb
+++ b/spec/models/block_composer_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe BlockComposer do
+  let(:id) { 'content' }
+  subject(:composer) { described_class.new(blocks, id) }
+
+  let(:content_block) do
+    { 'identifier' => 'content', 'content' => 'Content Block' }
+  end
+
+  describe '#initialize' do
+    it 'accepts an array' do
+      dub = double
+      expect(described_class.new([dub]).blocks).to eql([dub])
+    end
+
+    it 'transforms a nil' do
+      expect(described_class.new(nil).blocks).to eql([])
+    end
+
+    it 'transforms a non-nil non-array' do
+      dub = double
+      expect(described_class.new(dub).blocks).to eql([dub])
+    end
+  end
+
+  describe '#to_s' do
+    context 'description' do
+      let(:blocks) { [{ 'identifier' => 'description', 'content' => 'meta description' }] }
+      let(:id) { 'description' }
+
+      it 'returns the meta description string' do
+        expect(composer.to_s).to eql('meta description')
+      end
+    end
+  end
+
+  describe '#to_html' do
+    context 'content block provided' do
+      let(:blocks) { [content_block] }
+
+      it 'returns a composed html string' do
+        expect(composer.to_html).to eql("<p>Content Block</p>\n")
+      end
+    end
+
+    context 'no blocks provided' do
+      let(:blocks) { [] }
+
+      it 'is an empty string' do
+        expect(composer.to_html).to eql("\n")
+      end
+    end
+
+    context 'non-content block provided' do
+      let(:non_content_block) do
+        { 'identifier' => 'not_content', 'content' => 'Definitely not a Content Block' }
+      end
+
+      let(:blocks) { [non_content_block] }
+
+      it 'returns a composed html string' do
+        expect(composer.to_html).to eql("\n")
+      end
+    end
+  end
+end

--- a/spec/serializers/block_serializer_spec.rb
+++ b/spec/serializers/block_serializer_spec.rb
@@ -6,7 +6,15 @@ describe BlockSerializer do
     let(:page) { Comfy::Cms::Page.new(state: 'published') }
 
     it 'returns the blocks content' do
-      expect(subject).to eq('published content')
+      expect(subject).to eq("<p>published content</p>\n")
+    end
+
+    context 'when contains mastalk snippets' do
+      let(:object) { Comfy::Cms::Block.new(blockable: page, content: '## content') }
+
+      it 'converts output to html' do
+        expect(subject).to eq("<h2 id=\"content\">content</h2>\n")
+      end
     end
   end
 
@@ -17,7 +25,7 @@ describe BlockSerializer do
     let(:page) { Comfy::Cms::Page.new(state: 'published_being_edited', revisions: [revisions]) }
 
     it 'returns the last published content' do
-      expect(subject).to eq('Last published content')
+      expect(subject).to eq("<p>Last published content</p>\n")
     end
   end
 
@@ -26,7 +34,7 @@ describe BlockSerializer do
     let(:page) { Comfy::Cms::Page.new(state: 'scheduled', scheduled_on: passed_date) }
 
     it 'returns the blocks content' do
-      expect(subject).to eq('published content')
+      expect(subject).to eq("<p>published content</p>\n")
     end
   end
 
@@ -38,7 +46,7 @@ describe BlockSerializer do
     let(:page) { Comfy::Cms::Page.new(state: 'scheduled', scheduled_on: future_date, revisions: [revisions]) }
 
     it 'returns the last published revision content' do
-      expect(subject).to eq('Last published content')
+      expect(subject).to eq("<p>Last published content</p>\n")
     end
   end
 end


### PR DESCRIPTION
- At the moment the CMS generates markdown content which is then processed by the client.
- This changes the API so it is now the job of the CMS to generate HTML.
- I think this is the job of the CMS and not the client hence the move
- This will save every client from having implement something to process the markdown (with custom snippets) to HTML