### PR TITLE
[DEV APPROVED] Editors changing content should trigger a notification email

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,4 @@ RACKSPACE_API_KEY='key'
 MAS_CMS_URL="http://localhost:3000/"
 FARADAY_HOST='localhost:5000'
 FARADAY_X_FORWARDED_PROTO='http'
+MAILJET_DEFAULT_FROM_ADDRESS=notmonitored@notify.moneyadviceservice.org.uk

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'paper_trail'
 gem 'feature'
 
 gem 'mastalk', '~> 0.5.8'
+gem 'mailjet'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    domain_name (0.5.20160128)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
       dotenv (= 1.0.2)
@@ -300,6 +302,8 @@ GEM
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
     htmlentities (4.3.4)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.6.11)
     inflecto (0.0.2)
     ipaddress (0.8.0)
@@ -325,6 +329,10 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    mailjet (1.3.1)
+      activesupport (>= 3.1.0)
+      rack (>= 1.4.0)
+      rest-client
     mastalk (0.5.8)
       htmlentities (~> 4.3.2, >= 4.3.2)
       kramdown (~> 1.5.0, >= 1.5.0)
@@ -341,6 +349,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
+    netrc (0.11.0)
     newrelic_rpm (3.12.1.298)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
@@ -408,6 +417,10 @@ GEM
     remotipart (1.2.1)
     responders (1.1.1)
       railties (>= 3.2, < 4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     retriable (1.4.1)
     reverse_markdown (0.6.0)
       nokogiri
@@ -493,6 +506,9 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -539,6 +555,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails (~> 5.0)
   legato (= 0.4.0)
+  mailjet
   mastalk (~> 0.5.8)
   mysql2
   newrelic_rpm

--- a/app/mailers/revision_mailer.rb
+++ b/app/mailers/revision_mailer.rb
@@ -1,0 +1,12 @@
+class RevisionMailer < ActionMailer::Base
+  TO_ADDRESS = 'welsh.editors@moneyadviceservice.org.uk'
+  SUBJECT    = 'Content updated by External Editor'
+
+  default from: ENV['MAILJET_DEFAULT_FROM_ADDRESS']
+
+  def external_editor_change(user:, page:)
+    @page = page
+    @user = user
+    mail(to: TO_ADDRESS, subject: SUBJECT)
+  end
+end

--- a/app/models/page_register.rb
+++ b/app/models/page_register.rb
@@ -16,6 +16,7 @@ class PageRegister
     update_state_if_new_page
     update_state_or_save_existing_page
     create_revision
+    send_change_notfication
   end
 
   def create_revision
@@ -46,6 +47,12 @@ class PageRegister
   end
 
   private
+
+  def send_change_notfication
+    return unless @current_user.editor?
+    RevisionMailer.external_editor_change(user: @current_user, page: @page)
+                  .deliver
+  end
 
   def update_state
     @page.update_state!(state_event)

--- a/app/views/revision_mailer/external_editor_change.html.erb
+++ b/app/views/revision_mailer/external_editor_change.html.erb
@@ -1,0 +1,5 @@
+<p>
+  The external editor <%= @user.name %> has made changes to the page
+  <%= link_to @page.meta_title,
+              edit_comfy_admin_cms_site_page_url(@page, site_id: @page.site_id) %>
+</p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,4 +85,10 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.delivery_method = :mailjet
+
+  config.action_mailer.default_url_options = {
+    host: 'comfy.moneyadviceservice.org.uk'
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,4 +37,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.action_mailer.default_url_options = {
+    host: 'mas.example.com'
+  }
 end

--- a/config/initializers/mailjet.rb
+++ b/config/initializers/mailjet.rb
@@ -1,0 +1,5 @@
+Mailjet.configure do |config|
+ config.api_key = ENV['MAILJET_API_KEY']
+ config.secret_key = ENV['MAILJET_SECRET_KEY']
+ config.default_from = ENV['MAILJET_DEFAULT_FROM_ADDRESS']
+end

--- a/features/email_notification.feature
+++ b/features/email_notification.feature
@@ -1,0 +1,19 @@
+Feature: Email Notification
+
+Scenario: External Editor updates a page
+  Given I am an editor user
+  And I am working on a Draft Article
+  When I save changes to the page
+  Then an email notification should be sent
+
+Scenario: User updates a page
+  Given I am not an admin user
+  And I am working on a Draft Article
+  When I save changes to the page
+  Then no email notifications are sent
+
+Scenario: Admin updates a page
+  Given I am an admin user
+  And I am working on a Draft Article
+  When I save changes to the page
+  Then no email notifications are sent

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -45,6 +45,10 @@ When(/^I publish the article$/) do
   edit_page.publish.click
 end
 
+When(/^I save changes to the page$/) do
+  edit_page.save_changes_button.click
+end
+
 Then(/^I should be able to publish it$/) do
   edit_page.should have_publish
   edit_page.publish.click
@@ -109,4 +113,12 @@ end
 
 Then(/^I should not be able to schedule the article$/) do
   expect(edit_page).not_to have_schedule
+end
+
+Then(/^an email notification should be sent$/) do
+  expect(ActionMailer::Base.deliveries.last.subject).to include('Content updated by External Editor')
+end
+
+Then(/^no email notifications are sent$/) do
+  expect(ActionMailer::Base.deliveries).to be_empty
 end

--- a/features/support/ui/pages/edit.rb
+++ b/features/support/ui/pages/edit.rb
@@ -18,6 +18,7 @@ module UI::Pages
     element :save_changes, 'button[type="submit"][value="save_changes_as_draft"]'
     element :delete_page, '.t-delete_page'
     element :schedule, '.t-schedule'
+    element :save_changes_button, '.t-save_changes'
     element :category_remove, '.search-choice-close'
     element :category_chosen, '#categories_chosen .chosen-choices'
     elements :categories_selected, '.t-categories-select > option[selected]'

--- a/spec/mailers/revision_mailer_spec.rb
+++ b/spec/mailers/revision_mailer_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe RevisionMailer, type: :mailer do
+  let(:user) { FactoryGirl.build(:user, name: 'Mr. Ed Itor') }
+  let(:page) { FactoryGirl.create(:page, meta_title: 'How to save 50p a day.') }
+
+  describe '#external_editor_change' do
+    let(:email) { described_class.external_editor_change(user: user, page: page) }
+
+    it 'sets the email "from"' do
+      expect(email.from).to eq(['notmonitored@notify.moneyadviceservice.org.uk'])
+    end
+
+    it 'sets the email "subject"' do
+      expect(email.subject).to eq('Content updated by External Editor')
+    end
+
+    it 'sets the email recipient' do
+      expect(email.to.length).to eq(1)
+      expect(email.to).to include('welsh.editors@moneyadviceservice.org.uk')
+    end
+
+    it "includes the editor's name in the body" do
+      expect(email.body).to include('Mr. Ed Itor')
+    end
+
+    it 'includes the page title in the body' do
+      expect(email.body).to include('How to save 50p a day.')
+    end
+
+    it 'includes a link to the page' do
+      url = "http://mas.example.com/admin/sites/#{page.site_id}/pages/#{page.id}/edit"
+      expect(email.body).to include(url)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds functionality for a notification email to be triggered whenever a user with an 'editor' role saves changes to content. We've added mailjet and reuse existing env vars from scripts. 