### PR TITLE
Fix builds with newer Bundler.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ EOT
 
 echo "Cleaning temporary files"
 echo "----"
-rm -rf public/assets vendor/cache coverage log/* tmp/*
+rm -rf public/assets vendor/cache coverage log/* tmp/* .bundle/config
 
 echo "Running Bundle package"
 echo "----"

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,9 @@ export BUNDLE_WITHOUT=development
 CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 BUNDLE_JOBS=$((CORES-1))
 
+# remove prior dirty packaged gems e.g. build.sh
+rm -rf vendor/cache .bundle/config
+
 bundle install --jobs $BUNDLE_JOBS
 npm install
 


### PR DESCRIPTION
Newer versions of bundler create .bundle/config which is taking priority
over env var settings, BUNDLE_WITHOUT in particular. This breaks builds
when test.sh bundles without the "test" group and that state gets
saved. The fix, until Bundle 2 is released, is to rm the config file:
https://github.com/bundler/bundler/issues/3288