### PR TITLE
Partner feeds for articles

### DIFF
--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,6 +1,6 @@
 module API
   class ContentController < APIController
-    before_action :find_site, only: [:show, :preview]
+    before_action :find_site, only: [:show, :preview, :published]
     before_action :verify_page_type, only: :show, if: -> { slug.present? }
 
     def show
@@ -20,6 +20,12 @@ module API
       page = current_site.pages.find_by(slug: params[:slug])
 
       render_page(page, scope: 'preview')
+    end
+
+    def published
+      pages = current_site.pages.published
+
+      render json: pages
     end
 
     private

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -1,6 +1,6 @@
 module API
   class ContentController < APIController
-    before_action :find_site, only: [:show, :preview, :published]
+    before_action :find_site, only: [:show, :preview, :published, :unpublished]
     before_action :verify_page_type, only: :show, if: -> { slug.present? }
 
     def show
@@ -24,6 +24,12 @@ module API
 
     def published
       pages = current_site.pages.published
+
+      render json: pages
+    end
+
+    def unpublished
+      pages = current_site.pages.unpublished
 
       render json: pages
     end

--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -41,6 +41,8 @@ class Comfy::Cms::Page < ActiveRecord::Base
       )
   end)
 
+  scope :unpublished, -> { where(state: 'unpublished') }
+
   def self.in_category(category_id)
     joins(
       'INNER JOIN comfy_cms_categorizations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,8 @@ Rails.application.routes.draw do
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
     get '/preview/:locale/(*slug)(.:format)' => 'content#preview', as: 'preview_content'
+
+    get '/:locale/:page_type/published(.:format)' => 'content#published', defaults: { format: 'json' }
     get '/:locale/:page_type/(*slug)(.:format)' => 'content#show', as: 'content'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     get '/preview/:locale/(*slug)(.:format)' => 'content#preview', as: 'preview_content'
 
     get '/:locale/:page_type/published(.:format)' => 'content#published', defaults: { format: 'json' }
+    get '/:locale/:page_type/unpublished(.:format)' => 'content#unpublished', defaults: { format: 'json' }
     get '/:locale/:page_type/(*slug)(.:format)' => 'content#show', as: 'content'
   end
 

--- a/spec/controllers/api/content_controller_spec.rb
+++ b/spec/controllers/api/content_controller_spec.rb
@@ -42,6 +42,42 @@ RSpec.describe API::ContentController, type: :request do
     end
   end
 
+  describe 'GET /:locale/articles/unpublished.json' do
+    let!(:article_layout) { create(:layout, :article, site: site) }
+    let(:response_body) { JSON.load(response.body) }
+
+    context 'when no unpublished articles' do
+      it 'returns an empty array' do
+        get '/en/articles/unpublished'
+        expect(response_body).to eql([])
+      end
+    end
+
+    context 'when unpublished articles' do
+      let(:article_layout) { create(:layout, :article, site: site) }
+      let!(:page) do
+        object = create(:page, label: 'Borrow', slug: 'borrow', site: site, state: 'unpublished', layout: article_layout, full_path: '/')
+        object.blocks.create(identifier: 'content', content: 'stuff')
+        object.revisions.create(data: {previous_event: 'published', event: 'unpublished', blocks_attributes: [{ identifier: 'content', content: "## title" }]})
+        object
+      end
+
+      before :each do
+        create(:page, label: 'Borrow v2', slug: 'borrow-v2', site: site, state: 'published', layout: article_layout, full_path: '/')
+      end
+
+      it 'returns unpublished articles' do
+        get '/en/articles/unpublished'
+        expect(response_body.count).to eql(1)
+      end
+
+      it 'content is html' do
+        get '/en/articles/unpublished'
+        expect(response_body[0]['blocks'][0]['content']).to include('<h2 id="title">title</h2>')
+      end
+    end
+  end
+
   describe 'GET /:locale/articles/:slug' do
     let(:state) { 'published' }
     let(:article_layout) { create(:layout, :article, site: site) }

--- a/spec/controllers/api/content_controller_spec.rb
+++ b/spec/controllers/api/content_controller_spec.rb
@@ -7,6 +7,41 @@ RSpec.describe API::ContentController, type: :request do
     allow_any_instance_of(PageSerializer).to receive(:related_content).and_return({})
   end
 
+  describe 'GET /:locale/articles/published.json' do
+    let!(:article_layout) { create(:layout, :article, site: site) }
+    let(:response_body) { JSON.load(response.body) }
+
+    context 'when no published articles' do
+      it 'returns an empty array' do
+        get '/en/articles/published'
+        expect(response_body).to eql([])
+      end
+    end
+
+    context 'when published articles' do
+      let(:article_layout) { create(:layout, :article, site: site) }
+      let!(:page) do
+        object = create(:page, label: 'Borrow', slug: 'borrow', site: site, state: 'published', layout: article_layout, full_path: '/')
+        object.blocks.create(identifier: 'content', content: '## title')
+        object
+      end
+
+      before :each do
+        create(:page, label: 'Borrow v2', slug: 'borrow-v2', site: site, state: 'draft', layout: article_layout, full_path: '/')
+      end
+
+      it 'returns published articles' do
+        get '/en/articles/published'
+        expect(response_body.count).to eql(1)
+      end
+
+      it 'content is html' do
+        get '/en/articles/published'
+        expect(response_body[0]['blocks'][0]['content']).to include('<h2 id="title">title</h2>')
+      end
+    end
+  end
+
   describe 'GET /:locale/articles/:slug' do
     let(:state) { 'published' }
     let(:article_layout) { create(:layout, :article, site: site) }


### PR DESCRIPTION
This add partner feeds for published and unpublished articles.

- I'm pretty sure these feeds will be slow and we may need to consider some sort of caching mechanism.