### PR TITLE
editors should be able to create drafts from an existing published page

### DIFF
--- a/app/models/page_register.rb
+++ b/app/models/page_register.rb
@@ -74,7 +74,7 @@ class PageRegister
   end
 
   def editor_can_perform_event?
-    %w(save_changes save_unsaved).include? state_event
+    %w(save_changes save_unsaved save_draft_changes).include? state_event
   end
 
   def update_state_if_new_page

--- a/spec/models/page_register_spec.rb
+++ b/spec/models/page_register_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe PageRegister do
           end
         end
 
+        context 'trying to save changes to an existing PUBLISHED page' do
+          let(:page) { FactoryGirl.create(:page) }
+          let(:params) { { state_event: 'save_draft_changes' } }
+
+          it 'updates the page' do
+            expect(page).to receive(:update_state!)
+            subject.save
+          end
+        end
+
         context 'trying to publish an existing page' do
           let(:page) { FactoryGirl.create(:page) }
           let(:params) { { state_event: 'publish' } }
@@ -200,6 +210,53 @@ RSpec.describe PageRegister do
           end
         end
       end
+
+      context 'existing PUBLISHED page record' do
+        let(:page) { FactoryGirl.create(:page) }
+
+        context 'PageRegister has state_event "save_unsaved"' do
+          let(:params) { { state_event: 'save_draft_changes' } }
+
+          it 'updates the state of the page' do
+            expect(page).to receive(:update_state!).with('save_draft_changes')
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+
+        context 'PageRegister has state_event which is not "save_draft_changes"' do
+          let(:params) { { state_event: 'publish' } }
+
+          it 'updates the state of the page' do
+            expect(page).to receive(:update_state!).with('publish')
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+
+        context 'PageRegister has no state_event' do
+          let(:params) { {} }
+
+          it 'does not update the state of the page' do
+            expect(page).not_to receive(:update_state!)
+            subject.save
+          end
+
+          it 'creates a revision' do
+            subject.save
+            expect(subject).to have_received(:create_revision)
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Users with an editor role, are able to make changes to pages, but not publish them.

We discovered whilst looking at QA test data, that we had missed one of the possible events (when a editor makes a draft version of an already published page).

This small PR addresses this issue.