### PR TITLE
[DEV APPROVED]7228 link to mas bug

### DIFF
--- a/app/controllers/links/pages_controller.rb
+++ b/app/controllers/links/pages_controller.rb
@@ -1,6 +1,6 @@
 class Links::PagesController < PagesController
   def index
-    pages  = Comfy::Cms::Page.includes(:site).published.filter(params.slice(:category))
+    pages  = Comfy::Cms::Page.includes(:site).where('state != ?', 'unpublished').filter(params.slice(:category))
     pages  = Comfy::Cms::Search.new(pages, params[:search]).results if params[:search].present?
 
     @pages = PageMirror.collect(pages)

--- a/app/controllers/links/pages_controller.rb
+++ b/app/controllers/links/pages_controller.rb
@@ -1,6 +1,6 @@
 class Links::PagesController < PagesController
   def index
-    pages  = Comfy::Cms::Page.includes(:site).where('state != ?', 'unpublished').filter(params.slice(:category))
+    pages  = Comfy::Cms::Page.includes(:site).where.not(state: :published).filter(params.slice(:category))
     pages  = Comfy::Cms::Search.new(pages, params[:search]).results if params[:search].present?
 
     @pages = PageMirror.collect(pages)

--- a/app/presenters/page_mirror_presenter.rb
+++ b/app/presenters/page_mirror_presenter.rb
@@ -6,8 +6,4 @@ class PageMirrorPresenter < Presenter
   def label
     object.label(:en) || object.page_label
   end
-
-  def disabled?
-    (published? || published_being_edited?).blank?
-  end
 end

--- a/app/views/links/pages/_listing.html.haml
+++ b/app/views/links/pages/_listing.html.haml
@@ -13,4 +13,4 @@
           .grid-list__item.grid-list__item--center-aligned
             = render 'page_button', page_mirror: page.mirror(:cy), page_url: page.url(:cy)
           .grid-list__item
-            = page.label
+            #{page.label} (#{current_status(page.page)})

--- a/app/views/links/pages/_page_button.html.haml
+++ b/app/views/links/pages/_page_button.html.haml
@@ -1,2 +1,2 @@
 - if page_mirror.present?
-  = radio_button_tag(:page_radio_button_name, page_url, false, disabled: page_mirror.disabled?, data: { 'dough-insertmanager-value-trigger' => true, 'dough-insertmanager-insert-type' => 'page' })
+  = radio_button_tag(:page_radio_button_name, page_url, false, disabled: page_mirror.unpublished?, data: { 'dough-insertmanager-value-trigger' => true, 'dough-insertmanager-insert-type' => 'page' })

--- a/features/link_to_article.feature
+++ b/features/link_to_article.feature
@@ -1,0 +1,25 @@
+@javascript
+Feature: Link to existing articles
+  As a CMS user editing or creating a page
+  I want to be able to insert a link to an existing articles
+  So that I can link my article to other articles
+
+Scenario: Linking to a scheduled article
+  Given I have a scheduled article with the slug "Scheduled-Article-to-Link"
+    And I am working on a new draft article
+    And I populate the editor with the text "anything really"
+  When I press the button "Insert link"
+   And I type "Scheduled" into the search input
+  Then I should see "Scheduled-Article-to-Link" in the list of linkable pages
+
+Scenario: Linking to an article with scheduled mirror
+  Given there is an English and Welsh site
+    And I have a published article "link-to-language-test" in "en"
+    And I have a scheduled update to the "cy" mirror of "link-to-language-test"
+  When I edit a new draft article
+   And I populate the editor with the text "anything really"
+   And I press the button "Insert link"
+   And I type "link-to-language" into the search input
+  Then I should see "link-to-language-test" in the list of linkable pages
+   And the "en" and "cy" versions are available for linking
+

--- a/features/step_definitions/categories_steps.rb
+++ b/features/step_definitions/categories_steps.rb
@@ -1,14 +1,14 @@
 Given(/^I have an article with(out)? categories$/) do |uncategorized|
   cms_site
   cms_layout
-  cms_page
+  @cms_page = build_cms_page
   cms_categories
