### PR TITLE
editors are allowed to alter scheduled pages

### DIFF
--- a/app/models/page_register.rb
+++ b/app/models/page_register.rb
@@ -2,7 +2,7 @@ class PageRegister
   attr_reader :page, :params, :current_user, :state_was
   delegate :new_record?, :persisted?, :save!, to: :page
 
-  ALLOWED_EDITOR_STATES = %w(save_changes save_unsaved save_draft_changes save_changes_as_draft)
+  ALLOWED_EDITOR_STATE_EVENTS = %w(save_changes save_unsaved save_draft_changes save_changes_as_draft schedule)
 
   def initialize(page, params: params, current_user: current_user)
     @page                  = page
@@ -76,7 +76,7 @@ class PageRegister
   end
 
   def editor_can_perform_event?
-    ALLOWED_EDITOR_STATES.include? state_event
+    ALLOWED_EDITOR_STATE_EVENTS.include? state_event
   end
 
   def update_state_if_new_page

--- a/spec/models/page_register_spec.rb
+++ b/spec/models/page_register_spec.rb
@@ -88,10 +88,9 @@ RSpec.describe PageRegister do
           let(:page) { FactoryGirl.create(:page) }
           let(:params) { { state_event: 'schedule' } }
 
-          it 'does not allow the object to be saved' do
-            expect { subject.save }.to raise_error(ActiveRecord::RecordInvalid)
-            expect(page.errors.full_messages)
-              .to include('Insufficient permissions to change')
+          it 'updates the page' do
+            expect(page).to receive(:update_state!)
+            subject.save
           end
         end
       end


### PR DESCRIPTION
Currently, editors are only able to save pages which are not published or scheduled. This change enables editors to save changes to pages that are already scheduled. 