### PR TITLE
Add home page seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,3 +48,7 @@ end
 
 puts "Seeding MAS users..."
 Comfy::Cms::User.create_with(password: 'password', role: 'admin').find_or_create_by!(email: 'user@test.com')
+
+puts 'Adding home page...'
+Cms::LayoutBuilder.add_home_page!
+Cms::PageBuilder.add_home_page!

--- a/lib/cms/layout_builder.rb
+++ b/lib/cms/layout_builder.rb
@@ -1,0 +1,83 @@
+module Cms
+  class LayoutBuilder
+    def self.add_home_page!
+      Comfy::Cms::Layout.create!(
+        site: english_site,
+        label: 'Home Page',
+        identifier: 'home_page',
+        content: home_page_content
+      )
+
+      welsh_layout = welsh_site.layouts.find_by(identifier: 'home_page')
+      welsh_layout.update_attributes!(content: home_page_content)
+    end
+
+    def self.english_site
+      Comfy::Cms::Site.find_by(label: 'en')
+    end
+
+    def self.welsh_site
+      Comfy::Cms::Site.find_by(label: 'cy')
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def self.home_page_content
+      <<-CONTENT
+        {{ cms:page:raw_heading:string }}
+        {{ cms:page:raw_hero_image:image }}
+        {{ cms:page:raw_bullet_1:string }}
+        {{ cms:page:raw_bullet_2:string }}
+        {{ cms:page:raw_bullet_3:string }}
+        {{ cms:page:raw_cta_text:string }}
+        {{ cms:page:raw_cta_link:string }}
+
+        {{ cms:field:raw_tool_1_heading }}
+        {{ cms:field:raw_tool_1_url }}
+        {{ cms:page:raw_tool_1_text }}
+
+        {{ cms:field:raw_tool_2_heading }}
+        {{ cms:field:raw_tool_2_url }}
+        {{ cms:page:raw_tool_2_text }}
+
+        {{ cms:field:raw_tool_3_heading }}
+        {{ cms:field:raw_tool_3_url }}
+        {{ cms:page:raw_tool_3_text }}
+
+        {{ cms:field:raw_tile_1_heading }}
+        {{ cms:page:raw_tile_1_image:image }}
+        {{ cms:field:raw_tile_1_url }}
+        {{ cms:field:raw_tile_1_label }}
+        {{ cms:page:raw_tile_1_content }}
+
+        {{ cms:field:raw_tile_2_heading }}
+        {{ cms:page:raw_tile_2_image:image }}
+        {{ cms:field:raw_tile_2_url }}
+        {{ cms:field:raw_tile_2_label }}
+        {{ cms:page:raw_tile_2_content }}
+
+        {{ cms:field:raw_tile_3_heading }}
+        {{ cms:page:raw_tile_3_image:image }}
+        {{ cms:field:raw_tile_3_url }}
+        {{ cms:field:raw_tile_3_label }}
+        {{ cms:page:raw_tile_3_content }}
+
+        {{ cms:field:raw_tile_4_heading }}
+        {{ cms:page:raw_tile_4_image:image }}
+        {{ cms:field:raw_tile_4_url }}
+        {{ cms:field:raw_tile_4_label }}
+        {{ cms:page:raw_tile_4_content }}
+
+        {{ cms:field:raw_text_tile_1_heading }}
+        {{ cms:field:raw_text_tile_1_url }}
+        {{ cms:page:raw_text_tile_1_content }}
+
+        {{ cms:field:raw_text_tile_2_heading }}
+        {{ cms:field:raw_text_tile_2_url }}
+        {{ cms:page:raw_text_tile_2_content }}
+
+        {{ cms:field:raw_promo_banner_content }}
+        {{ cms:field:raw_promo_banner_url }}
+      CONTENT
+    end
+  end
+end

