### PR TITLE
[DEV APPROVED] 7805 - "clumps" - models/schema changes, initial data, api, admin view

### DIFF
--- a/app/controllers/api/clumps_controller.rb
+++ b/app/controllers/api/clumps_controller.rb
@@ -1,0 +1,33 @@
+module API
+  class InvalidLocale < Exception;  end
+
+  class ClumpsController < ApplicationController
+    skip_before_action :load_cms_page
+    around_filter :validate_locale
+
+    def index
+      @clumps = Clump.all
+      render json: @clumps, scope: locale
+    end
+
+    private
+
+    def locale
+      fail InvalidLocale.new unless params[:locale].in?(accepted_locales)
+
+      params[:locale]
+    end
+
+    def validate_locale
+      yield
+    rescue InvalidLocale
+      render json: {
+        error: "Unaccepted locale (must be #{accepted_locales.join(' ')})"
+      }, status: 400
+    end
+
+    def accepted_locales
+      @accepted_locales ||= Comfy::Cms::Site.pluck(:path)
+    end
+  end
+end

--- a/app/controllers/clumps_controller.rb
+++ b/app/controllers/clumps_controller.rb
@@ -1,0 +1,7 @@
+class ClumpsController < Comfy::Admin::Cms::BaseController
+
+  def index
+    @clumps = Clump.all
+  end
+
+end

--- a/app/helpers/main_menu_helper.rb
+++ b/app/helpers/main_menu_helper.rb
@@ -25,6 +25,7 @@ module MainMenuHelper
           MenuLink.new(name: t('comfy.admin.cms.base.users'),    path: users_path),
           MenuLink.new(name: t('comfy.admin.cms.base.tags'),     path: tags_path),
           MenuLink.new(name: t('comfy.admin.cms.base.categories'), path: categories_path),
