### PR TITLE
Adding the mas-version-diff script to CMS

### DIFF
--- a/bin/mas-version-diff
+++ b/bin/mas-version-diff
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+# USAGE
+# ./bin/mas-version-diff 1869 1870
+# They should be in ascending order
+
+if [[ -z "$1" || -z "$2" ]]
+then
+    echo "Usage: $0 START_VERSION END_VERSION"
+    exit 1
+fi
+
+git --no-pager log --decorate --pretty=format:"%C(yellow)moneyadviceservice/cms@%h%C(auto)%d %C(reset)%s %C(blue)[%cn]"  $1..$2
+echo ''


### PR DESCRIPTION
In the Frontend repo we have the `bin/mas-version-diff.sh`script which we use to compare Frontend versions before deploying. The output allows us to see all commits that are to be included in the release.

This doesn't currently exist in the CMS project so with this PR I suggest we add it?