### PR TITLE
redirects with parameters are considered as dupes

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -54,13 +54,15 @@ class Redirect < ActiveRecord::Base
   end
 
   def destination_does_not_match_existing_source
-    if Redirect.where.not(id: self.id).exists?(source: destination)
-      errors.add(:destination, :matches_an_existing_source)
+    if destination.present?
+      if Redirect.where.not(id: self.id).exists?(source: destination.split('?').first)
+        errors.add(:destination, :matches_an_existing_source)
+      end
     end
   end
 
   def source_does_not_match_existing_destination
-    if Redirect.where.not(id: self.id).exists?(destination: source)
+    if Redirect.where.not(id: self.id).exists?(["destination = ? OR destination LIKE ?", source, "#{source}?%"])
       errors.add(:source, :matches_an_existing_destination)
     end
   end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -49,6 +49,44 @@ describe Redirect do
       end
     end
 
+    describe 'chaining with utm parameters' do
+      context 'creating the first part' do
+        let!(:second) do
+          described_class.create!(source: '/en/middle',
+                                  destination: '/en/final',
+                                  redirect_type: 'temporary')
+        end
+
+        subject do
+          described_class.new(source: '/en/origin',
+                              destination: '/en/middle?utma=a',
+                              redirect_type: 'temporary')
+        end
+
+        it 'is invalid' do
+          expect(subject).to_not be_valid
+        end
+      end
+
+      context 'creating the second part' do
+        let!(:first) do
+          described_class.create!(source: '/en/origin',
+                                  destination: '/en/middle?utma=a',
+                                  redirect_type: 'temporary')
+        end
+
+        subject do
+          described_class.new(source: '/en/middle',
+                              destination: '/en/final',
+                              redirect_type: 'temporary')
+        end
+
+        it 'is invalid' do
+          expect(subject).to_not be_valid
+        end
+      end
+    end
+
     describe 'modifying an existing record' do
       it 'does not perform validations against itself' do
         subject.save!


### PR DESCRIPTION
this prevents hops eg.

/en/origin => /en/middle?param=a
/en/middle => /en/final

the above scenario above is not considered valid
as `middle` is considered a duplicate