### PR TITLE
[DEV APPROVED] Stop "Collapsable" componentName warning

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SearchBar.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/SearchBar.js
@@ -32,7 +32,10 @@ define([
   SearchBarProto.init = function(initialised) {
     this._cacheComponentElements();
     this._setupAppEvents();
+
+    Collapsable.componentName = 'SearchBar';
     this.collapsable = new Collapsable(this.$el).init();
+
     this._initialisedSuccess(initialised);
   };
 


### PR DESCRIPTION
When browsing the application or running the cucumber tests, there is a warning:

```bash
"Collapsable" componentName was not found in the data-dough-component attribute
```

The reason this is occurring is that there is a component called `SearchBar`, which internally uses the `Collapsable` component.

To set up a dough component, there is typically an attribute on an HTML element like:

```html
<div data-dough-component="SearchBar">...</div>
```

However, when the Collapsable component is initialised within another component, it looks at the same HTML element's `data-dough-component` attribute to do a name check to make sure it's loading correctly. The check fails as it is effectively trying to match `"SearchBar"` to `"Collapsable"`. This change overrides the standard name for the collapsable component to avoid this error from appearing.



