### PR TITLE
Fix create page errors

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,8 +1,8 @@
 class PagesController < Comfy::Admin::Cms::PagesController
   before_action :build_file,     only: [:new, :edit]
-  before_action :set_categories, only: [:new, :edit]
+  before_action :set_categories, only: [:new, :edit, :create]
   before_action :set_pages,      only: :index
-  before_action :set_activity_log, only: [:new, :edit]
+  before_action :set_activity_log, only: [:new, :edit, :create]
 
   protected
 

--- a/app/views/pages/new.html.haml
+++ b/app/views/pages/new.html.haml
@@ -1,1 +1,3 @@
+- flash.now[:danger] = @page.errors.full_messages.join(', ') if @page.errors.present?
+
 = render 'form', form_url: site_pages_path(@site)

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe PagesController do
         expect(assigns[:page].state).to eq 'draft'
       end
 
+      it 'assigns required instance variables' do
+        expect(assigns[:categories]).to_not be_nil
+        expect(assigns[:activity_logs]).to_not be_nil
+      end
+
       context 'creating a revision' do
         before do
           assigns[:page].revisions.reload


### PR DESCRIPTION
- On failed page creation this no longer raises an unexpected exception due to missing variables
- Slight hack to populate flash has with something meaningful. Comfy doesn't provide any hooks to make this possible.