### PR TITLE
[DEV APPROVED] - 7711 protect cms endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@
 # N.B. This file is intended as a placeholder. Never put any real values in this file and commit.
 ####################################################################################################
 
+MAS_CMS_API_TOKEN=mytoken
 AZURE_ASSETS_STORAGE_CMS_CONTAINER='container'
 AZURE_ASSETS_STORAGE_CMS_ACCOUNT_KEY='key'
 AZURE_ASSETS_STORAGE_CMS_ACCOUNT_NAME='name'

--- a/app/controllers/api/page_feedbacks_controller.rb
+++ b/app/controllers/api/page_feedbacks_controller.rb
@@ -1,6 +1,7 @@
 class API::PageFeedbacksController < APIController
   before_action :find_site, :find_page
   before_action :find_page_feedback, only: :update
+  before_action API::AuthenticationFilter
 
   def create
     page_feedback = @page.feedbacks.new(page_feedback_params)

--- a/app/controllers/page_feedbacks_controller.rb
+++ b/app/controllers/page_feedbacks_controller.rb
@@ -1,5 +1,5 @@
 class PageFeedbacksController < Comfy::Admin::Cms::BaseController
   def index
-    @page_feedbacks = PageFeedback.includes(:page).page(params[:page])
+    @page_feedbacks = PageFeedback.includes(:page).page(params[:page]).order('created_at DESC')
   end
 end

--- a/app/filters/api/authentication_filter.rb
+++ b/app/filters/api/authentication_filter.rb
@@ -1,0 +1,16 @@
+module API
+  class AuthenticationFilter
+    MAS_CMS_API_TOKEN = ENV.fetch('MAS_CMS_API_TOKEN')
+
+    def self.before(controller)
+      authenticate?(controller)
+    end
+
+    def self.authenticate?(controller)
+      controller.authenticate_or_request_with_http_token do |token, _|
+        ::Digest::SHA256.hexdigest(MAS_CMS_API_TOKEN) ==
+          ::Digest::SHA256.hexdigest(token)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Background:
 
On the development of this feature it was added one endpoint with two HTTP verbs on CMS API:
 
POST   "/api/en/example-article/page_feedbacks"
PATCH "/api/en/example-article/page_feedbacks"
 
The problem that the CMS API is public and doesn't have any authentication mechanisms, so anybody malicious can create a script to just create a lot of likes and dislikes for each article if they want it. So adding an authentication solves the problem.