### PR TITLE
Force an article to exist before creating a homepage

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,6 +49,12 @@ end
 puts "Seeding MAS users..."
 Comfy::Cms::User.create_with(password: 'password', role: 'admin').find_or_create_by!(email: 'user@test.com')
 
+puts 'Creating an example article'
+# If we don't do this, we end up in a weird state where because the home_page has
+# been created first, then Comfy decides the default layout for future pages should
+# also be home_page.
+Cms::PageBuilder.add_example_article!
+
 puts 'Adding home page...'
 Cms::LayoutBuilder.add_home_page!
 Cms::PageBuilder.add_home_page!

--- a/lib/cms/page_builder.rb
+++ b/lib/cms/page_builder.rb
@@ -1,5 +1,11 @@
 module Cms
   class PageBuilder
+    def self.add_example_article!
+      site   = Comfy::Cms::Site.find_by(label: 'en')
+      layout = site.layouts.find_by(identifier: 'article')
+      Comfy::Cms::Page.create!(slug: 'example-article', site: site, layout: layout)
+    end
+
     def self.add_home_page!
       site   = Comfy::Cms::Site.find_by(label: 'en')
       layout = site.layouts.find_by(identifier: 'home_page')

--- a/spec/lib/cms/page_builder_spec.rb
+++ b/spec/lib/cms/page_builder_spec.rb
@@ -1,6 +1,19 @@
 RSpec.describe Cms::PageBuilder do
   let!(:site)   { create(:site) }
-  let!(:layout) { create(:layout, identifier: 'home_page', site: site) }
+  let!(:article_layout) { create(:layout, identifier: 'article', site: site) }
+  let!(:home_page_layout) { create(:layout, identifier: 'home_page', site: site) }
+
+  describe '.add_example_article!' do
+    before { Cms::PageBuilder.add_example_article! }
+
+    it 'adds a page' do
+      expect(Comfy::Cms::Page.count).to eq(1)
+    end
+
+    it 'adds a page using the "article" layout' do
+      expect(Comfy::Cms::Page.first.layout).to eq(article_layout)
+    end
+  end
 
   describe '.add_home_page!' do
     let(:page) { Comfy::Cms::Page.first }
@@ -12,7 +25,7 @@ RSpec.describe Cms::PageBuilder do
     end
 
     it 'adds a page using the "home_page" layout' do
-      expect(page.layout).to eq(layout)
+      expect(page.layout).to eq(home_page_layout)
     end
 
     it 'adds the page to the english site' do


### PR DESCRIPTION
Now that we've updated the seeds.rb to generate a homepage, we've discovered an unexpected side effect...

Comfy weirdly defaults to the first layout used, which means if you've seeded a db from scratch, it now decides that the home_page layout should be the default, see gif:

![](http://g.recordit.co/fjM8TAUHUI.gif)

This behaviour *only* happens when seeding a database from scratch.

This PR adds an example article into the database before adding the homepage, so it mimics the behaviour you would expect to see locally, or on a server with existing data like QA.

![](http://g.recordit.co/lzkLUWZt9z.gif)