### PR TITLE
[DEV APPROVED] Limit editor functionality

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -38,6 +38,11 @@ module PagesHelper
     end
   end
 
+  def display_additional_button_menu?(page, user)
+    return false if user.editor? || page_state_buttons(page).empty?
+    page.publishable?
+  end
+
   private
 
   def preview_domain

--- a/app/views/pages/_footer_bar.html.haml
+++ b/app/views/pages/_footer_bar.html.haml
@@ -27,11 +27,9 @@
             = button_tag state_event[:label], value: state_event[:value], data: state_event[:data], type: 'submit', name: 'state_event', class: "button--action t-#{state_event[:value]}" do
               %span.button__text
                 = state_event[:label]
-            - unless current_user.editor?
-              - unless page_state_buttons(@page).empty?
-                - if @page.publishable?
-                  %span{:data => {:'dough-component' => 'Collapsable', :'dough-collapsable-trigger' => 1, :'dough-collapsable-config' => '{"hideOnBlur": "true"}'}}
-                    %span.button__icon.fa.fa-caret-up
+            - if display_additional_button_menu?(@page, current_user)
+              %span{:data => {:'dough-component' => 'Collapsable', :'dough-collapsable-trigger' => 1, :'dough-collapsable-config' => '{"hideOnBlur": "true"}'}}
+                %span.button__icon.fa.fa-caret-up
 
         - unless current_user.editor?
           .popover.popover--options.popover--top{:data => { :'dough-collapsable-target' => 1 }}

--- a/app/views/pages/_footer_bar.html.haml
+++ b/app/views/pages/_footer_bar.html.haml
@@ -27,17 +27,19 @@
             = button_tag state_event[:label], value: state_event[:value], data: state_event[:data], type: 'submit', name: 'state_event', class: "button--action t-#{state_event[:value]}" do
               %span.button__text
                 = state_event[:label]
-            - unless page_state_buttons(@page).empty?
-              - if @page.publishable?
-                %span{:data => {:'dough-component' => 'Collapsable', :'dough-collapsable-trigger' => 1, :'dough-collapsable-config' => '{"hideOnBlur": "true"}'}}
-                  %span.button__icon.fa.fa-caret-up
+            - unless current_user.editor?
+              - unless page_state_buttons(@page).empty?
+                - if @page.publishable?
+                  %span{:data => {:'dough-component' => 'Collapsable', :'dough-collapsable-trigger' => 1, :'dough-collapsable-config' => '{"hideOnBlur": "true"}'}}
+                    %span.button__icon.fa.fa-caret-up
 
-        .popover.popover--options.popover--top{:data => { :'dough-collapsable-target' => 1 }}
-          .popover__inner
-            .menu
-              .menu__body
-                - page_state_buttons(@page).each do |state_event|
-                  .menu__item
-                    = button_tag state_event[:label], value: state_event[:value], data: state_event[:data], type: 'submit', name: 'state_event', class: "menu__action t-#{state_event[:value]}" do
-                      =state_event[:label]
-          .popover__pointer
+        - unless current_user.editor?
+          .popover.popover--options.popover--top{:data => { :'dough-collapsable-target' => 1 }}
+            .popover__inner
+              .menu
+                .menu__body
+                  - page_state_buttons(@page).each do |state_event|
+                    .menu__item
+                      = button_tag state_event[:label], value: state_event[:value], data: state_event[:data], type: 'submit', name: 'state_event', class: "menu__action t-#{state_event[:value]}" do
+                        =state_event[:label]
+            .popover__pointer

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -9,11 +9,12 @@
         - else
           %h1.l-panel-content__heading
             = "Welcome #{current_user.name}"
-      .l-panel-content__col.l-panel-content__col--right
-        = link_to new_site_page_path(@site), class: 'button--action button--search' do
-          %span.button__text
-            %span.fa.fa-file-o
-            = I18n.t('actions.pages.new')
+      - unless current_user.editor?
+        .l-panel-content__col.l-panel-content__col--right
+          = link_to new_site_page_path(@site), class: 'button--action button--search' do
+            %span.button__text
+              %span.fa.fa-file-o
+              = I18n.t('actions.pages.new')
 
 .l-panel-content.l-panel-content--flush
   .l-constrained