+          MenuLink.new(name: t('comfy.admin.cms.base.clumps'), path: clumps_path),
           MenuLink.new(name: t('comfy.admin.cms.base.redirects'), path: redirects_path),
           MenuLink.new(
             name: t('comfy.admin.cms.base.page_feedbacks'),

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -1,5 +1,8 @@
 class Clump < ActiveRecord::Base
 
+  has_many :clumpings, -> { order(:ordinal) }, inverse_of: :clump
+  has_many :categories, through: :clumpings
+
   validates :name_en, presence: true
   validates :name_cy, presence: true
   validates :description_en, presence: true

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -1,0 +1,11 @@
+class Clump < ActiveRecord::Base
+
+  validates :name_en, presence: true
+  validates :name_cy, presence: true
+  validates :description_en, presence: true
+  validates :description_cy, presence: true
+  validates :ordinal, presence: true
+
+  default_scope { order(:ordinal) }
+
+end

--- a/app/models/clumping.rb
+++ b/app/models/clumping.rb
@@ -1,0 +1,10 @@
+class Clumping < ActiveRecord::Base
+
+  belongs_to :clump
+  belongs_to :category, class_name: 'Comfy::Cms::Category'
+
+  validates :clump, presence: true
+  validates :category, presence: true
+  validates :ordinal, presence: true
+
+end

--- a/app/models/comfy/cms/category.rb
+++ b/app/models/comfy/cms/category.rb
@@ -13,6 +13,9 @@ class Comfy::Cms::Category < ActiveRecord::Base
 
   has_many :category_promos
 
+  has_many :clumpings, inverse_of: :category
+  has_many :clumps, through: :clumpings
+
   accepts_nested_attributes_for :category_promos, reject_if: ->(promo) { promo[:title].blank? },
                                                   allow_destroy: true
 

--- a/app/serializers/clump_serializer.rb
+++ b/app/serializers/clump_serializer.rb
@@ -1,0 +1,16 @@
+class ClumpSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description
+
+  has_many :categories
+
+  private
+
+  def name
+    scope == 'en' ? object.name_en : object.name_cy
+  end
+
+  def description
+    scope == 'en' ? object.description_en : object.description_cy
+  end
+
+end

--- a/app/views/clumps/index.html.haml
+++ b/app/views/clumps/index.html.haml
@@ -1,0 +1,26 @@
+.l-panel-content.l-panel-content--form
+  .l-constrained
+    .l-panel-content__row
+      .l-panel-content__col
+        %h1 Clumps
+
+.l-panel-content
+  .l-constrained
+    %p Clumps and the categories they contain
+
+    %ul.sortable-list
+      - @clumps.each do |clump|
+        %li
+          <b>Clump:</b> #{clump.name_en} / #{clump.name_cy}
+          %p
+            #{clump.description_en} / #{clump.description_cy}
+
+          %ul
+            - clump.categories.each do |category|
+              %li
+                <b>Category:</b> #{link_to category.title_en, category_path(category)}
+
+                %ul
+                  - category.child_categories.each do |child|
+                    %li
+                      <b>Child category:</b> #{link_to child.title_en, category_path(child)}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
       collection { put :reorder }
     end
 
+    resources :clumps, only: :index
+
     resources :tags, only: [:index, :create] do
       collection do
         get :starting_by

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ Rails.application.routes.draw do
   end
 
   namespace :api, path: '/' do
+    get '/:locale/clumps(.:format)' => 'clumps#index'
+
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
     get '/preview/:locale/(*slug)(.:format)' => 'content#preview'

--- a/db/migrate/20161118113307_create_clumps.rb
+++ b/db/migrate/20161118113307_create_clumps.rb
@@ -1,0 +1,13 @@
+class CreateClumps < ActiveRecord::Migration
+  def change
+    create_table :clumps do |t|
+      t.string :name_en
+      t.string :name_cy
+      t.text :description_en
+      t.text :description_cy
+      t.integer :ordinal
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161118115306_create_clumpings.rb
+++ b/db/migrate/20161118115306_create_clumpings.rb
@@ -1,0 +1,11 @@
+class CreateClumpings < ActiveRecord::Migration
+  def change
+    create_table :clumpings do |t|
+      t.integer :clump_id
+      t.integer :category_id
+      t.integer :ordinal
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161118135342_create_initial_clumps.rb
+++ b/db/migrate/20161118135342_create_initial_clumps.rb
@@ -1,0 +1,109 @@
+class CreateInitialClumps < ActiveRecord::Migration
+  def change
+    Clump.create! do |clump|
+      clump.ordinal = 1
+      clump.name_en = 'Debt & Borrowing'
+      clump.name_cy = 'Dyled a benthyca'
+      clump.description_en = 'Taking control of debt, getting free debt advice, and how to borrow affordably'
+      clump.description_cy = 'Cymryd rheolaeth o ddyled, cael cyngor am ddim ar ddyledion, a sut i fenthyg fforddiadwy'
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 1
+        clumping.category = Comfy::Cms::Category.find_by(label: 'debt-and-borrowing')
+      end
+    end
+
+    Clump.create! do |clump|
+      clump.ordinal = 2
+      clump.name_en = 'Homes & Mortgages'
+      clump.name_cy = 'Cymorth gyda morgeisi'
+      clump.description_en = 'Everything you need to know about buying a home and choosing the right mortgage'
+      clump.description_cy = 'Popeth sydd angen i chi ei wybod am brynu cartref a dewis y morgais cywir'
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 1
+        clumping.category = Comfy::Cms::Category.find_by(label: 'homes-and-mortgages')
+      end
+    end
+
+    Clump.create! do |clump|
+      clump.ordinal = 3
+      clump.name_en = 'Managing Money'
+      clump.name_cy = 'Rheoli arian'
+      clump.description_en = 'Advice on running a bank account, planning your finances, and cutting costs'
+      clump.description_cy = 'Cyngor ar redeg cyfrif banc, cynllunio eich sefyllfa ariannol, a thorri costau'
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 1
+        clumping.category = Comfy::Cms::Category.find_by(label: 'budgeting-and-managing-money')
+      end
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 2
+        clumping.category = Comfy::Cms::Category.find_by(label: 'saving-and-investing')
+      end
+    end
+
+    Clump.create! do |clump|
+      clump.ordinal = 4
+      clump.name_en = 'Work, Benefits & Pension'
+      clump.name_cy = 'Gwaith, Budddaliadau a Pensiwn'
+      clump.description_en = 'Find out what benefits you\'re entitled to and learn about Universal Credit'
+      clump.description_cy = 'Cael gwybod pa fudd-daliadau mae gennych hawl iddo a dysgu am Gredyd Cynhwysol'
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 1
+        clumping.category = Comfy::Cms::Category.find_by(label: 'pensions-and-retirement')
+      end
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 2
+        clumping.category = Comfy::Cms::Category.find_by(label: 'benefits')
+      end
+    end
+
+    Clump.create! do |clump|
+      clump.ordinal = 5
+      clump.name_en = 'Family'
+      clump.name_cy = 'Teulu'
+      clump.description_en = 'Having a baby, making a will, and dealing with divorce and separation'
+      clump.description_cy = 'Cael babi, gwneud ewyllys, a delio â ysgaru a gwahanu'
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 1
+        clumping.category = Comfy::Cms::Category.find_by(label: 'births-deaths-and-family')
+      end
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 2
+        clumping.category = Comfy::Cms::Category.find_by(label: 'care-and-disability')
+      end
+    end
+
+    Clump.create! do |clump|
+      clump.ordinal = 6
+      clump.name_en = 'Cars & Travel'
+      clump.name_cy = 'Ceir a theithio'
+      clump.description_en = 'Help with buying, running and selling a car, buying foreign currency, and sending money abroad'
+      clump.description_cy = 'Help gyda phrynu, rhedeg a gwerthu car, prynu arian tramor, ac anfon arian dramor'
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 1
+        clumping.category = Comfy::Cms::Category.find_by(label: 'cars-and-travel')
+      end
+    end
+
+    Clump.create! do |clump|
+      clump.ordinal = 7
+      clump.name_en = 'Insurance'
+      clump.name_cy = 'Yswiriant'
+      clump.description_en = 'Help and advice on protecting your family and getting the right home and car insurance'
+      clump.description_cy = 'Cymorth a chyngor ar ddiogelu eich teulu a chael y yswiriant cartref a car cywir'
+
+      clump.clumpings.build do |clumping|
+        clumping.ordinal = 1
+        clumping.category = Comfy::Cms::Category.find_by(label: 'insurance')
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161118115306) do
+ActiveRecord::Schema.define(version: 20161118135342) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161118113307) do
+ActiveRecord::Schema.define(version: 20161118115306) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"
@@ -23,6 +23,14 @@ ActiveRecord::Schema.define(version: 20161118113307) do
   end
 
   add_index "category_promos", ["locale"], name: "index_category_promos_on_locale", using: :btree
