### PR TITLE
7686 - A11Y - a way to add captions to tables

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/snippets-model.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/snippets-model.js
@@ -8,7 +8,7 @@ define([], function () {
     collapsible: '$=\r\n# Before you borrow\r\n=$\r\n\r\n$-\r\nFind out if you need to borrow money and whether you can afford it. Learn how to work out the true cost of borrowing.\r\n\r\nTaking control of debt\r\n\r\nWhere to get free debt advice, how to speak to the people you owe money to, and tips to help you pay back your debts in the right order.\r\n-$',
     callout: '$~callout\r\n# Budgeting tips\r\nIn 1985, average first-time buyers needed a deposit of 5% to buy a home - in 2012, this had increased to 20%\r\n*Source: HMS Treasury*\r\n~$\r\n',
     promoBlock: '$bl\r\n\r\n$bl_m\r\n\r\nbl_m$\r\n\r\n$bl_c\r\n\r\nbl_c$\r\n\r\nbl$',
-    table: '| Equity loans | Mortgage guarantees\r\n|---|---\r\n | New-build properties | New-build and pre-owned properties\r\n| Minimum 5% deposit | Minimum 5% deposit',
+    table: '| Equity loans | Mortgage guarantees\r\n|---|---\r\n | New-build properties | New-build and pre-owned properties\r\n| Minimum 5% deposit | Minimum 5% deposit\r\n\r\nA caption for the table\r\n{: .caption}\r\n',
     ticks: '$yes-no\r\n[y] yes [\/y]\r\n[n] no [\/n]\r\n$end',
     videoYoutube: '$~youtube_video\r\nVIDEO_ID\r\nA title for the video\r\n~$',
     videoBrightcove: '$~brightcove_video\r\nVIDEO_ID\r\nA title for the video\r\n~$',

--- a/app/models/content_composer.rb
+++ b/app/models/content_composer.rb
@@ -20,6 +20,6 @@ class ContentComposer
   end
 
   def post_processors
-    [TableWrapper, ExternalLink]
+    [TableWrapper, TableCaptioner, ExternalLink]
   end
 end

--- a/app/models/table_captioner.rb
+++ b/app/models/table_captioner.rb
@@ -1,0 +1,35 @@
+require 'nokogiri'
+
+class TableCaptioner
+  attr_reader :source
+
+  def initialize(_, source)
+    @source = source
+  end
+
+  def call
+    process!
+    doc.to_s
+  end
+
+  private
+
+  def process!
+    table_nodes.each do |node|
+      if (next_element = node.next_element || node.parent.next_element)
+        if next_element.name == 'p' && next_element.attributes['class'].try(:value) == 'caption'
+          node.children.before("<caption>#{next_element.text.strip}</caption>")
+          next_element.remove
+        end
+      end
+    end
+  end
+
+  def doc
+    @doc ||= Nokogiri::HTML.fragment(source)
+  end
+
+  def table_nodes
+    @table_nodes ||= doc.css('table')
+  end
+end

--- a/spec/models/content_composer_spec.rb
+++ b/spec/models/content_composer_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe ContentComposer do
     end
 
    describe '#post_processors' do
-     it 'returns TableWrapper and ExternalLink' do
-       expect(subject.post_processors).to match_array [TableWrapper, ExternalLink]
+     it 'returns TableWrapper, TableCaptioner and ExternalLink' do
+       expect(subject.post_processors).to match_array [TableWrapper, TableCaptioner, ExternalLink]
      end
    end
 

--- a/spec/models/table_captioner_spec.rb
+++ b/spec/models/table_captioner_spec.rb
@@ -1,0 +1,42 @@
+describe TableCaptioner do
+  context 'when there is no table' do
+    let(:source) { '<p>hello</p>' }
+
+    subject do
+      described_class.new(double, source)
+    end
+
+    it 'does nothing' do
+      expect(subject.call).to eql(source)
+    end
+  end
+
+  context 'when there is a table' do
+    context 'and there is a paragraph with class "caption" immediately after it' do
+      let(:caption) { 'This is the caption' }
+      let(:source) { "<table><tr><td></td></tr></table><p class='caption'>#{caption}</p>" }
+
+      subject do
+        described_class.new(double, source)
+      end
+
+      it 'removes the paragraph and inserts the contents of it as a caption tag' do
+        # Include newlines due to Nokogiri's formatted output
+        expected_response = "<table>\n<caption>#{caption}</caption>\n<tr><td></td></tr>\n</table>"
+        expect(subject.call).to eql(expected_response)
+      end
+    end
+
+    context 'and it is followed by paragraph without any particular class' do
+      let(:source) { '<table><tr><td></td></tr></table>' }
+
+      subject do
+        described_class.new(double, source)
+      end
+
+      it 'does not make any changes' do
+        expect(subject.call).to eql(source)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Explored various different approaches and eventually went with leaving tables to be generated as normal, and adding a post processor to look for a paragraph with class of `caption` immediately after a table and if found add it as the `<caption>` tag.

Adding a class to a paragraph is done like so:

```
A paragraph of text
{: .a-class-to-apply}
```

The javascript table insert snippet has been updated to include the caption paragraph.

I ran the styling past @slaywell and we ended up with leave it as it was as it appears that the styling had already been considered in the past.