### PR TITLE
7695 - Fix bug when inserting external link with no anchor text

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/scribe/scribe-plugin-linkeditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/scribe/scribe-plugin-linkeditor.js
@@ -70,7 +70,13 @@ function (eventsWithPromises, rangy, rangySelectionSaveRestore, filterEvent) {
       };
 
       linkEditorCommand.insertLinkSuffix = function(node, suffix) {
-        node.insertAdjacentText('afterend', suffix);
+        var childNode = node.childNodes[0];
+
+        if(childNode.nodeType === 3) {
+          node.insertAdjacentText('afterend', suffix);
+        } else {
+          childNode.insertAdjacentText('afterend', suffix);
+        }
       };
 
       linkEditorCommand.removeLinkSuffix = function(referenceNode, suffixRegEx) {


### PR DESCRIPTION
When inserting an external link via the editor, if you do this without selecting some anchor text, the inserted kramdown markup appears over two lines/paragraphs.

This fixes that bug.