### PR TITLE
Use public url for comfy if available.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,11 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV['MAS_CMS_URL']
+  config.action_controller.asset_host = if ENV.has_key?('MAS_CMS_PUBLIC_URL')
+                                          ENV['MAS_CMS_PUBLIC_URL']
+                                        else
+                                          ENV['MAS_CMS_URL']
+                                        end
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
In our current environment the same hostname is being used for both internal and external access to the CMS, by resolving the hostname to an internal or external IP depending on where it's being resolved from. To fix this, we need to allow the CMS to have a separate public hostname in the environment config.