### PR TITLE
7758 - initial clump administration

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -46,7 +46,7 @@ class CategoriesController < Comfy::Admin::Cms::BaseController
 
   def category_params
     params.require(:comfy_cms_category).permit(
-      :label, :parent_id, :title_en, :title_cy, :description_en,
+      :label, :parent_id, :clump_id, :title_en, :title_cy, :description_en,
       :description_cy, :ordinal, :navigation, :third_level_navigation,
       :site_id, :categorized_type, :large_image_id, :small_image_id,
       links_attributes: [:text, :url, :locale, :id, :_destroy],

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -1,7 +1,9 @@
 class Clump < ActiveRecord::Base
 
   has_many :clumpings, -> { order(:ordinal) }, inverse_of: :clump
-  has_many :categories, through: :clumpings
+
+  # Category model has a default scope on label, so have to override this
+  has_many :categories, -> { reorder('clumpings.ordinal ASC') }, through: :clumpings
 
   validates :name_en, presence: true
   validates :name_cy, presence: true

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -13,4 +13,10 @@ class Clump < ActiveRecord::Base
 
   default_scope { order(:ordinal) }
 
+  before_validation :set_default_ordinal, on: :create
+
+  def set_default_ordinal
+    self.ordinal ||= Clump.count
+  end
+
 end

--- a/app/models/clumping.rb
+++ b/app/models/clumping.rb
@@ -7,4 +7,10 @@ class Clumping < ActiveRecord::Base
   validates :category, presence: true
   validates :ordinal, presence: true
 
+  before_validation :set_default_ordinal, on: :create
+
+  def set_default_ordinal
+    self.ordinal ||= clump.clumpings.count
+  end
+
 end

--- a/app/models/comfy/cms/category.rb
+++ b/app/models/comfy/cms/category.rb
@@ -13,8 +13,8 @@ class Comfy::Cms::Category < ActiveRecord::Base
 
   has_many :category_promos
 
-  has_many :clumpings, inverse_of: :category
-  has_many :clumps, through: :clumpings
+  has_one :clumping, inverse_of: :category
+  has_one :clump, through: :clumping
 
   accepts_nested_attributes_for :category_promos, reject_if: ->(promo) { promo[:title].blank? },
                                                   allow_destroy: true

--- a/app/models/comfy/cms/category.rb
+++ b/app/models/comfy/cms/category.rb
@@ -35,6 +35,18 @@ class Comfy::Cms::Category < ActiveRecord::Base
     @parent ||= self.class.find_by(id: parent_id)
   end
 
+  def clump_id
+    clump.try(:id)
+  end
+
+  def clump_id=(new_clump_id)
+    if new_clump_id.blank?
+      self.clump = nil
+    else
+      self.clump = Clump.find(new_clump_id)
+    end
+  end
+
   private
 
   def find_parents

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -26,6 +26,7 @@
           %h2 Category details
           = comfy_form_for @category, url: {action: 'update'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
             = f.collection_select :parent_id, Comfy::Cms::Category.where(site_id: 1).reorder(:label), :id, :label, include_blank: true
+            = f.collection_select :clump_id, Clump.reorder(:name_en), :id, :name_en, include_blank: true
             = f.text_field :title_en
             = f.text_field :title_cy
             = f.text_field :description_en

--- a/app/views/clumps/index.html.haml
+++ b/app/views/clumps/index.html.haml
@@ -2,25 +2,25 @@
   .l-constrained
     .l-panel-content__row
       .l-panel-content__col
-        %h1 Clumps
+        %h1 Clump Manager
+      .l-panel-content__col.l-panel-content__col--right
+        = link_to new_clump_path, class: 'button--action' do
+          %span.button__text
+            = t('clumps.listing.create')
 
-.l-panel-content
+
+= form_tag(reorder_clumps_path, method: 'put') do |f|
+  .l-panel-content
+    .l-constrained
+      %p Clumps used to group categories in the navigation bar
+      %ol.sortable-list{data: {dough_component: :ListSorter, dough_listsorter_context: 'clump-order'}}
+        -@clumps.each do |clump|
+          %li.sortable-list__item{data: {dough_listsorter_item_id: clump.id}}
+            = link_to clump.name_en, clump_path(clump), class: 'sortable-list__link'
+
+  = hidden_field_tag 'order', nil, data: { dough_listsorter_order_field: true, dough_listsorter_context: 'clump-order'}
   .l-constrained
-    %p Clumps and the categories they contain
-
-    %ul.sortable-list
-      - @clumps.each do |clump|
-        %li
-          <b>Clump:</b> #{clump.name_en} / #{clump.name_cy}
-          %p
-            #{clump.description_en} / #{clump.description_cy}
-
-          %ul
-            - clump.categories.each do |category|
-              %li
-                <b>Category:</b> #{link_to category.title_en, category_path(category)}
-
-                %ul
-                  - category.child_categories.each do |child|
-                    %li
-                      <b>Child category:</b> #{link_to child.title_en, category_path(child)}
+    .panel.panel--centered
+      = button_tag class: 'button--action' do
+        %span.button__text
+          = t('clumps.listing.submit.update_order')

--- a/app/views/clumps/new.html.haml
+++ b/app/views/clumps/new.html.haml
@@ -1,0 +1,23 @@
+.l-panel-content.l-panel-content--form
+  .l-constrained
+    .l-panel-content__row
+      .l-panel-content__col
+        %h1 Clump Manager
+
+.l-panel-content
+  .l-constrained
+    %h2.breadcrumb
+      = @clump.name_en
+
+    %h2 Clump details
+    = comfy_form_for @clump, url: {action: 'create'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
+      = f.text_field :name_en
+      = f.text_field :name_cy
+      = f.text_field :description_en
+      = f.text_field :description_cy
+
+      .form-group
+        .form__input-wrapper
+          = button_tag class: 'button--action' do
+            %span.button__text
+              = t('categories.edit.submit.create')

--- a/app/views/clumps/show.html.haml
+++ b/app/views/clumps/show.html.haml
@@ -1,0 +1,39 @@
+.l-panel-content.l-panel-content--form
+  .l-constrained
+    .l-panel-content__row
+      .l-panel-content__col
+        %h1 Clump Manager
+
+.l-panel-content
+  .l-constrained
+    %h2.breadcrumb
+      = @clump.name_en
+
+    .l-panel-content__row
+      .l-split-content
+        .l-split-content__col
+          %h2 Clump details
+          = comfy_form_for @clump, url: {action: 'update'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
+            = f.text_field :name_en
+            = f.text_field :name_cy
+            = f.text_field :description_en
+            = f.text_field :description_cy
+            = hidden_field_tag 'category_order', nil , data: { dough_listsorter_order_field: true, dough_listsorter_context: 'category-order'}
+
+            %hr.roomy
+
+            .form-group
+              .form__input-wrapper
+                = button_tag class: 'button--action' do
+                  %span.button__text
+                    = t('categories.edit.submit.update')
+
+        .l-split-content__col
+          %h2 Categories
+          - if @clump.categories.present?
+            %ol.sortable-list{data: {dough_component: :ListSorter, dough_listsorter_context: 'category-order'}}
+              -@clump.categories.each do |category|
+                %li.sortable-list__item{data: {dough_listsorter_item_id: category.id}}
+                  = link_to category.label, category_path(category), class: 'sortable-list__link'
+          - else
+            %p No categories allocated

--- a/config/locales/clumps.yml
+++ b/config/locales/clumps.yml
@@ -1,0 +1,10 @@
+en:
+  clumps:
+    listing:
+      create: Create clump
+      submit:
+        update_order: Update order
+    edit:
+      submit:
+        create: Create clump
+        update: Update clump

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,9 @@ Rails.application.routes.draw do
       collection { put :reorder }
     end
 
-    resources :clumps, only: :index
+    resources :clumps, except: :destroy do
+      collection { put :reorder }
+    end
 
     resources :tags, only: [:index, :create] do
       collection do

--- a/spec/controllers/clumps_controller_spec.rb
+++ b/spec/controllers/clumps_controller_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe ClumpsController, type: :controller do
+  let(:site) { create(:site) }
+  let(:current_user) { create(:user) }
+  let!(:category_1) { create(:category) }
+  let!(:category_2) { create(:category) }
+  let!(:clump) { create(:clump, categories: [category_1, category_2]) }
+
+  before do
+    sign_in current_user
+  end
+
+  describe '#create' do
+    let(:params) do
+      {
+        site_id: site,
+        id: clump,
+        clump: {
+          name_en: Faker::Lorem.sentence,
+          name_cy: Faker::Lorem.sentence,
+          description_en: Faker::Lorem.paragraph,
+          description_cy: Faker::Lorem.paragraph
+        },
+        category_order: "#{category_1.id}, #{category_2.id}"
+      }
+    end
+
+    context 'when the params are invalid' do
+      before { params[:clump][:name_en] = '' }
+
+      it 'does not create the new record' do
+        expect { post :create, params }.not_to change { Clump.count }
+      end
+
+      it 'renders the new template' do
+        post :create, params
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the params are valid' do
+      it 'creates the new record' do
+        expect { post :create, params }.to change { Clump.count }.by(1)
+      end
+
+      it 'redirects to the show page' do
+        post :create, params
+        expect(response).to redirect_to(action: :show, id: assigns(:clump).id)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:params) do
+      {
+        site_id: site,
+        id: clump,
+        clump: {
+          name_en: clump.name_en,
+          name_cy: clump.name_cy,
+          description_en: clump.description_en,
+          description_cy: clump.description_cy
+        },
+        category_order: "#{category_1.id}, #{category_2.id}"
+      }
+    end
+
+    context 'when the params are invalid' do
+      before { params[:clump][:name_en] = '' }
+
+      it 'does not save the change' do
+        patch :update, params
+        expect(clump.reload.name_en).to eq clump.name_en
+      end
+
+      it 'renders the new template' do
+        patch :update, params
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'when the params are valid' do
+      let(:new_name_en) { Faker::Lorem.sentence }
+      before { params[:clump][:name_en] = new_name_en }
+
+      it 'saves the changes' do
+        patch :update, params
+        expect(clump.reload.name_en).to eq new_name_en
+      end
+
+      it 'redirects to the show page' do
+        patch :update, params
+        expect(response).to redirect_to(action: :show)
+      end
+    end
+
+    context 'reordering the categories' do
+      before { params[:category_order] = "#{category_2.id}, #{category_1.id}" }
+
+      it 'updates the order of the categories' do
+        patch :update, params
+        expect(clump.reload.categories).to eq([category_2, category_1])
+      end
+    end
+  end
+
+  describe '#reorder' do
+    let(:second_clump) { create(:clump) }
+
+    it 'updates the order of the clumps' do
+      patch :reorder, site_id: site, order: "#{second_clump.id}, #{clump.id}"
+      expect(Clump.order(:ordinal)).to eq([second_clump, clump])
+    end
+  end
+end

--- a/spec/factories/clumpings.rb
+++ b/spec/factories/clumpings.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :clumping do
+    association :clump
+    association :category
+  end
+end

--- a/spec/factories/clumps.rb
+++ b/spec/factories/clumps.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :clump do
+    name_en { Faker::Lorem.sentence }
+    name_cy { Faker::Lorem.sentence }
+    description_en { Faker::Lorem.paragraph }
+    description_cy { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/models/clump_spec.rb
+++ b/spec/models/clump_spec.rb
@@ -1,0 +1,24 @@
+describe Clump do
+  describe 'validations' do
+    # Test validation on a saved record, to avoid complication
+    # arising from the default population of ordinal
+    subject { create(:clump) }
+
+    it { should validate_presence_of(:name_en) }
+    it { should validate_presence_of(:name_cy) }
+    it { should validate_presence_of(:description_en) }
+    it { should validate_presence_of(:description_cy) }
+    it { should validate_presence_of(:ordinal) }
+  end
+
+  describe 'default ordinal' do
+    it 'is present on a new clump' do
+      expect(create(:clump).ordinal).to be_present
+    end
+
+    it 'is numbered appropriately' do
+      rand(1..5).times { create(:clump) }
+      expect(create(:clump).ordinal).to eq(Clump.count - 1)
+    end
+  end
+end

--- a/spec/models/clumping_spec.rb
+++ b/spec/models/clumping_spec.rb
@@ -1,0 +1,26 @@
+describe Clumping do
+  let(:clump) { create(:clump) }
+
+  describe 'validations' do
+    # Test validation on a saved record, to avoid complication
+    # arising from the default population of ordinal
+    subject { create(:clumping, clump: clump) }
+
+    it { should validate_presence_of(:clump) }
+    it { should validate_presence_of(:category) }
+    it { should validate_presence_of(:ordinal) }
+  end
+
+  describe 'default ordinal' do
+    let(:clumping) { create(:clumping, clump: clump, category: create(:category)) }
+
+    it 'is present on a new clump' do
+      expect(clumping.ordinal).to be_present
+    end
+
+    it 'is numbered appropriately' do
+      rand(1..5).times { create(:clumping, clump: clump, category: create(:category)) }
+      expect(clumping.ordinal).to eq(clump.reload.clumpings.count - 1)
+    end
+  end
+end

--- a/spec/models/comfy/cms/category_spec.rb
+++ b/spec/models/comfy/cms/category_spec.rb
@@ -45,4 +45,44 @@ RSpec.describe Comfy::Cms::Category do
     it { expect(described_class.new).to belong_to(:small_image) }
     it { expect(described_class.new).to belong_to(:large_image) }
   end
+
+  describe '#clump_id' do
+    let(:subject) { create(:category) }
+
+    context 'when there is a clumping' do
+      let!(:clumping) { create(:clumping, category: subject) }
+
+      it 'returns the clump id from the clumping' do
+        expect(subject.clump_id).to eq(clumping.clump_id)
+      end
+    end
+
+    context 'when there is no clumping' do
+      it 'returns nil' do
+        expect(subject.clump_id).to be_nil
+      end
+    end
+  end
+
+  describe '#clump_id=' do
+    let(:subject) { create(:category) }
+    let(:clump) { create(:clump) }
+
+    context 'assigning a new clump' do
+
+      it 'associates the clump (through a clumping)' do
+        subject.clump_id = clump.id
+        expect(subject.reload.clump).to eq(clump)
+      end
+    end
+
+    context 'unassigning a clump' do
+      before { create(:clumping, clump: clump, category: subject) }
+
+      it 'removes the clump (and clumping)' do
+        subject.clump_id = nil
+        expect(subject.clump).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
This ticket is being split off into two tickets. It originally was for adding an interface for editing aspects of the clumps including the tool links, however we still need to do some backend work for those tool links, that portion is being put into a new ticket.  This PR now solely deals with adding some interface for the parts of the clumps which already exists (titles, descriptions, categories).

The interface I've implemented here largely mirrors that of the categories.

We can create, edit and reorder clumps (but, like with categories, not delete them).

We can reorder the categories in the clumps via the category#show page.

We can (un)assign categories to clumps via the category#edit page.