### PR TITLE
[DEV APPROVED]Allow editor to create pages

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -9,7 +9,7 @@
         - else
           %h1.l-panel-content__heading
             = "Welcome #{current_user.name}"
-      - unless current_user.editor?
+      - if current_user.editor? || current_user.admin?
         .l-panel-content__col.l-panel-content__col--right
           = link_to new_site_page_path(@site), class: 'button--action button--search' do
             %span.button__text

--- a/lib/permission_check.rb
+++ b/lib/permission_check.rb
@@ -8,7 +8,7 @@ class PermissionCheck
 
   attr_accessor :user, :page, :action, :event
 
-  FORBIDDEN_ACTIONS = %w(new create destroy)
+  FORBIDDEN_ACTIONS = %w(destroy)
   ALLOWED_EDITOR_STATE_EVENTS = %w(create_initial_draft create_new_draft)
   ALLOWED_EDITOR_UPDATE_STATES = %w(draft published_being_edited scheduled)
 

--- a/spec/lib/permission_check_spec.rb
+++ b/spec/lib/permission_check_spec.rb
@@ -48,16 +48,16 @@ RSpec.describe PermissionCheck do
       context 'and the action is new' do
         let(:action) { 'new' }
 
-        it 'returns false' do
-          expect(subject).to be false
+        it 'returns true' do
+          expect(subject).to be true
         end
       end
 
       context 'and the action is create' do
         let(:action) { 'create' }
 
-        it 'returns false' do
-          expect(subject).to be false
+        it 'returns true' do
+          expect(subject).to be true
         end
       end
 


### PR DESCRIPTION
**Feature**
[card 7701](https://moneyadviceservice.tpondemand.com/entity/7701)
As a Welsh Translator, I need to be able to create and edit draft pages in Contento, so that I can create Welsh versions of pages and thus lighten the workload of the MAS internal content team.

**Proposed Solution**
 - [x] Amend the privileges of 'Editor' users to enable them to create new draft pages.