--- a/lib/cms/page_builder.rb
+++ b/lib/cms/page_builder.rb
@@ -1,0 +1,18 @@
+module Cms
+  class PageBuilder
+    def self.add_home_page!
+      site   = Comfy::Cms::Site.find_by(label: 'en')
+      layout = site.layouts.find_by(identifier: 'home_page')
+
+      page = Comfy::Cms::Page.create!(slug: 'the-money-advice-service', site: site, layout: layout)
+
+      content_areas = layout.content.scan(/{{\s*\w+\:\w+\:(\w+)/).map(&:first)
+      content_areas.each do |content_area|
+        page.blocks.create!(identifier: content_area, content: '')
+      end
+
+      page.save_unsaved!
+      page.publish!
+    end
+  end
+end

--- a/spec/lib/cms/layout_builder_spec.rb
+++ b/spec/lib/cms/layout_builder_spec.rb
@@ -1,0 +1,92 @@
+RSpec.describe Cms::LayoutBuilder do
+  let!(:english_site) { create(:site, is_mirrored: true) }
+  let!(:welsh_site)   { create(:site, :welsh, is_mirrored: true) }
+
+  describe '.add_home_page!' do
+    before { Cms::LayoutBuilder.add_home_page! }
+
+    context 'English site' do
+      let(:layout) { english_site.layouts.reload.first }
+
+      it 'creates a layout for the English site' do
+        expect(english_site.layouts.count).to eq(1)
+      end
+
+      it 'sets the label for the layout to be "Home Page"' do
+        expect(layout.label).to eq('Home Page')
+      end
+
+      it 'sets the label for the layout to be "Home Page"' do
+        expect(layout.identifier).to eq('home_page')
+      end
+
+      it 'defines the content areas for the home page layout' do
+        expect(layout.content).to include('{{ cms:page:raw_heading:string }}')
+        expect(layout.content).to include('{{ cms:page:raw_hero_image:image }}')
+        expect(layout.content).to include('{{ cms:page:raw_bullet_1:string }}')
+        expect(layout.content).to include('{{ cms:page:raw_bullet_2:string }}')
+        expect(layout.content).to include('{{ cms:page:raw_bullet_3:string }}')
+        expect(layout.content).to include('{{ cms:page:raw_cta_text:string }}')
+        expect(layout.content).to include('{{ cms:page:raw_cta_link:string }}')
+        expect(layout.content).to include('{{ cms:field:raw_tool_1_heading }}')
+        expect(layout.content).to include('{{ cms:field:raw_tool_1_url }}')
+        expect(layout.content).to include('{{ cms:page:raw_tool_1_text }}')
+        expect(layout.content).to include('{{ cms:field:raw_tool_2_heading }}')
+        expect(layout.content).to include('{{ cms:field:raw_tool_2_url }}')
+        expect(layout.content).to include('{{ cms:page:raw_tool_2_text }}')
+        expect(layout.content).to include('{{ cms:field:raw_tool_3_heading }}')
+        expect(layout.content).to include('{{ cms:field:raw_tool_3_url }}')
+        expect(layout.content).to include('{{ cms:page:raw_tool_3_text }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_1_heading }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_1_image:image }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_1_url }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_1_label }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_1_content }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_2_heading }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_2_image:image }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_2_url }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_2_label }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_2_content }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_3_heading }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_3_image:image }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_3_url }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_3_label }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_3_content }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_4_heading }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_4_image:image }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_4_url }}')
+        expect(layout.content).to include('{{ cms:field:raw_tile_4_label }}')
+        expect(layout.content).to include('{{ cms:page:raw_tile_4_content }}')
+        expect(layout.content).to include('{{ cms:field:raw_text_tile_1_heading }}')
+        expect(layout.content).to include('{{ cms:field:raw_text_tile_1_url }}')
+        expect(layout.content).to include('{{ cms:page:raw_text_tile_1_content }}')
+        expect(layout.content).to include('{{ cms:field:raw_text_tile_2_heading }}')
+        expect(layout.content).to include('{{ cms:field:raw_text_tile_2_url }}')
+        expect(layout.content).to include('{{ cms:page:raw_text_tile_2_content }}')
+        expect(layout.content).to include('{{ cms:field:raw_promo_banner_content }}')
+        expect(layout.content).to include('{{ cms:field:raw_promo_banner_url }}')
+      end
+    end
+
+    context 'Welsh site' do
+      let(:layout) { welsh_site.layouts.reload.first }
+
+      it 'creates a layout for the Welsh site' do
+        expect(welsh_site.layouts.count).to eq(1)
+      end
+
+      it 'sets the label for the layout to be "Home Page"' do
+        expect(layout.label).to eq('Home Page')
+      end
+
+      it 'sets the label for the layout to be "Home Page"' do
+        expect(layout.identifier).to eq('home_page')
+      end
+
+      it 'uses the same content areas as the english layout' do
+        english_layout = english_site.layouts.reload.first
+        expect(layout.content).to eq(english_layout.content)
+      end
+    end
+  end
+end

--- a/spec/lib/cms/page_builder_spec.rb
+++ b/spec/lib/cms/page_builder_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Cms::PageBuilder do
+  let!(:site)   { create(:site) }
+  let!(:layout) { create(:layout, identifier: 'home_page', site: site) }
+
+  describe '.add_home_page!' do
+    let(:page) { Comfy::Cms::Page.first }
+
+    before { Cms::PageBuilder.add_home_page! }
+
+    it 'adds a page' do
+      expect(Comfy::Cms::Page.count).to eq(1)
+    end
+
+    it 'adds a page using the "home_page" layout' do
+      expect(page.layout).to eq(layout)
+    end
+
+    it 'adds the page to the english site' do
+      expect(page.site).to eq(site)
+    end
+
+    it 'sets the slug to be "the-money-advice-service"' do
+      expect(page.slug).to eq('the-money-advice-service')
+    end
+
+    it "generates blank 'blocks' for each of the layout's content areas" do
+      expect(page.blocks.count).to eq(3)
+    end
+
+    it 'publishes the home_page' do
+      expect(page).to be_published
+    end
+  end
+end


### PR DESCRIPTION
We've been looking at adding the ability to edit additional content on the frontend website. In the process of this, we had to run frontend locally against CMS locally. During this process, we encountered an issue where we were unable to load the website as there was no "Home Page" within contento.

Upon further investigation, we realised that in order for the frontpage of frontend to render, we needed to create a 'home_page' layout, and create a `Page` within contento with the slug 'the-money-advice-service', which uses this layout.

This PR adds to `seeds.rb` an additional snippet to generate the 'home_page' layout, and a very basic published homepage.

We were struggling with coming up with good names for the classes we've wrapped the behaviour in, also if anyone has any suggestions on how to better structure the code, that would be awesome!
