### PR TITLE
[DEV APPROVED] Adding new snippet to CMS for Tools Callout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,7 @@ gem 'clockwork'
 gem 'paper_trail'
 gem 'feature'
 gem 'httparty', '~> 0.13.7'
-
-gem 'mastalk', '~> 0.7.0'
+gem 'mastalk', '~> 0.8.0'
 gem 'mailjet'
 gem 'paperclip-azure', '~> 0.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mastalk (0.7.0)
+    mastalk (0.8.1)
       htmlentities (~> 4.3.2, >= 4.3.2)
       kramdown (~> 1.5.0, >= 1.5.0)
     method_source (0.8.2)
@@ -597,7 +597,7 @@ DEPENDENCIES
   launchy
   legato (= 0.4.0)
   mailjet
-  mastalk (~> 0.7.0)
+  mastalk (~> 0.8.0)
   mysql2
   newrelic_rpm
   oauth2 (= 1.0.0)

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
@@ -102,6 +102,7 @@ define([
     this.editorLib.editor.use(scribePluginMastalk('videoVimeo'));
     this.editorLib.editor.use(scribePluginMastalk('video'));
     this.editorLib.editor.use(scribePluginMastalk('callout'));
+    this.editorLib.editor.use(scribePluginMastalk('calloutTool'));
     this.editorLib.editor.use(scribePluginMastalk('table'));
     this.editorLib.editor.use(scribePluginMastalk('bullets'));
     this.editorLib.editor.use(scribePluginMastalk('promoBlock'));

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/snippets-model.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/snippets-model.js
@@ -7,6 +7,7 @@ define([], function () {
     bullets: '$bullet\r\n[%] point 1 [\/%]\r\n[%] point 2 [\/%]\r\n$point',
     collapsible: '$=\r\n# Before you borrow\r\n=$\r\n\r\n$-\r\nFind out if you need to borrow money and whether you can afford it. Learn how to work out the true cost of borrowing.\r\n\r\nTaking control of debt\r\n\r\nWhere to get free debt advice, how to speak to the people you owe money to, and tips to help you pay back your debts in the right order.\r\n-$',
     callout: '$~callout\r\n# Budgeting tips\r\nIn 1985, average first-time buyers needed a deposit of 5% to buy a home - in 2012, this had increased to 20%\r\n*Source: HMS Treasury*\r\n~$\r\n',
+    calloutTool: '$~tool-callout\r\n# Budget Planner\r\nUse our Budget Planer\r\n~$\r\n',
     promoBlock: '$bl\r\n\r\n$bl_m\r\n\r\nbl_m$\r\n\r\n$bl_c\r\n\r\nbl_c$\r\n\r\nbl$',
     table: '| Equity loans | Mortgage guarantees\r\n|---|---\r\n | New-build properties | New-build and pre-owned properties\r\n| Minimum 5% deposit | Minimum 5% deposit\r\n\r\nA caption for the table\r\n{: .caption}\r\n',
     ticks: '$yes-no\r\n[y] yes [\/y]\r\n[n] no [\/n]\r\n$end',

--- a/app/views/comfy/admin/cms/pages/_toolbar.haml
+++ b/app/views/comfy/admin/cms/pages/_toolbar.haml
@@ -19,6 +19,8 @@
               %li.menu__item
                 =button_tag('Call out box', type: 'button', class: 'menu__action', data: { dough_snippetinserter_trigger:'callout', dough_snippetinserter_context: 'markdown-snippets'})
               %li.menu__item
+                =button_tag('Call out box - Tool', type: 'button', class: 'menu__action', data: { dough_snippetinserter_trigger:'calloutTool', dough_snippetinserter_context: 'markdown-snippets'})
+              %li.menu__item
                 =button_tag('Ticks', type: 'button', class: 'menu__action', data: { dough_snippetinserter_trigger:'ticks', dough_snippetinserter_context: 'markdown-snippets'})
               %li.menu__item
                 =button_tag("Bullets", type: 'button', class: 'menu__action', data: { dough_snippetinserter_trigger: 'bullets', dough_snippetinserter_context: 'markdown-snippets'})
@@ -75,6 +77,8 @@
                 =button_tag('Add action', type: 'button', class: 'menu__action', data: { 'command-name' => 'mastalk_addAction'})
               %li.menu__item
                 =button_tag('Call out box', type: 'button', class: 'menu__action', data: { 'command-name' => 'mastalk_callout'})
+              %li.menu__item
+                =button_tag('Call out box - Tools', type: 'button', class: 'menu__action', data: { 'command-name' => 'mastalk_calloutTool'})
               %li.menu__item
                 =button_tag('Ticks', type: 'button', class: 'menu__action', data: { 'command-name' => 'mastalk_ticks'})
               %li.menu__item


### PR DESCRIPTION
This is part of a collection of 4 pull requests across 4 repos, concerning the **'Callout'** module that we have within most articles:

![image](https://cloud.githubusercontent.com/assets/14920201/20713527/87caa524-b640-11e6-84bb-356c188ef265.png)

### Linked PRs:
- [Frontend - 7757 - Adding icon for Tool callout box](https://github.com/moneyadviceservice/frontend/pull/1612)
- [Yeast - 7757 - New styles for Callout module](https://github.com/moneyadviceservice/yeast/pull/24)
- [MASTALK - 7757- New callout tool snippet](https://github.com/moneyadviceservice/mastalk/pull/21)

## Changes

- Restyling the default Callout module to use the turquoise style below
- Adding a new 'Tools' Callout module that can be used by editors to differentiate our Tools from different types of content

![image](https://cloud.githubusercontent.com/assets/14920201/20713517/7aaa9052-b640-11e6-8a06-5ede61fb23ae.png)

## This PR...
...Adds the new MASTalk snippet to the CMS so that editors can insert it.