### PR TITLE
make full_path in serializer useful

### DIFF
--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -8,6 +8,10 @@ class PageSerializer < ActiveModel::Serializer
   has_many :blocks, serializer: BlockSerializer
   has_many :translations, serializer: PageTranslationSerializer
 
+  def full_path
+    PagePresenter.new(object).link
+  end
+
   def related_content
     {
       latest_blog_post_links: PageLink::LatestLinks.new(object),

--- a/spec/serializers/page_serializer_spec.rb
+++ b/spec/serializers/page_serializer_spec.rb
@@ -1,6 +1,6 @@
 describe PageSerializer do
   let(:site) { Comfy::Cms::Site.new(label: 'en') }
-  let(:article) { Comfy::Cms::Page.new(site: site) }
+  let(:article) { Comfy::Cms::Page.new(site: site, slug: 'i-am-slug') }
   subject { described_class.new(article) }
 
   before do
@@ -10,10 +10,14 @@ describe PageSerializer do
     allow(Publify::API).to receive(:latest_links).and_return([])
   end
 
+  describe '#full_path' do
+    it 'returns /locale/page_type/slug' do
+      expect(subject.full_path).to eql('/en/articles/i-am-slug')
+    end
+  end
+
   describe '#related_content' do
-
     context 'latest blog post links' do
-
       let(:latest_links) do
         [
           { 'title' => 'First post', 'link' => 'http://a.com' },


### PR DESCRIPTION
this use to return the slug we now return /locale/page_type/slug
although this is a breaking change to the API I am not aware of any external
apps using they full_path at the moment

cc @tomas-stefano 