### PR TITLE
[DEV APPROVED] Bumping mastalk to 0.5.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'clockwork'
 gem 'paper_trail'
 gem 'feature'
 
-gem 'mastalk', '~> 0.5.8'
+gem 'mastalk', '~> 0.5.9'
 gem 'mailjet'
 gem 'paperclip-azure', '~> 0.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mastalk (0.5.8)
+    mastalk (0.5.9)
       htmlentities (~> 4.3.2, >= 4.3.2)
       kramdown (~> 1.5.0, >= 1.5.0)
     method_source (0.8.2)
@@ -582,7 +582,7 @@ DEPENDENCIES
   launchy
   legato (= 0.4.0)
   mailjet
-  mastalk (~> 0.5.8)
+  mastalk (~> 0.5.9)
   mysql2
   newrelic_rpm
   oauth2 (= 1.0.0)


### PR DESCRIPTION
## Bumping mastalk gem to 0.5.9

- Updated mastalk gem contains Azure CDN URL for cost calculator snippet (PR:https://github.com/moneyadviceservice/mastalk/pull/17)
- Mastalk 0.5.9 uploaded to rubygems
- Version already bumped in mastalk (PR:https://github.com/moneyadviceservice/mastalk/pull/18)