### PR TITLE
link inserter uses correct url

### DIFF
--- a/app/models/page_mirror.rb
+++ b/app/models/page_mirror.rb
@@ -26,7 +26,7 @@ class PageMirror
     language_mirror = mirror(language)
     return if language_mirror.blank?
 
-    "/#{language_mirror.site.path}/articles/#{language_mirror.slug}".squeeze('/')
+    language_mirror.fullest_path
   end
 
   def mirror(language)

--- a/spec/models/page_mirror_spec.rb
+++ b/spec/models/page_mirror_spec.rb
@@ -104,17 +104,23 @@ RSpec.describe PageMirror do
 
     context 'when english' do
       let(:language) { :en }
+      let(:expected) do
+        "/en/#{page.layout.identifier.pluralize}/before-borrow-money"
+      end
 
       it 'returns english url' do
-        expect(url).to eq('/en/articles/before-borrow-money')
+        expect(url).to eq(expected)
       end
     end
 
     context 'when welsh' do
       let(:language) { :cy }
+      let(:expected) do
+        "/cy/#{welsh_page.layout.identifier.pluralize}/cyn-i-chi-fenthyca-arian"
+      end
 
       it 'returns welsh url' do
-        expect(url).to eq('/cy/articles/cyn-i-chi-fenthyca-arian')
+        expect(url).to eq(expected)
       end
     end
 


### PR DESCRIPTION
all links inserted were previously hard coded to the page type of
articles. this now corretly looks up the page type for the link