--- a/features/delete_page.feature
+++ b/features/delete_page.feature
@@ -1,0 +1,13 @@
+Feature: Page Delete
+  As a user
+  I want to be able to delete an article
+  So that I can remove content I no longer want website visitors to see
+
+  Scenario: User or Admin user can delete a page
+    When I am working on a Draft Article
+    Then I should be able to delete the article
+
+  Scenario: Editor cannot delete a page
+    Given I am an editor user
+    When I am working on a Draft Article
+    Then I should not be able to delete the article

--- a/features/home_page.feature
+++ b/features/home_page.feature
@@ -6,3 +6,8 @@ Feature: Home page
   Scenario: User sees site listing
     When I visit the home page
     Then I should be in the sites section
+
+  Scenario: Editor does not see link to create a new page
+    Given I am an editor user
+    When I visit the home page
+    Then I should not be able to create a new page

--- a/features/publish.feature
+++ b/features/publish.feature
@@ -10,3 +10,8 @@ Feature: Publish
   Scenario: Publish draft article
     When I am working on a Draft Article
     Then I should be able to publish it
+
+  Scenario: External editor cannot publish an article
+    Given I am an editor user
+    When I am working on a Draft Article
+    Then I should not be able to publish the article

--- a/features/schedule.feature
+++ b/features/schedule.feature
@@ -1,0 +1,14 @@
+Feature: Page schedule
+  As a user
+  I want to be able to schedule an article
+  So that I can publish content at a specific time or date
+
+  Scenario: Admin can schedule an page
+    Given I am an admin user
+    When I am working on a Draft Article
+    Then I should be able to schedule the article
+
+  Scenario: Editor cannot schedule a page
+    Given I am an editor user
+    When I am working on a Draft Article
+    Then I should not be able to schedule the article

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -90,3 +90,23 @@ end
 Given(/^the article is regulated$/) do
   cms_page.update_attributes!(regulated: true)
 end
+
+Then(/^I should be able to delete the article$/) do
+  expect(edit_page).to have_delete_page
+end
+
+Then(/^I should not be able to delete the article$/) do
+  expect(edit_page).not_to have_delete_page
+end
+
+Then(/^I should not be able to publish the article$/) do
+  expect(edit_page).not_to have_publish
+end
+
+Then(/^I should be able to schedule the article$/) do
+  expect(edit_page).to have_schedule
+end
+
+Then(/^I should not be able to schedule the article$/) do
+  expect(edit_page).not_to have_schedule
+end

--- a/features/step_definitions/home_page_steps.rb
+++ b/features/step_definitions/home_page_steps.rb
@@ -6,3 +6,7 @@ end
 Then(/^I should be in the sites section$/) do
   expect(home_page.header.title.text).to match(/site/i)
 end
+
+Then(/^I should not be able to create a new page$/) do
+  expect(home_page).not_to have_content('Create new page')
+end

--- a/features/step_definitions/user_management_steps.rb
+++ b/features/step_definitions/user_management_steps.rb
@@ -54,6 +54,15 @@ Given(/^I am not an admin user$/) do
                                     )
 end
 
