### PR TITLE
[DEV APPROVED] 7333 Removing editable footer newsletter

### DIFF
--- a/app/views/pages/form_blocks/_footer.html.erb
+++ b/app/views/pages/form_blocks/_footer.html.erb
@@ -24,13 +24,5 @@
         <%= tag_for_identifier(tags, 'raw_contact_small_print', cms_blocks, 11) %>
       </div>
     </div>
-
-    <div class="l-split-content">
-      <div class="l-split-content__col">
-        <h2>Newsletter Panel</h2>
-        <%= tag_for_identifier(tags, 'raw_newsletter_heading', cms_blocks, 12) %>
-        <%= tag_for_identifier(tags, 'raw_newsletter_introduction', cms_blocks, 13) %>
-      </div>
-    </div>
   <% end %>
 </div>

--- a/lib/cms/layout_builder.rb
+++ b/lib/cms/layout_builder.rb
@@ -55,9 +55,6 @@ module Cms
         {{ cms:page:raw_contact_additional_two:string }}
         {{ cms:page:raw_contact_additional_three:string }}
         {{ cms:page:raw_contact_small_print:string }}
-
-        {{ cms:page:raw_newsletter_heading:string }}
-        {{ cms:page:raw_newsletter_introduction:string }}
       CONTENT
     end
 

--- a/spec/lib/cms/layout_builder_spec.rb
+++ b/spec/lib/cms/layout_builder_spec.rb
@@ -125,11 +125,6 @@ RSpec.describe Cms::LayoutBuilder do
         expect(layout.content).to include('{{ cms:page:raw_contact_additional_three:string }}')
         expect(layout.content).to include('{{ cms:page:raw_contact_small_print:string }}')
       end
-
-      it 'defines the content areas for the footer newsletter section' do
-        expect(layout.content).to include('{{ cms:page:raw_newsletter_heading:string }}')
-        expect(layout.content).to include('{{ cms:page:raw_newsletter_introduction:string }}')
-      end
     end
 
     context 'Welsh site' do


### PR DESCRIPTION
## 7333 Removing editable footer newsletter

Related to the task to [remove the newsletter signup from the footer in Frontend](https://github.com/moneyadviceservice/frontend/pull/1455) (PR) and [ticket 7333 in TP](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx?acid=E9844BE5A953DC8AF06B0B23D5B7DBA0#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==)

This must not be merged in before the [related frontend PR](https://github.com/moneyadviceservice/frontend/pull/1455)



Note: [Click here for the original PR which added the editable footer to the CMS](https://github.com/moneyadviceservice/cms/pull/318/files)