### PR TITLE
Use label instead of meta_title, as latter is not guaranteed to exist

### DIFF
--- a/app/views/revision_mailer/external_editor_change.html.erb
+++ b/app/views/revision_mailer/external_editor_change.html.erb
@@ -1,5 +1,5 @@
 <p>
   The external editor <%= @user.name %> has made changes to the page
-  <%= link_to @page.meta_title,
+  <%= link_to @page.label,
               edit_comfy_admin_cms_site_page_url(@page, site_id: @page.site_id) %>
 </p>

--- a/spec/mailers/revision_mailer_spec.rb
+++ b/spec/mailers/revision_mailer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe RevisionMailer, type: :mailer do
   let(:user) { FactoryGirl.build(:user, name: 'Mr. Ed Itor') }
-  let(:page) { FactoryGirl.create(:page, meta_title: 'How to save 50p a day.') }
+  let(:page) { FactoryGirl.create(:page, label: 'How to save 50p a day.') }
 
   describe '#external_editor_change' do
     let(:email) { described_class.external_editor_change(user: user, page: page) }


### PR DESCRIPTION
Small PR. Switch email to use @page.label instead of @page.meta_title.

When an external editor saved changes to an English page, a link to the page was sent via email, however if changes were made to a Welsh page the link was not visible in the email as meta titles are not automatically copied across. Labels will always exist in both pages, so the label is a more appropriate attribute to use for the link in the email.