+
+  create_table "clumpings", force: true do |t|
+    t.integer  "clump_id"
+    t.integer  "category_id"
+    t.integer  "ordinal"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "clumps", force: true do |t|
     t.string   "name_en"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161014135133) do
+ActiveRecord::Schema.define(version: 20161118113307) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"
@@ -23,6 +23,16 @@ ActiveRecord::Schema.define(version: 20161014135133) do
   end
 
   add_index "category_promos", ["locale"], name: "index_category_promos_on_locale", using: :btree
+
+  create_table "clumps", force: true do |t|
+    t.string   "name_en"
+    t.string   "name_cy"
+    t.text     "description_en"
+    t.text     "description_cy"
+    t.integer  "ordinal"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "comfy_cms_blocks", force: true do |t|
     t.string   "identifier",                      null: false


### PR DESCRIPTION
This is a formalising of the work spiked in ticket 7755.

* `Clump` model, consisting of names and descriptions in English and Welsh, plus an ordinal column
* `Clumping` model to associate clumps with categories, again with an ordinal column for ordering
* A migration to populate some initial clumps and categories to go in them. This populates the clumps as best as we can with the categories that currently exist and @jriga's next tranche of work will include a script to modify the categories and that will also take care of populating the clumps with the correct new categories
* An api end point at `/:locale/clumps.json`
* A page in the back end that displays the clump/category hierarchy
