### PR TITLE
Add requirejs and mocha to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "jscs": "^1.5.4",
     "jshint": "^2.5.5",
     "karma": "^0.12.2",
-    "karma-osx-reporter": "*",
-    "karma-spec-reporter": "0.0.13",
     "karma-chai": "^0.1.0",
     "karma-chai-jquery": "^1.0.0",
     "karma-chrome-launcher": "^0.1.2",
@@ -34,9 +32,13 @@
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-jquery": "^0.1.0",
     "karma-mocha": "^0.1.3",
+    "karma-osx-reporter": "*",
     "karma-phantomjs-launcher": "~0.1",
     "karma-requirejs": "^0.2.1",
     "karma-sinon": "^1.0.3",
+    "karma-spec-reporter": "0.0.13",
+    "mocha": "^3.1.0",
+    "requirejs": "^2.3.2",
     "sinon": "^1.9.0",
     "sinon-chai": "^2.5.0"
   }


### PR DESCRIPTION
This will fix for the users that do the fresh install for cms.

This will solve the annoying error:

```
$ ./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js --single-run

   cms/node_modules/di/lib/injector.js:9
      throw error('No provider for "' + name + '"!');
      ^

   Error: No provider for "framework:requirejs"! (Resolving: framework:requirejs)
```