+Given(/^I am an admin user$/) do
+  @current_user = FactoryGirl.create(:user,
+                                     role: Comfy::Cms::User.roles[:admin],
+                                     email: 'test@tester.com',
+                                     password: 'password',
+                                     password_confirmation: 'password'
+                                    )
+end
+
 Given(/^I am an editor user$/) do
   @current_user = FactoryGirl.create(:user,
                                      role: Comfy::Cms::User.roles[:editor],

--- a/features/support/ui/pages/edit.rb
+++ b/features/support/ui/pages/edit.rb
@@ -16,6 +16,8 @@ module UI::Pages
     element :publish, 'button[type="submit"][value="publish"]'
     element :publish_changes, 'button[type="submit"][value="publish_changes"]'
     element :save_changes, 'button[type="submit"][value="save_changes_as_draft"]'
+    element :delete_page, '.t-delete_page'
+    element :schedule, '.t-schedule'
     element :category_remove, '.search-choice-close'
     element :category_chosen, '#categories_chosen .chosen-choices'
     elements :categories_selected, '.t-categories-select > option[selected]'

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -60,4 +60,34 @@ describe PagesHelper do
       expect(helper.page_slug(site, presenter, page)).to eq(expected)
     end
   end
+
+  describe '#display_additional_button_menu?' do
+    let(:page) { FactoryGirl.build(:page) }
+    let(:user) { FactoryGirl.build(:user, role: Comfy::Cms::User.roles[:user]) }
+    let(:buttons) { [double] }
+    before { allow(helper).to receive(:page_state_buttons).and_return(buttons) }
+
+    context 'user is an editor' do
+      let(:user) { FactoryGirl.build(:user, role: Comfy::Cms::User.roles[:editor]) }
+
+      it 'returns false if the current user is an editor' do
+        expect(helper.display_additional_button_menu?(page, user)).to be(false)
+      end
+    end
+
+    context 'page is publishable and page_state_buttons is empty' do
+      let(:buttons) { [] }
+      it { expect(helper.display_additional_button_menu?(page, user)).to be(false) }
+    end
+
+    context 'page is publishable and page_state_buttons contains something' do
+      let(:buttons) { [double] }
+      it { expect(helper.display_additional_button_menu?(page, user)).to be(true) }
+    end
+
+    context 'page is not publishable' do
+      before { allow(page).to receive(:publishable?).and_return(false) }
+      it { expect(helper.display_additional_button_menu?(page, user)).to be(false) }
+    end
+  end
 end

--- a/spec/models/page_register_spec.rb
+++ b/spec/models/page_register_spec.rb
@@ -1,0 +1,135 @@
+RSpec.describe PageRegister do
+  let(:user) { FactoryGirl.build(:user) }
+  subject { described_class.new(page, params: params, current_user: user) }
+
+  describe '#save' do
+    before { allow(subject).to receive(:create_revision) }
+
+    describe 'saving the page' do
+      context 'new page record' do
+        let(:page) { FactoryGirl.build(:page) }
+        let(:params) { {} }
+
+        it 'saves the page' do
+          expect(page).to receive(:save!)
+          subject.save
+        end
+
+        it 'creates a revision' do
+          subject.save
+          expect(subject).to have_received(:create_revision)
+        end
+      end
+
+      context 'existing page record with no state_event' do
+        let(:page) { FactoryGirl.create(:page) }
+        let(:params) { {} }
+
+        it 'saves the page' do
+          expect(page).to receive(:save!)
+          subject.save
+        end
+
+        it 'creates a revision' do
+          subject.save
+          expect(subject).to have_received(:create_revision)
+        end
+      end
+
+      context 'existing page record with state_event' do
+        let(:page) { FactoryGirl.create(:page) }
+        let(:params) { { state_event: 'publish' } }
+
+        it 'does not save the page' do
+          expect(page).not_to receive(:save!)
+          subject.save
+        end
+
+        it 'creates a revision' do
+          subject.save
+          expect(subject).to have_received(:create_revision)
+        end
+      end
+    end
+
+    describe 'updating page state' do
+      context 'new page record' do
+        let(:page) { FactoryGirl.build(:page) }
+
+        context 'PageRegister has state_event "save_unsaved"' do
+          let(:params) { { state_event: 'save_unsaved' } }
+
+          it 'updates the state of the page' do
+            expect(page).to receive(:update_state!).with('save_unsaved')
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+
+        context 'PageRegister has state_event which is not "save_unsaved"' do
+          let(:params) { { state_event: 'publish' } }
+
+          it 'does not update the state of the page' do
+            expect(page).not_to receive(:update_state!)
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+      end
+
+      context 'existing page record' do
+        let(:page) { FactoryGirl.create(:page) }
+
+        context 'PageRegister has state_event "save_unsaved"' do
+          let(:params) { { state_event: 'save_unsaved' } }
+
+          it 'updates the state of the page' do
+            expect(page).to receive(:update_state!).with('save_unsaved')
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+
+        context 'PageRegister has state_event which is not "save_unsaved"' do
+          let(:params) { { state_event: 'publish' } }
+
+          it 'updates the state of the page' do
+            expect(page).to receive(:update_state!).with('publish')
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+
+        context 'PageRegister has no state_event' do
+          let(:params) { {} }
+
+          it 'does not update the state of the page' do
+            expect(page).not_to receive(:update_state!)
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/page_register_spec.rb
+++ b/spec/models/page_register_spec.rb
@@ -1,11 +1,81 @@
 RSpec.describe PageRegister do
   let(:user) { FactoryGirl.build(:user) }
+  let(:params) { {} }
   subject { described_class.new(page, params: params, current_user: user) }
 
   describe '#save' do
     before { allow(subject).to receive(:create_revision) }
 
     describe 'saving the page' do
+      context 'user is an editor' do
+        let(:user) do
+          FactoryGirl.build(:user, role: Comfy::Cms::User.roles[:editor])
+        end
+
+        context 'new page' do
+          let(:page) { FactoryGirl.build(:page) }
+
+          it 'allows the object to be saved' do
+            expect { subject.save }.to raise_error(ActiveRecord::RecordInvalid)
+            expect(page.errors.full_messages)
+              .to include('Insufficient permissions to change')
+          end
+        end
+
+        context 'trying to save an "unsaved" existing page' do
+          let(:page) { FactoryGirl.create(:page) }
+          let(:params) { { state_event: 'save_unsaved' } }
+
+          it 'updates the page' do
+            expect(page).to receive(:update_state!)
+            subject.save
+          end
+        end
+
+        context 'trying to save changes to an existing page' do
+          let(:page) { FactoryGirl.create(:page) }
+          let(:params) { { state_event: 'save_changes' } }
+
+          it 'updates the page' do
+            expect(page).to receive(:update_state!)
+            subject.save
+          end
+        end
+
+        context 'trying to publish an existing page' do
+          let(:page) { FactoryGirl.create(:page) }
+          let(:params) { { state_event: 'publish' } }
+
+          it 'does not allow the object to be saved' do
+            expect { subject.save }.to raise_error(ActiveRecord::RecordInvalid)
+            expect(page.errors.full_messages)
+              .to include('Insufficient permissions to change')
+          end
+        end
+
+        context 'trying to unpublish an existing page' do
+          let(:page) { FactoryGirl.create(:page) }
+          let(:params) { { state_event: 'unpublish' } }
+
+          it 'does not allow the object to be saved' do
+            expect { subject.save }.to raise_error(ActiveRecord::RecordInvalid)
+            expect(page.errors.full_messages)
+              .to include('Insufficient permissions to change')
+          end
+        end
+
+        context 'trying to schedule an existing page' do
+          let(:page) { FactoryGirl.create(:page) }
+          let(:params) { { state_event: 'schedule' } }
+
+          it 'does not allow the object to be saved' do
+            expect { subject.save }.to raise_error(ActiveRecord::RecordInvalid)
+            expect(page.errors.full_messages)
+              .to include('Insufficient permissions to change')
+          end
+        end
+      end
+
       context 'new page record' do
         let(:page) { FactoryGirl.build(:page) }
         let(:params) { {} }


### PR DESCRIPTION
Previously we introduced the notion of an 'Editor' role into the cms. This PR is a continuation of that work to enforce the permitted abilities for an Editor.
 
* Removes ability to create a new page if current user is an editor
* Removes ability to schedule, publish, unpublish if current user is an editor
* Updated `PageRegister#save` to restrict editor capability.

#### Admin (existing behaviour):
![](http://g.recordit.co/y3zoCVj9Fd.gif)

#### Editor (new behaviour):
![](http://g.recordit.co/aLC3uxaxUl.gif)