### PR TITLE
[DEV APPROVED] 7674 - Extract a list of All articles and what categories they sit in

### DIFF
--- a/lib/tasks/adhoc.rake
+++ b/lib/tasks/adhoc.rake
@@ -3,7 +3,8 @@ namespace :adhoc do
   task :extract_page => :environment do
     File.open('pages_with_cat.csv','w') do |file|
       file.write "Url\tCategories\n"
-      Comfy::Cms::Page.where(state: :published).find_each do |page|
+      en = Comfy::Cms::Site.where(label: :en).first
+      Comfy::Cms::Page.where(site: en, state: :published).find_each do |page|
         file.write "/en/articles/#{page.slug}\t#{page.categories.map(&:label).join(', ')}\n"
         $stdout.write '.'
       end

--- a/lib/tasks/adhoc.rake
+++ b/lib/tasks/adhoc.rake
@@ -1,0 +1,14 @@
+namespace :adhoc do
+  desc 'Extract a list of All articles and what categories they sit in'
+  task :extract_page => :environment do
+    File.open('pages_with_cat.csv','w') do |file|
+      file.write "Url\tCategories\n"
+      Comfy::Cms::Page.where(state: :published).find_each do |page|
+        file.write "/en/articles/#{page.slug}\t#{page.categories.map(&:label).join(', ')}\n"
+        $stdout.write '.'
+      end
+      puts "\nCreated csv file `#{file.path}`"
+      file.flush
+    end
+  end
+end

--- a/lib/tasks/adhoc.rake
+++ b/lib/tasks/adhoc.rake
@@ -3,13 +3,16 @@ namespace :adhoc do
   task :extract_page => :environment do
     File.open('pages_with_cat.csv','w') do |file|
       file.write "Url\tCategories\n"
-      en = Comfy::Cms::Site.where(label: :en).first
-      Comfy::Cms::Page.where(site: en, state: :published).find_each do |page|
-        file.write "/en/articles/#{page.slug}\t#{page.categories.map(&:label).join(', ')}\n"
-        $stdout.write '.'
+      if en = Comfy::Cms::Site.find_by(label: :en)
+        en.pages.published.find_each do |page|
+          file.write "/en/articles/#{page.slug}\t#{page.categories.map(&:label).join(', ')}\n"
+          $stdout.write '.'
+        end
+        puts "\nCreated csv file `#{file.path}`"
+        file.flush
+      else
+        puts 'No english site'
       end
-      puts "\nCreated csv file `#{file.path}`"
-      file.flush
     end
   end
 end


### PR DESCRIPTION
**Feature**
Added task `rake adhoc:extract_page` to create csv file for published articles and all their categories