### PR TITLE
Editors can ALSO save_changes_as_draft

### DIFF
--- a/app/models/page_register.rb
+++ b/app/models/page_register.rb
@@ -74,7 +74,7 @@ class PageRegister
   end
 
   def editor_can_perform_event?
-    %w(save_changes save_unsaved save_draft_changes).include? state_event
+    %w(save_changes save_unsaved save_draft_changes save_changes_as_draft).include? state_event
   end
 
   def update_state_if_new_page

--- a/app/models/page_register.rb
+++ b/app/models/page_register.rb
@@ -2,6 +2,8 @@ class PageRegister
   attr_reader :page, :params, :current_user, :state_was
   delegate :new_record?, :persisted?, :save!, to: :page
 
+  ALLOWED_EDITOR_STATES = %w(save_changes save_unsaved save_draft_changes save_changes_as_draft)
+
   def initialize(page, params: params, current_user: current_user)
     @page                  = page
     @params                = params
@@ -74,7 +76,7 @@ class PageRegister
   end
 
   def editor_can_perform_event?
-    %w(save_changes save_unsaved save_draft_changes save_changes_as_draft).include? state_event
+    ALLOWED_EDITOR_STATES.include? state_event
   end
 
   def update_state_if_new_page

--- a/spec/models/page_register_spec.rb
+++ b/spec/models/page_register_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe PageRegister do
           end
         end
 
+        context 'trying to save changes as draft' do
+          let(:page) { FactoryGirl.create(:page) }
+          let(:params) { { state_event: 'save_changes_as_draft' } }
+
+          it 'updates the page' do
+            expect(page).to receive(:update_state!)
+            subject.save
+          end
+        end
+
         context 'trying to publish an existing page' do
           let(:page) { FactoryGirl.create(:page) }
           let(:params) { { state_event: 'publish' } }


### PR DESCRIPTION
There is an additional state where an Editor making changes to a page, should be able to save changes as a new draft.

To recap why we have 4 states here now:

* save_unsaved – Saving a new page which has been generated automatically, but no content exists.
* save_changes – We have a saved page which is unpublished, and changes are being saved
* save_changes_as_draft – There is a published page, and the user is saving a draft page.
* save_draft_changes – After creating a draft from a published page, the user can then save further changes to that draft.