### PR TITLE
Allow linking to heading anchors within editorial

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/InsertManager.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/InsertManager.js
@@ -21,7 +21,9 @@ define([
           loader: '[data-dough-insertmanager-loader]',
           url: '[data-dough-insertmanager-url]',
           activeClass: 'is-active',
-          inactiveClass: 'is-inactive'
+          inactiveClass: 'is-inactive',
+          anchors: '[data-dough-insertmanager-insert-type="anchor"]',
+          editorContents: '.editor__content'
         }
       };
 
@@ -65,6 +67,7 @@ define([
       .on('input', '[data-dough-insertmanager-value-trigger][type="text"]', $.proxy(this._handleFormControlUpdate, this))
       .on('keyup', '[data-dough-insertmanager-value-trigger][type="text"]', $.proxy(this._handleFormControlUpdate, this))
       .on('change', '[data-dough-insertmanager-value-trigger][type="radio"]', $.proxy(this._handleFormControlUpdate, this))
+      .on('change', 'select[data-dough-insertmanager-value-trigger]', $.proxy(this._handleFormControlUpdate, this))
       .on('click', '[data-dough-insertmanager-insert]', $.proxy(this._handleInsertValue, this));
   };
 

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/LinkManager.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/LinkManager.js
@@ -3,13 +3,15 @@ define([
   'DoughBaseComponent',
   'InsertManager',
   'eventsWithPromises',
-  'filter-event'
+  'filter-event',
+  'URLFormatter'
 ], function (
   $,
   DoughBaseComponent,
   InsertManager,
   eventsWithPromises,
-  filterEvent
+  filterEvent,
+  URLFormatter
 ) {
   'use strict';
 
@@ -40,9 +42,43 @@ define([
     this._initialisedSuccess(initialised);
   };
 
+  LinkManagerProto._setup = function(type, val) {
+    LinkManager.superclass._setup.call(this);
+    this._populateAnchors(val);
+  };
+
   LinkManagerProto._setupAppEvents = function() {
     eventsWithPromises.subscribe('cmseditor:insert-published', filterEvent($.proxy(this._handleShown, this), this.context));
     LinkManager.superclass._setupAppEvents.call(this);
+  };
+
+  LinkManagerProto._populateAnchors = function(selectedValue) {
+    var self = this,
+        html = '',
+        id,
+        text;
+
+    this._resetSelectOptions(this.config.selectors.anchors);
+
+    $(this.config.selectors.editorContents).find('h2, h3, h4').each(function() {
+      text = $(this).html();
+      id = '#' + self._slugify(text);
+      html += self._getAnchorOptionMarkup(self.config.selectors.anchors, id, text, selectedValue);
+    });
+
+    this.$insertInputs.filter(self.config.selectors.anchors).append(html);
+  };
+
+  LinkManagerProto._resetSelectOptions = function(selectSelector) {
+    $(selectSelector).find('option[value]').remove();
+  };
+
+  LinkManagerProto._getAnchorOptionMarkup = function(selectSelector, value, text, selectedValue) {
+    return '<option value="' + value + '"' + (value === selectedValue ? ' selected="selected"' : '') + '>' + text + '</option>';
+  };
+
+  LinkManagerProto._slugify = function(str) {
+    return URLFormatter.prototype.slugify(str);
   };
 
   return LinkManager;

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
@@ -58,10 +58,10 @@ define([
             ul: {},
             li: {},
             a: { href: true, id: true, title: true },
-            h2: {},
-            h3: {},
-            h4: {},
-            h5: {},
+            h2: { id: true },
+            h3: { id: true },
+            h4: { id: true },
+            h5: { id: true },
             sub: {},
             sup: {},
             span: { 'class': true, id: true },
@@ -84,6 +84,7 @@ define([
     this._cacheComponentElements();
     this._stripEditorWhitespace();
     this.enableToolbar('html');
+
     this.editorLib = new Editor(
       this.$htmlContent[0],
       this.markdownContent,
@@ -105,7 +106,6 @@ define([
     this.editorLib.editor.use(scribePluginMastalk('promoBlock'));
 
     this.setupMarkdownContentResize();
-
     this._initialisedSuccess(initialised);
   };
 

--- a/app/views/links/anchors/_form.html.haml
+++ b/app/views/links/anchors/_form.html.haml
@@ -1,0 +1,17 @@
+.tab-selector__target#anchor.is-inactive{'data-dough-tab-selector-target' => 'anchor' }
+  %h3.l-tab-panels__heading
+    = t('links.anchor.header')
+  .form.form--vertical
+    .form-group
+      .form__input-wrapper
+        %select{ data: { 'dough-insertmanager-insert-type' => 'anchor',
+                         'dough-insertmanager-value-trigger' => true },
+                 class: 'pages-categories-select form__select--fill-width' }
+          %option
+            = t('links.anchor.placeholder')
+
+    .form-group
+      .form__input-wrapper
+        %button.button--action
+          %span.button__text{'data-dough-insertmanager-insert' => 'anchor' }
+            = t('links.anchor.insert_button')

--- a/app/views/pages/_insert_link_dialog.html.haml
+++ b/app/views/pages/_insert_link_dialog.html.haml
@@ -11,11 +11,14 @@
               %a.tab-selector__trigger{ href: '#file', 'data-dough-tab-selector-trigger' => 'file' } A file
             .tab-selector__trigger-container.is-inactive{ 'data-dough-tab-selector-trigger-container' => true }
               %a.tab-selector__trigger{ href: '#external', 'data-dough-tab-selector-trigger' => 'external' } External site
+            .tab-selector__trigger-container.is-inactive{ 'data-dough-tab-selector-trigger-container' => true }
+              %a.tab-selector__trigger{ href: '#anchor', 'data-dough-tab-selector-trigger' => 'anchor' } An anchor
 
       .l-tab-panels__item.l-tab-panels__item--content
         = render 'links/pages/form'
         = render 'links/documents/form'
         = render 'links/external/form'
+        = render 'links/anchors/form'
 
       .loader.is-inactive{'data-dough-insertmanager-loader' => true}
         .loader__inner

--- a/config/locales/links.yml
+++ b/config/locales/links.yml
@@ -5,6 +5,10 @@ en:
         _destroy: Delete
   links:
     current: 'Current link'
+    anchor:
+      header: Select an anchor
+      placeholder: Select an anchor
+      insert_button: Insert anchor
     external:
       header: 'Add external link'
       insert_button: 'Insert Link'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jshint": "^2.5.5",
     "karma": "^0.12.2",
     "karma-osx-reporter": "*",
+    "karma-spec-reporter": "0.0.13",
     "karma-chai": "^0.1.0",
     "karma-chai-jquery": "^1.0.0",
     "karma-chrome-launcher": "^0.1.2",

--- a/spec/javascripts/fixtures/LinkManager.html
+++ b/spec/javascripts/fixtures/LinkManager.html
@@ -6,10 +6,14 @@
     <button data-dough-tab-selector-trigger="page">Internal Link</button>
     <button data-dough-tab-selector-trigger="external">External Link</button>
     <button data-dough-tab-selector-trigger="file">File</button>
+    <button data-dough-tab-selector-trigger="anchor">Anchor</button>
 
     <input data-dough-insertmanager-insert-type="page" type="text" value="/foo">
     <input data-dough-insertmanager-insert-type="external" type="text" value="http://foo.com">
     <input data-dough-insertmanager-insert-type="file" type="text" value="foo.pdf">
+    <select data-dough-insertmanager-insert-type="anchor">
+      <option>Select an anchor</option>
+    </select>    
 
     <span class="is-inactive" data-dough-insertmanager-label="file"></span>
 
@@ -20,4 +24,9 @@
 
     <div class="loader is-inactive" data-dough-insertmanager-loader></div>
   </div>
+</div>
+<div class="editor__content theme theme--dough" data-dough-component="WordCount" data-dough-maseditor-html-content="" data-dough-wordcount-target="article" data-dough-word-count-initialised="yes" contenteditable="true">
+  <h2 id="h-a">H A</h2>
+  <h3 id="h-b">H B</h3>
+  <h3>H C</h3>
 </div>

--- a/spec/javascripts/karma.conf.js
+++ b/spec/javascripts/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
     preprocessors: {
       '**/*.html': ['html2js']
     },
-    reporters: ['progress', 'osx'],
+    reporters: ['spec', 'progress', 'osx'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_ERROR,

--- a/spec/javascripts/tests/LinkManager_spec.js
+++ b/spec/javascripts/tests/LinkManager_spec.js
@@ -33,6 +33,27 @@ describe('LinkManager', function() {
     this.eventsWithPromises.unsubscribeAll();
   });
 
+  describe('Slugify function', function() {
+    beforeEach(function(done) {
+      this.component = new this.LinkManager(this.$fixture, {
+        tabIds: {
+          'page': 'page',
+          'file': 'file',
+          'external': 'external',
+          'anchor': 'anchor'
+        }
+      });
+      done();
+    });
+
+    it('should return a URL-friendly version of the given string', function() {
+      var str = '  foo%^@£$%!   123-123 ',
+          generatedSlug = this.component._slugify(str);
+
+      expect(generatedSlug).to.equal('foo-123-123');
+    });
+  });
+
   describe('App Events', function() {
     beforeEach(function(done) {
       this.component = new this.LinkManager(this.$fixture, {
@@ -62,7 +83,8 @@ describe('LinkManager', function() {
         tabIds: {
           'page': 'page',
           'file': 'file',
-          'external': 'external'
+          'external': 'external',
+          'anchor': 'anchor'
         }
       });
       done();
@@ -103,6 +125,29 @@ describe('LinkManager', function() {
         expect(spy.calledWith('new')).to.be.true;
       });
     });
-  });
 
+    describe('Populating anchor links', function() {
+      beforeEach(function(done) {
+        this.component.init();        
+        done();
+      });
+
+      it('should call the _populateAnchors function', function() {
+        var spy = sandbox.spy(this.LinkManager.prototype, '_populateAnchors');
+        this.component._setup();
+        expect(spy.called).to.be.true;
+      });
+
+      it('should render additional select options based upon headings in the editable area', function() {
+        this.component._setup();
+        expect($(this.component.config.selectors.anchors).children('option').size()).to.equal(4);
+      });
+
+      it('should generate valid option values for headings without IDs', function() {
+        this.component._setup();
+        $(this.component.config.selectors.anchors).children().eq(3).prop('selected', true);
+        expect($(this.component.config.selectors.anchors)).to.have.value('#h-c');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Provides a new tab within the Insert Manager dialog, to add an anchor to one of the headings on the page.