### PR TITLE
Bumping mastalk to 0.5.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'clockwork'
 gem 'paper_trail'
 gem 'feature'
 
-gem 'mastalk', '~> 0.5.7'
+gem 'mastalk', '~> 0.5.8'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mastalk (0.5.7)
+    mastalk (0.5.8)
       htmlentities (~> 4.3.2, >= 4.3.2)
       kramdown (~> 1.5.0, >= 1.5.0)
     method_source (0.8.2)
@@ -527,7 +527,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails (~> 5.0)
   legato (= 0.4.0)
-  mastalk (~> 0.5.7)
+  mastalk (~> 0.5.8)
   mysql2
   newrelic_rpm
   oauth2 (= 1.0.0)


### PR DESCRIPTION
Bumping mastalk from version 0.5.7 to 0.5.8, Mastalk-0.5.8 gem pushed to rubygems