### PR TITLE
Removing bad Karma tests

### DIFF
--- a/spec/javascripts/tests/EmbeddedGoogleAnalytics_spec.js
+++ b/spec/javascripts/tests/EmbeddedGoogleAnalytics_spec.js
@@ -38,7 +38,10 @@ describe('EmbeddedGoogleAnalytics', function() {
       expect(component.config.path).to.equal('/en/articles/foo');
     });
 
-    it('create a DataChart', function() {
+    // Skipping next three tests. 
+    // They are checking a JS object that is returned from Google API, which changes every few months without warning / documentaiton
+    // Instead we should be testing that the chart actually renders
+    xit('create a DataChart', function() {
       var config = { 'chartContainer': 'some-chart-container',
                      'viewContainer': 'some-view-container',
                      'metrics': 'some-metrics',
@@ -51,7 +54,7 @@ describe('EmbeddedGoogleAnalytics', function() {
       expect(dataChart.Ka.query.filters).equal('ga:pagePath=~^/some/path');
     });
 
-    it('create a ViewSelector', function() {
+    xit('create a ViewSelector', function() {
       var config = { 'chartContainer': 'some-chart-container',
                      'viewContainer': 'some-view-container',
                      'metrics': 'some-metrics',
@@ -62,7 +65,7 @@ describe('EmbeddedGoogleAnalytics', function() {
       expect(viewSelector.Ka.container).equal('some-view-container');
     });
 
-    it('create a ViewSelector change binding', function() {
+    xit('create a ViewSelector change binding', function() {
       var config = { 'chartContainer': 'some-chart-container',
                      'viewContainer': 'some-view-container',
                      'metrics': 'some-metrics',


### PR DESCRIPTION
The Karma tests for DataCharts rely on checking properties of a JS object that is returned from the Google API - this object changes every few months. We are not testing a documented part of their API with these tests (nor are we actually checking that the DataChart is successfully created).

To be exact, we _could_ fix this right now by making this change:
from:
`expect(dataChart.Ka.chart.container).equal('some-chart-container');`
to:
`expect(dataChart.g$.chart.container).equal('some-chart-container');`

But that is merely pushing the problem on a few months until this happens again (see the commit history of this file). `g$` is not documented anywhere.

At the moment we can't get the CMS pipeline to run. So I'm suggesting we remove these tests, and write alternative ones that actually check the chart has rendered.