### PR TITLE
Add editor

### DIFF
--- a/app/models/comfy/cms/user.rb
+++ b/app/models/comfy/cms/user.rb
@@ -5,7 +5,7 @@ class Comfy::Cms::User < ActiveRecord::Base
 
   validates :role, presence: true
 
-  enum role: { user: 0, admin: 1 }
+  enum role: { user: 0, admin: 1, editor: 2 }
 
   def email_local_part
     email.split('@').first

--- a/features/step_definitions/user_management_steps.rb
+++ b/features/step_definitions/user_management_steps.rb
@@ -46,11 +46,12 @@ Then(/^the new user should not be able to log in$/) do
 end
 
 Given(/^I am not an admin user$/) do
-  @current_user = Comfy::Cms::User.create!(
-    role: Comfy::Cms::User.roles[:user],
-    email: 'test@tester.com',
-    password: 'password'
-  )
+  @current_user = FactoryGirl.create(:user,
+                                     role: Comfy::Cms::User.roles[:user],
+                                     email: 'test@tester.com',
+                                     password: 'password',
+                                     password_confirmation: 'password'
+                                    )
 end
 
 Given(/^I am an editor user$/) do

--- a/features/step_definitions/user_management_steps.rb
+++ b/features/step_definitions/user_management_steps.rb
@@ -53,6 +53,15 @@ Given(/^I am not an admin user$/) do
   )
 end
 
+Given(/^I am an editor user$/) do
+  @current_user = FactoryGirl.create(:user,
+                                     role: Comfy::Cms::User.roles[:editor],
+                                     email: 'test@tester.com',
+                                     password: 'password',
+                                     password_confirmation: 'password'
+                                    )
+end
+
 Then(/^I should not be able to visit the user management page$/) do
   step('I visit the user management page')
   expect(page).to_not have_content('Users')

--- a/features/user_management.feature
+++ b/features/user_management.feature
@@ -23,3 +23,8 @@ Feature: User Management
     When I visit the user management page
     And I go to my profile page
     Then I should be able to see my profile
+
+    Scenario: Editor goes to the user management
+    Given I am an editor user
+    Then I should not be able to visit the user management page
+    

--- a/features/user_management.feature
+++ b/features/user_management.feature
@@ -24,7 +24,6 @@ Feature: User Management
     And I go to my profile page
     Then I should be able to see my profile
 
-    Scenario: Editor goes to the user management
+  Scenario: Editor goes to the user management page
     Given I am an editor user
     Then I should not be able to visit the user management page
-    

--- a/spec/models/comfy/cms/user_spec.rb
+++ b/spec/models/comfy/cms/user_spec.rb
@@ -15,7 +15,7 @@ describe Comfy::Cms::User do
     end
 
     it 'allows the role to be set as an editor' do
-      subject.role = 2
+      subject.role = Comfy::Cms::User.roles[:editor]
       expect(subject.role).to eq('editor')
     end
   end

--- a/spec/models/comfy/cms/user_spec.rb
+++ b/spec/models/comfy/cms/user_spec.rb
@@ -13,6 +13,11 @@ describe Comfy::Cms::User do
       subject.role = Comfy::Cms::User.roles[:admin]
       expect(subject.role).to eq('admin')
     end
+
+    it 'allows the role to be set as an editor' do
+      subject.role = 2
+      expect(subject.role).to eq('editor')
+    end
   end
 
   describe '#email_local_part' do


### PR DESCRIPTION
Using the groundwork laid in PR #300, a new editor role has been added.

The existing behaviour stating only admin users have access to the admin section has not been changed, therefore an editor does not have access to the user management page and only an admin can create a new editor user profile.

![](http://g.recordit.co/QDQmoRA3QO.gif)