### PR TITLE
Fix issue of assets not being show in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  config.action_controller.asset_host = 'http://localhost:3000'
 end


### PR DESCRIPTION
* When you use a different port of CMS, the assets are not showed
  anywhere. Removing this assets configuration solves the issue.