### PR TITLE
[WIP] 7749/7755 - SPIKE - navigation categories active yaml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'mastalk', '~> 0.7.0'
 gem 'mailjet'
 gem 'paperclip-azure', '~> 0.2'
 
+gem 'active_hash'
+
 group :development do
   gem 'spring'
   gem 'spring-commands-cucumber'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       activesupport (= 4.1.1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
+    active_hash (1.4.1)
+      activesupport (>= 2.2.2)
     active_link_to (1.0.3)
       actionpack
     active_model_serializers (0.9.0)
@@ -569,6 +571,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   active_model_serializers
   autoprefixer-rails
   better_errors

--- a/app/controllers/api/clumps_controller.rb
+++ b/app/controllers/api/clumps_controller.rb
@@ -1,0 +1,33 @@
+module API
+  class InvalidLocale < Exception;  end
+
+  class ClumpsController < ApplicationController
+    skip_before_action :load_cms_page
+    around_filter :validate_locale
+
+    def index
+      @clumps = Clump.all
+      render json: @clumps, scope: locale
+    end
+
+    private
+
+    def locale
+      fail InvalidLocale.new unless params[:locale].in?(accepted_locales)
+
+      params[:locale]
+    end
+
+    def validate_locale
+      yield
+    rescue InvalidLocale
+      render json: {
+        error: "Unaccepted locale (must be #{accepted_locales.join(' ')})"
+      }, status: 400
+    end
+
+    def accepted_locales
+      @accepted_locales ||= Comfy::Cms::Site.pluck(:path)
+    end
+  end
+end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -46,7 +46,7 @@ class CategoriesController < Comfy::Admin::Cms::BaseController
 
   def category_params
     params.require(:comfy_cms_category).permit(
-      :label, :parent_id, :title_en, :title_cy, :description_en,
+      :label, :parent_id, :clump_id, :title_en, :title_cy, :description_en,
       :description_cy, :ordinal, :navigation, :third_level_navigation,
       :site_id, :categorized_type, :large_image_id, :small_image_id,
       links_attributes: [:text, :url, :locale, :id, :_destroy],

--- a/app/controllers/clumps_controller.rb
+++ b/app/controllers/clumps_controller.rb
@@ -1,0 +1,7 @@
+class ClumpsController < Comfy::Admin::Cms::BaseController
+
+  def index
+    @clumps = Clump.all
+  end
+
+end

--- a/app/helpers/main_menu_helper.rb
+++ b/app/helpers/main_menu_helper.rb
@@ -25,6 +25,7 @@ module MainMenuHelper
           MenuLink.new(name: t('comfy.admin.cms.base.users'),    path: users_path),
           MenuLink.new(name: t('comfy.admin.cms.base.tags'),     path: tags_path),
           MenuLink.new(name: t('comfy.admin.cms.base.categories'), path: categories_path),
+          MenuLink.new(name: t('comfy.admin.cms.base.clumps'), path: clumps_path),
           MenuLink.new(name: t('comfy.admin.cms.base.redirects'), path: redirects_path),
           MenuLink.new(
             name: t('comfy.admin.cms.base.page_feedbacks'),

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -1,0 +1,67 @@
+class Clump < ActiveHash::Base
+  self.data = [
+    {
+      id: 1,
+      name_en: 'Debt & Borrowing',
+      name_cy: 'Dyled a benthyca',
+      category_labels: [
+        'debt-and-borrowing'
+      ]
+    },
+    {
+      id: 2,
+      name_en: 'Homes & Mortgages',
+      name_cy: 'Cymorth gyda morgeisi',
+      category_labels: [
+        'homes-and-mortgages'
+      ]
+    },
+    {
+      id: 3,
+      name_en: 'Managing Money',
+      name_cy: 'Rheoli arian',
+      category_labels: [
+        'budgeting-and-managing-money',
+        'saving-and-investing'
+      ]
+    },
+    {
+      id: 4,
+      name_en: 'Work, Benefits & Pension',
+      name_cy: 'Gwaith, Budddaliadau a Pensiwn',
+      category_labels: [
+        'pensions-and-retirement',
+        'benefits'
+      ]
+    },
+    {
+      id: 5,
+      name_en: 'Family',
+      name_cy: 'Teulu',
+      category_labels: [
+        'births-deaths-and-family',
+        'care-and-disability'
+      ]
+    },
+    {
+      id: 6,
+      name_en: 'Cars & Travel',
+      name_cy: 'Ceir a theithio',
+      category_labels: [
+        'cars-and-travel'
+      ]
+    },
+    {
+      id: 7,
+      name_en: 'Insurance',
+      name_cy: 'Yswiriant',
+      category_labels: [
+        'insurance'
+      ]
+    }
+  ]
+
+  def categories
+    category_labels.collect { |l| Comfy::Cms::Category.find_by(label: l) }
+  end
+end

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -64,4 +64,8 @@ class Clump < ActiveHash::Base
   def categories
     category_labels.collect { |l| Comfy::Cms::Category.find_by(label: l) }
   end
+
+  def read_attribute_for_serialization(n)
+    attributes[n]
+  end
 end

--- a/app/serializers/clump_serializer.rb
+++ b/app/serializers/clump_serializer.rb
@@ -1,0 +1,12 @@
+class ClumpSerializer < ActiveModel::Serializer
+  attributes :id, :name
+
+  has_many :categories
+
+  private
+
+  def name
+    scope == 'en' ? object.name_en : object.name_cy
+  end
+
+end

--- a/app/views/clumps/index.html.haml
+++ b/app/views/clumps/index.html.haml
@@ -1,0 +1,24 @@
+.l-panel-content.l-panel-content--form
+  .l-constrained
+    .l-panel-content__row
+      .l-panel-content__col
+        %h1 Clumps
+
+.l-panel-content
+  .l-constrained
+    %p Clumps and the categories they contain
+
+    %ul.sortable-list
+      - @clumps.each do |clump|
+        %li
+          <b>Clump:</b> #{clump.name_en} / #{clump.name_cy}
+
+          %ul
+            - clump.categories.each do |category|
+              %li
+                <b>Category:</b> #{link_to category.title_en, category_path(category)}
+
+                %ul
+                  - category.child_categories.each do |child|
+                    %li
+                      <b>Child category:</b> #{link_to child.title_en, category_path(child)}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
       collection { put :reorder }
     end
 
+    resources :clumps, only: :index
+
     resources :tags, only: [:index, :create] do
       collection do
         get :starting_by

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,8 @@ Rails.application.routes.draw do
   end
 
   namespace :api, path: '/' do
+    get '/:locale/clumps(.:format)' => 'clumps#index'
+
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
     get '/preview/:locale/(*slug)(.:format)' => 'content#preview'


### PR DESCRIPTION
Opening a PR for this to start some discussion.

My understanding of the requirements is that the "Clumps" that are the main groupings for the nav simply contain categories, with those subcategories being used to generate the lists of links under each heading on the different drop down pages.

I've populated them with categories as close to the ones described in the ticket, but it's assumed that when we progress with this, part of the work will include some reorganisation of the existing categories.

I've used the [ActiveHash](https://github.com/zilkey/active_hash) library as the basis for the clumps here, but also explored an ActiveRecord based approach [in another branch](https://github.com/moneyadviceservice/cms/tree/7755-navigation-categories-activerecord).