-  cms_page.categories << cms_categories.first unless uncategorized
+  @cms_page.categories << cms_categories.first unless uncategorized
 end
 
 When(/^I visit the article's edit page$/) do
   step("I am logged in")
-  edit_page.load(site: cms_site.id, page: cms_page.id)
+  edit_page.load(site: cms_site.id, page: @cms_page.id)
   wait_for_page_load
 end
 

--- a/features/step_definitions/categories_steps.rb
+++ b/features/step_definitions/categories_steps.rb
@@ -9,6 +9,7 @@ end
 When(/^I visit the article's edit page$/) do
   step("I am logged in")
   edit_page.load(site: cms_site.id, page: cms_page.id)
+  wait_for_page_load
 end
 
 Then(/^I should see the article's (new )?category$/) do |new_category|

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -18,11 +18,27 @@ Then(/^I should not be able to see live draft article$/) do
 end
 
 Given(/^I have an articles with unpublished changes$/) do
-  edit_page.load(site: cms_site.id, page: cms_new_draft_page.id)
+  load_page_in_editor(site: cms_site, page: cms_new_draft_page).slug
   edit_page.content.set("New Published Content")
   edit_page.publish.click
   edit_page.content.set("New unpublished Content")
   edit_page.create_new_draft.click
+end
+
+Given(/^I have a scheduled article with the slug "([\w\s-]+)"/) do |title|
+  build_cms_scheduled_page(identifier: title)
+end
+
+Given(/^I have a published article "([\w\s-]+)" in "([a-zA-Z]{2})"$/) do |slug, locale|
+  build_cms_published_page(identifier: slug, locale: locale)
+end
+
+Given(/^I have a scheduled update to the "([a-zA-Z]{2})" mirror of "([\w\s-]+)"$/) do |slug, locale|
+  build_cms_scheduled_page(identifier: slug, locale: locale)
+end
+
+Given(/^the published article has a "([a-zA-Z]{2})" update scheduled$/) do |locale|
+  cms_scheduled_page(identifier: title)
 end
 
 When(/^I view the live published article$/) do
@@ -34,35 +50,35 @@ Then(/^I should see the published Article content$/) do
 end
 
 When(/^I (?:am working on|edit) a new unsaved article$/) do
-  edit_page.load(site: cms_site.id, page: cms_new_unsaved_page.id)
+  load_page_in_editor(page: cms_new_unsaved_page)
 end
 
 When(/^I (?:am working on|edit) a new draft article$/) do
-  edit_page.load(site: cms_site.id, page: cms_new_draft_page.id)
+  load_page_in_editor(page: cms_new_draft_page)
 end
 
 When(/^I (?:am working on|edit) a published article$/) do
-  edit_page.load(site: cms_site.id, page: cms_published_page.id)
+  load_page_in_editor(page: cms_published_page)
 end
 
 When(/^I (?:am working on|edit) a scheduled but not live article$/) do
-  edit_page.load(site: cms_site.id, page: cms_scheduled_page.id)
+  load_page_in_editor(page: cms_scheduled_page)
 end
 
 When(/^I (?:am working on|edit) a scheduled and live article$/) do
-  edit_page.load(site: cms_site.id, page: cms_scheduled_page(true).id)
+  load_page_in_editor(page: cms_scheduled_page(live: true))
 end
 
 When(/^I (?:am working on|edit) a draft new version of an article$/) do
-  alternate_edit_page.load(site: cms_site.id, page: cms_draft_version_of_page.id)
+  load_alternate_page_in_editor(page: cms_draft_version_of_page)
 end
 
 When(/^I (?:am working on|edit) a scheduled update to an article$/) do
-  alternate_edit_page.load(site: cms_site.id, page: cms_scheduled_new_version_of_page.id)
+  load_alternate_page_in_editor(page: cms_scheduled_new_version_of_page)
 end
 
 When(/^I (?:am working on|edit) a live scheduled update to an article$/) do
-  edit_page.load(site: cms_site.id, page: cms_scheduled_new_version_of_page(true).id)
+  load_page_in_editor(page: cms_scheduled_new_version_of_page(live: true))
 end
 
 When(/^I publish the article$/) do
@@ -84,6 +100,12 @@ Then(/^I should be able to see the last revision status$/) do
   expect(edit_page.activity_log_box).to have_content('Status: published')
 end
 
+When(/^I type "(.*?)" into the search input$/) do |text|
+  edit_page.link_manager.pages.search_input_box.set(text)
+  edit_page.link_manager.pages.search_button.click
+  wait_for_ajax
+end
+
 Given(/^there is an English and Welsh site$/) do
   cms_sites
 end
@@ -91,7 +113,10 @@ end
 When(/^I (?:am working on|edit) a new draft article on the "(.*?)" site$/) do |locale|
   cms_page(locale: locale).create_initial_draft!
   step("I am logged in")
-  edit_page.load(site: cms_site(locale).id, page: cms_page(locale: locale).id)
+  load_page_in_editor(
+    page: cms_page(locale: locale),
+    site: cms_site(locale)
+  )
 end
 
 When(/^I switch to the "(.*?)" article$/) do |locale|
@@ -101,7 +126,7 @@ When(/^I switch to the "(.*?)" article$/) do |locale|
 end
 
 When(/^I should be working on the "(.*?)" article$/) do |locale|
-  sleep(0.1) # wait for page to load
+  wait_for_page_load
   expect(edit_page.status.text).to match(/#{locale}/i)
   expect(edit_page.current_url).to match(/\/sites\/#{cms_site(locale).id}\/pages/)
 end
@@ -142,3 +167,18 @@ end
 Then(/^no email notifications are sent$/) do
   expect(ActionMailer::Base.deliveries).to be_empty
 end
+
+Then(/^I should see "(.*?)" in the list of linkable pages/) do |name|
+  @linkable_page = edit_page.link_manager.pages.results.find do |row|
+    row.page_name.text.include? name
+  end
+  expect(@linkable_page).to_not be_nil
+end
+
+Then(/^the "([a-zA-Z]{2})" and "([a-zA-Z]{2})" versions are available for linking$/) do |*locales|
+  locales.each do |locale|
+    expect(@linkable_page.send(locale)).
+      to have_field("page_radio_button_name__#{locale}_articles_link-to-language-test")
+  end
+end
+

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -25,20 +25,16 @@ Given(/^I have an articles with unpublished changes$/) do
   edit_page.create_new_draft.click
 end
 
-Given(/^I have a scheduled article with the slug "([\w\s-]+)"/) do |title|
-  build_cms_scheduled_page(identifier: title)
+Given(/^I have a scheduled article with the slug "([\w\s-]+)"/) do |label|
+  build_cms_scheduled_page(label: label)
 end
 
-Given(/^I have a published article "([\w\s-]+)" in "([a-zA-Z]{2})"$/) do |slug, locale|
-  build_cms_published_page(identifier: slug, locale: locale)
+Given(/^I have a published article "([\w\s-]+)" in "([a-zA-Z]{2})"$/) do |label, locale|
+  build_cms_published_page(label: label, locale: locale)
 end
 
-Given(/^I have a scheduled update to the "([a-zA-Z]{2})" mirror of "([\w\s-]+)"$/) do |slug, locale|
-  build_cms_scheduled_page(identifier: slug, locale: locale)
-end
-
-Given(/^the published article has a "([a-zA-Z]{2})" update scheduled$/) do |locale|
-  cms_scheduled_page(identifier: title)
+Given(/^I have a scheduled update to the "([a-zA-Z]{2})" mirror of "([\w\s-]+)"$/) do |label, locale|
+  build_cms_scheduled_page(label: label, locale: locale)
 end
 
 When(/^I view the live published article$/) do

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -1,11 +1,11 @@
 Then(/^I should be able to preview it in a new window$/) do
   edit_page.should have_preview
-  edit_page.preview['href'].should match /#{cms_page.slug}\/preview/
+  edit_page.preview['href'].should match /#{@cms_page.slug}\/preview/
   edit_page.preview['target'].should eq '_blank'
 end
 
 When(/^I preview the article$/) do
-  preview_page.load(locale: cms_site.label, slug: cms_page.slug)
+  preview_page.load(locale: cms_site.label, slug: @cms_page.slug)
 end
 
 Then(/^I should see the Draft Article$/) do
@@ -13,12 +13,12 @@ Then(/^I should see the Draft Article$/) do
 end
 
 Then(/^I should not be able to see live draft article$/) do
-  live_page.load(locale: cms_site.label, slug: cms_page.slug)
+  live_page.load(locale: cms_site.label, slug: @cms_page.slug)
   expect(JSON.load(live_page.text).symbolize_keys).to eq(message: 'Page not found')
 end
 
 Given(/^I have an articles with unpublished changes$/) do
-  load_page_in_editor(site: cms_site, page: cms_new_draft_page).slug
+  load_page_in_editor(site: cms_site, page: build_cms_new_draft_page).slug
   edit_page.content.set("New Published Content")
   edit_page.publish.click
   edit_page.content.set("New unpublished Content")
@@ -38,7 +38,7 @@ Given(/^I have a scheduled update to the "([a-zA-Z]{2})" mirror of "([\w\s-]+)"$
 end
 
 When(/^I view the live published article$/) do
-  live_page.load(locale: cms_site.label, slug: cms_page.slug)
+  live_page.load(locale: cms_site.label, slug: @cms_page.slug)
 end
 
 Then(/^I should see the published Article content$/) do
@@ -46,35 +46,35 @@ Then(/^I should see the published Article content$/) do
 end
 
 When(/^I (?:am working on|edit) a new unsaved article$/) do
-  load_page_in_editor(page: cms_new_unsaved_page)
+  load_page_in_editor(page: build_cms_new_unsaved_page)
 end
 
 When(/^I (?:am working on|edit) a new draft article$/) do
-  load_page_in_editor(page: cms_new_draft_page)
+  load_page_in_editor(page: build_cms_new_draft_page)
 end
 
 When(/^I (?:am working on|edit) a published article$/) do
-  load_page_in_editor(page: cms_published_page)
+  load_page_in_editor(page: build_cms_published_page)
 end
 
 When(/^I (?:am working on|edit) a scheduled but not live article$/) do
-  load_page_in_editor(page: cms_scheduled_page)
+  load_page_in_editor(page: build_cms_scheduled_page)
 end
 
 When(/^I (?:am working on|edit) a scheduled and live article$/) do
-  load_page_in_editor(page: cms_scheduled_page(live: true))
+  load_page_in_editor(page: build_cms_scheduled_page(live: true))
 end
 
 When(/^I (?:am working on|edit) a draft new version of an article$/) do
-  load_alternate_page_in_editor(page: cms_draft_version_of_page)
+  load_alternate_page_in_editor(page: build_cms_draft_version_of_page)
 end
 
 When(/^I (?:am working on|edit) a scheduled update to an article$/) do
-  load_alternate_page_in_editor(page: cms_scheduled_new_version_of_page)
+  load_alternate_page_in_editor(page: build_cms_scheduled_new_version_of_page)
 end
 
 When(/^I (?:am working on|edit) a live scheduled update to an article$/) do
-  load_page_in_editor(page: cms_scheduled_new_version_of_page(live: true))
+  load_page_in_editor(page: build_cms_scheduled_new_version_of_page(live: true))
 end
 
 When(/^I publish the article$/) do
@@ -88,7 +88,7 @@ end
 Then(/^I should be able to publish it$/) do
   edit_page.should have_publish
   edit_page.publish.click
-  expect(cms_page.reload.current_state).to eq(:published)
+  expect(@cms_page.reload.current_state).to eq(:published)
 end
 
 Then(/^I should be able to see the last revision status$/) do
@@ -107,12 +107,10 @@ Given(/^there is an English and Welsh site$/) do
 end
 
 When(/^I (?:am working on|edit) a new draft article on the "(.*?)" site$/) do |locale|
-  cms_page(locale: locale).create_initial_draft!
+  page = build_cms_page(locale: locale)
+  page.create_initial_draft!
   step("I am logged in")
-  load_page_in_editor(
-    page: cms_page(locale: locale),
-    site: cms_site(locale)
-  )
+  load_page_in_editor(page: page, site: cms_site(locale))
 end
 
 When(/^I switch to the "(.*?)" article$/) do |locale|
@@ -133,11 +131,11 @@ Given(/^I (select|deselect) the regulated check box$/) do |selection|
 end
 
 Then(/^the article should( not)? be regulated$/) do |negate|
-  expect(cms_page.reload.regulated?).to be !!!negate
+  expect(@cms_page.reload.regulated?).to be !!!negate
 end
 
 Given(/^the article is regulated$/) do
-  cms_page.update_attributes!(regulated: true)
+  @cms_page.update_attributes!(regulated: true)
 end
 
 Then(/^I should be able to delete the article$/) do

--- a/features/step_definitions/tags_steps.rb
+++ b/features/step_definitions/tags_steps.rb
@@ -12,7 +12,7 @@ end
 Then(/^I am editing a page$/) do
   loging_in_user do
     @page = edit_page
-    @page.load(site: cms_site.id, page: cms_page.id)
+    @page.load(site: cms_site.id, page: build_cms_page.id)
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,7 +8,7 @@ require 'capybara/poltergeist'
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: true, inspector: true)
+  Capybara::Poltergeist::Driver.new(app, js_errors: true, inspector: true, window_size: [2048, 1536])
 end
 
 Capybara.javascript_driver = :poltergeist

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,17 @@
+After do |scenario|
+  if scenario.failed?
+    timestamp = DateTime.now.strftime('%Y%m%d%H%M%S')
+    suffix    = "%04X" % rand(65536)
+    name      = scenario.name[0..20].downcase.gsub(/\W/, '-')
+    filename  = File.join(Dir.tmpdir, "#{name}-#{timestamp}-#{suffix}")
+    saved_image = save_screenshot("#{filename}.png")
+    unless saved_image.empty?
+      puts "saved screenshot for scenario \"#{scenario.name}\" to #{saved_image}"
+    end
+    saved_page = save_page("#{filename}.html")
+    unless saved_page.empty?
+      puts "saved page for scenario \"#{scenario.name}\" to #{saved_page}"
+    end
+  end
+end
+

--- a/features/support/ui/pages/edit.rb
+++ b/features/support/ui/pages/edit.rb
@@ -31,5 +31,16 @@ module UI::Pages
     element :regulated_checkbox, '#page_regulated_box'
     element :activity_log_button, '.activity-log-button'
     element :activity_log_box, '.activity-log-box'
+    section :link_manager, '[data-dough-component="LinkManager"]' do
+      section :pages, '#page' do
+        element :search_input_box, '#search'
+        element :search_button, '.t-search-btn'
+        sections :results, '.js-linkable-pages .grid-list--page-listing .grid-list__row:nth-child(1n+2)' do
+          element :en, '.grid-list__item:nth-child(0n+1)'
+          element :cy, '.grid-list__item:nth-child(0n+2)'
+          element :page_name, '.grid-list__item:nth-child(0n+3)'
+        end
+      end
+    end
   end
 end

--- a/features/support/world/cms.rb
+++ b/features/support/world/cms.rb
@@ -29,12 +29,6 @@ module World
       self.categories
     end
 
-    def cms_page(published: true, locale: 'en', label: identifier())
-      @cms_page ||= build_cms_page(
-        published: published,
-        locale: locale,
-        label: label
-      )
     end
 
     def build_cms_page(page: nil, published: true, locale: 'en', label: identifier())
@@ -52,18 +46,10 @@ module World
       page
     end
 
-    def cms_new_unsaved_page
-      build_cms_new_unsaved_page(page: cms_page)
-    end
-
     def build_cms_new_unsaved_page(page: nil)
       page ||= build_cms_page
       page.save!
       page
-    end
-
-    def cms_new_draft_page(label: identifier(), locale: 'en')
-      build_cms_new_draft_page(page: cms_page)
     end
 
     def build_cms_new_draft_page(page: nil, label: identifier(), locale: 'en')
@@ -75,14 +61,6 @@ module World
         new_blocks_attributes: page.blocks_attributes
       ).save!
       page
-    end
-
-    def cms_published_page(label: identifier(), locale: 'en')
-      build_cms_published_page(
-        page: cms_new_draft_page,
-        label: label,
-        locale: locale
-      )
     end
 
     def build_cms_published_page(page: nil, label: identifier(), locale: 'en')
@@ -98,10 +76,6 @@ module World
       page
     end
 
-    def cms_draft_version_of_page
-      build_cms_draft_version_of_page(page: cms_published_page)
-    end
-
     def build_cms_draft_version_of_page(page: nil)
       page ||= build_cms_published_page
 
@@ -112,15 +86,6 @@ module World
         new_blocks_attributes: page.blocks_attributes
       ).save!
       page
-    end
-
-    def cms_scheduled_page(live: false, label: identifier(), locale: 'en')
-      build_cms_scheduled_page(
-        page: cms_new_draft_page,
-        live: live,
-        label: label,
-        locale: locale
-      )
     end
 
     def build_cms_scheduled_page(page: nil, live: false, label: identifier(), locale: 'en')
@@ -136,15 +101,8 @@ module World
       page
     end
 
-    def cms_scheduled_new_version_of_page(live: false)
-      build_cms_scheduled_new_version_of_page(
-        page: cms_published_page,
-        live: live
-      )
-    end
-
     def build_cms_scheduled_new_version_of_page(page: nil, live: false)
-      page ||= build_cms_published_page(live: live)
+      page ||= build_cms_published_page
 
       page.create_new_draft
       AlternatePageBlocksRegister.new(
@@ -176,13 +134,14 @@ module World
     def load_page_in_editor(page: cms_page, site: cms_site)
       log_me_in!
       edit_page.load(site: site.id, page: page.id)
+      @cms_page = page
       wait_for_page_load
       page
     end
 
     def load_alternate_page_in_editor(page: cms_page, site: cms_site)
       log_me_in!
-      alternate_edit_page.load(site: cms_site.id, page: page.id)
+      alternate_edit_page.load(site: site.id, page: page.id)
     end
 
     private

--- a/features/support/world/cms.rb
+++ b/features/support/world/cms.rb
@@ -21,7 +21,6 @@ module World
 
     def cms_root(locale='en')
       self.root ||= cms_site(locale).pages.create!(layout: cms_layout, label: 'root')
-      self.root
     end
 
     def cms_categories

--- a/features/support/world/cms.rb
+++ b/features/support/world/cms.rb
@@ -30,20 +30,20 @@ module World
       self.categories
     end
 
-    def cms_page(published: true, locale: 'en', identifier: identifier())
+    def cms_page(published: true, locale: 'en', label: identifier())
       @cms_page ||= build_cms_page(
         published: published,
         locale: locale,
-        identifier: identifier
+        label: label
       )
     end
 
-    def build_cms_page(page: nil, published: true, locale: 'en', identifier: identifier())
+    def build_cms_page(page: nil, published: true, locale: 'en', label: identifier())
       page ||= cms_site(locale).pages.create!(
         parent: cms_root(locale),
         layout: cms_layout(locale),
-         label: identifier,
-          slug: identifier.downcase
+        label: label,
+        slug: label.parameterize
       )
       page.blocks.create!(
         identifier: 'content',
@@ -63,12 +63,12 @@ module World
       page
     end
 
-    def cms_new_draft_page(identifier: identifier(), locale: 'en')
+    def cms_new_draft_page(label: identifier(), locale: 'en')
       build_cms_new_draft_page(page: cms_page)
     end
 
-    def build_cms_new_draft_page(page: nil, identifier: identifier(), locale: 'en')
-      page ||= build_cms_page(identifier: identifier, locale: locale)
+    def build_cms_new_draft_page(page: nil, label: identifier(), locale: 'en')
+      page ||= build_cms_page(label: label, locale: locale)
       page.create_initial_draft
       PageBlocksRegister.new(
         page,
@@ -78,16 +78,16 @@ module World
       page
     end
 
-    def cms_published_page(identifier: identifier(), locale: 'en')
+    def cms_published_page(label: identifier(), locale: 'en')
       build_cms_published_page(
         page: cms_new_draft_page,
-        identifier: identifier,
+        label: label,
         locale: locale
       )
     end
 
-    def build_cms_published_page(page: nil, identifier: identifier(), locale: 'en')
-      page ||= build_cms_new_draft_page(identifier: identifier, locale: locale)
+    def build_cms_published_page(page: nil, label: identifier(), locale: 'en')
+      page ||= build_cms_new_draft_page(label: label, locale: locale)
 
       page.publish
       PageBlocksRegister.new(
@@ -115,17 +115,17 @@ module World
       page
     end
 
-    def cms_scheduled_page(live: false, identifier: identifier(), locale: 'en')
+    def cms_scheduled_page(live: false, label: identifier(), locale: 'en')
       build_cms_scheduled_page(
         page: cms_new_draft_page,
         live: live,
-        identifier: identifier,
+        label: label,
         locale: locale
       )
     end
 
-    def build_cms_scheduled_page(page: nil, live: false, identifier: identifier(), locale: 'en')
-      page ||= build_cms_new_draft_page(identifier: identifier, locale: locale)
+    def build_cms_scheduled_page(page: nil, live: false, label: identifier(), locale: 'en')
+      page ||= build_cms_new_draft_page(label: label, locale: locale)
 
       page.schedule
       page.scheduled_on = live ? 1.minute.ago : 1.minute.from_now

--- a/features/support/world/cms.rb
+++ b/features/support/world/cms.rb
@@ -29,6 +29,12 @@ module World
       self.categories
     end
 
+    def register_page_blocks(page: page, blocks_registrar: PageBlocksRegister)
+      blocks_registrar.new(
+        page,
+        author: set_current_user,
+        new_blocks_attributes: page.blocks_attributes
+      ).save!
     end
 
     def build_cms_page(page: nil, published: true, locale: 'en', label: identifier())
@@ -55,11 +61,7 @@ module World
     def build_cms_new_draft_page(page: nil, label: identifier(), locale: 'en')
       page ||= build_cms_page(label: label, locale: locale)
       page.create_initial_draft
-      PageBlocksRegister.new(
-        page,
-        author: set_current_user,
-        new_blocks_attributes: page.blocks_attributes
-      ).save!
+      register_page_blocks(page: page)
       page
     end
 
@@ -67,12 +69,7 @@ module World
       page ||= build_cms_new_draft_page(label: label, locale: locale)
 
       page.publish
-      PageBlocksRegister.new(
-        page,
-        author: set_current_user,
-        new_blocks_attributes: page.blocks_attributes
-      ).save!
-
+      register_page_blocks(page: page)
       page
     end
 
@@ -80,11 +77,10 @@ module World
       page ||= build_cms_published_page
 
       page.create_new_draft
-      AlternatePageBlocksRegister.new(
-        page,
-        author: set_current_user,
-        new_blocks_attributes: page.blocks_attributes
-      ).save!
+      register_page_blocks(
+        page: page,
+        blocks_registrar: AlternatePageBlocksRegister
+      )
       page
     end
 
@@ -93,11 +89,7 @@ module World
 
       page.schedule
       page.scheduled_on = live ? 1.minute.ago : 1.minute.from_now
-      PageBlocksRegister.new(
-        page,
-        author: set_current_user,
-        new_blocks_attributes: page.blocks_attributes
-      ).save!
+      register_page_blocks(page: page)
       page
     end
 
@@ -105,11 +97,10 @@ module World
       page ||= build_cms_published_page
 
       page.create_new_draft
-      AlternatePageBlocksRegister.new(
-        page,
-        author: set_current_user,
-        new_blocks_attributes: page.blocks_attributes
-      ).save!
+      register_page_blocks(
+        page: page,
+        blocks_registrar: AlternatePageBlocksRegister
+      )
 
       page.schedule
       page.scheduled_on = 1.minute.from_now

--- a/features/support/world/helpers.rb
+++ b/features/support/world/helpers.rb
@@ -14,13 +14,21 @@ module World
 
     # Waits for all the dough components to be loaded
     def wait_for_page_load
-      find('body[data-dough-component-loader-all-loaded="yes"]')
+      if Capybara.current_driver == :poltergeist
+        find('body[data-dough-component-loader-all-loaded="yes"]')
+      else
+        sleep(0.1)
+      end
     end
 
     # Waits for all ajax calls
     def wait_for_ajax
-      Timeout.timeout(Capybara.default_wait_time) do
-        loop until page.evaluate_script('jQuery.active').zero?
+      if Capybara.current_driver == :poltergeist
+        Timeout.timeout(Capybara.default_wait_time) do
+          loop until page.evaluate_script('jQuery.active').zero?
+        end
+      else
+        sleep(0.1)
       end
     end
 

--- a/spec/presenters/page_mirror_presenter_spec.rb
+++ b/spec/presenters/page_mirror_presenter_spec.rb
@@ -22,30 +22,4 @@ RSpec.describe PageMirrorPresenter do
       end
     end
   end
-
-  describe '#disabled?' do
-    context 'when page is published' do
-      let(:object) { double(published?: true) }
-
-      it 'returns false' do
-        expect(presenter).to_not be_disabled
-      end
-    end
-
-    context 'when page published being edited' do
-      let(:object) { double(published?: false, published_being_edited?: true) }
-
-      it 'returns false' do
-        expect(presenter).to_not be_disabled
-      end
-    end
-
-    context 'when page is not published or published being edited' do
-      let(:object) { double(published?: false, published_being_edited?: false) }
-
-      it 'returns true' do
-        expect(presenter).to be_disabled
-      end
-    end
-  end
 end


### PR DESCRIPTION
The tests added here include a certain amount of refactoring to partially take out the reliance on a singleton object `cms_page`. This allows us to work with two pages in the same test, for example when linking to pages like in this change. The end goal should probably be to move the fixture generation into factory girl ... although that's probably for later change.
