### PR TITLE
7222 fixes to scheduling functionality

### DIFF
--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -22,21 +22,17 @@ class BlockSerializer < ActiveModel::Serializer
   end
 
   def block_content
-    if identifier.start_with?('raw_')
-      object.content
-    else
-      # If we're previewing, we want to recognise when a live article
-      # has a draft new version in progress.
-      if scope == 'preview'
-        if alternate_blocks_retriever.blocks_attributes.present?
-          alternate_blocks_retriever.block_content(:content)
-        else
-          blocks_retriever.block_content(:content)
-        end
-
+    # If we're previewing, we want to recognise when a live article
+    # has a draft new version in progress.
+    if scope == 'preview'
+      if alternate_blocks_retriever.blocks_attributes.present?
+        alternate_blocks_retriever.block_content(identifier)
       else
-        blocks_retriever.block_content(:content) if blocks_retriever.live?
+        blocks_retriever.block_content(identifier)
       end
+
+    else
+      blocks_retriever.block_content(identifier) if blocks_retriever.live?
     end
   end
 

--- a/app/views/pages/_form.html.haml
+++ b/app/views/pages/_form.html.haml
@@ -3,11 +3,14 @@
     = render 'comfy/admin/cms/sites/mirrors', object: @page
 
 %div{data:{dough_component: 'StickyElements'}}
+  - data_attributes = { dough_scheduler_form: true }
+  - data_attributes[:dough_component] = 'MASEditor' if @blocks_attributes && @blocks_attributes.any? { |block| block[:identifier] == 'content' }
+
   = form_for @page, as: :page,
                     url: form_url,
                     class: 'form',
                     html: { multipart: true, autocomplete: 'off'},
-                    data: { dough_component: 'MASEditor', dough_scheduler_form: true } do |form|
+                    data: data_attributes do |form|
 
     - if params[:alternate]
       = hidden_field :alternate, true, id: 'js-alternate'

--- a/lib/cms/form_builder.rb
+++ b/lib/cms/form_builder.rb
@@ -38,9 +38,14 @@ class Cms::FormBuilder < ComfortableMexicanSofa::FormBuilder
   label       = tag.blockable.class.human_attribute_name(tag.identifier.to_s)
   css_class   = tag.class.to_s.demodulize.underscore
   content     = ''
+
+  # ACHTUNG, HACKY! - looks for the instance variable @blocks_attributes in the view to retrieve the current content
+  blocks_attributes = @template.instance_variable_get('@blocks_attributes')
+  current_value = blocks_attributes.find { |block_attributes| block_attributes[:identifier] == tag.identifier.to_s }[:content]
+
   case method
   when :file_field_tag
-    input_params = {:id => nil}
+    input_params = {:id => nil, value: current_value}
     name = "blocks_attributes[#{index}][content]"
 
     if options.delete(:multiple)
@@ -51,8 +56,8 @@ class Cms::FormBuilder < ComfortableMexicanSofa::FormBuilder
     content << @template.send(method, name, input_params)
     content << @template.render(:partial => 'comfy/admin/cms/files/page_form', :object => tag.block)
   else
-    options[:class] = ' form-control'
-    content << @template.send(method, "blocks_attributes[#{index}][content]", tag.content, options)
+    options[:class] = 'form-control'
+    content << @template.send(method, "blocks_attributes[#{index}][content]", current_value, options)
   end
   content << @template.hidden_field_tag("blocks_attributes[#{index}][identifier]", tag.identifier, :id => nil)
 

--- a/spec/lib/cms/form_builder_spec.rb
+++ b/spec/lib/cms/form_builder_spec.rb
@@ -1,6 +1,13 @@
 describe Cms::FormBuilder do
+  let(:template) { ActionView::Base.new }
+  let(:identifier) { 'identifier' }
+  let(:content) { 'content' }
+  let(:block_attributes) { { identifier: identifier, content: content } }
+
+  before { template.instance_variable_set('@blocks_attributes', [block_attributes]) }
+
   subject do
-    described_class.new(:model, Object.new, ActionView::Base.new, {})
+    described_class.new(:model, Object.new, template, {})
   end
 
   describe '#page_image' do
@@ -8,12 +15,12 @@ describe Cms::FormBuilder do
     let(:tag) do
       ComfortableMexicanSofa::Tag::PageImage.new.tap do |pi|
         pi.blockable = page
-        pi.identifier = 'hero_image'
+        pi.identifier = identifier
       end
     end
 
     it 'adds label' do
-      expect(subject.page_image(tag, 0)).to match(/label.*Hero image.*label/)
+      expect(subject.page_image(tag, 0)).to match(/label.*#{identifier.capitalize}.*label/)
     end
 
     it 'adds text input' do

--- a/spec/serializers/block_serializer_spec.rb
+++ b/spec/serializers/block_serializer_spec.rb
@@ -10,6 +10,8 @@ describe BlockSerializer do
 
     subject { JSON.parse(described_class.new(block).to_json)['content'] }
 
+    before { page.reload }
+
     it 'returns the raw content' do
       expect(subject).to eq(block_content)
     end


### PR DESCRIPTION
It was discovered that the new publishing workflow fell down when trying to be used on non article type pages (home page, footer).  This PR addresses the issues and now they can be updated and scheduled in the same manner as articles.

The solution is a bit hacky, but that fits in perfectly with the way these forms are built.