### PR TITLE
Persist published at

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -90,14 +90,7 @@ class Comfy::Cms::Page < ActiveRecord::Base
   def publishable?
     keywords.all?(&:publishable?)
   end
-
-  def published_at
-    if published?
-      updated_at
-    elsif scheduled?
-      scheduled_on
-    elsif ever_been_published?
-      revisions.detect { |revision| revision.data[:event] == 'published' }.created_at
-    end
-  end
 end
+
+Comfy::Cms::Page.state_machine.events[:publish].timestamp = :published_at
+Comfy::Cms::Page.state_machine.events[:publish_changes].timestamp = :published_at

--- a/db/migrate/20150608142817_add_published_at_to_page.rb
+++ b/db/migrate/20150608142817_add_published_at_to_page.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToPage < ActiveRecord::Migration
+  def change
+    add_column :comfy_cms_pages, :published_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428091610) do
+ActiveRecord::Schema.define(version: 20150608142817) do
 
   create_table "comfy_cms_blocks", force: true do |t|
     t.string   "identifier",                      null: false
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 20150428091610) do
     t.datetime "scheduled_on"
     t.integer  "page_views",                                         default: 0
     t.boolean  "suppress_from_links_recirculation",                  default: false
+    t.datetime "published_at"
   end
 
   add_index "comfy_cms_pages", ["parent_id", "position"], name: "index_comfy_cms_pages_on_parent_id_and_position", using: :btree


### PR DESCRIPTION
- Persist `published_at` when a page is published
- We will need to retrofit the `published_at` field for pages that are already published or have been published at some point