### PR TITLE
7831 - (tool) links in clumps

### DIFF
--- a/app/controllers/clumps_controller.rb
+++ b/app/controllers/clumps_controller.rb
@@ -9,7 +9,9 @@ class ClumpsController < Comfy::Admin::Cms::BaseController
   end
 
   def new
-    @clump = Clump.new
+    @clump = Clump.new do |clump|
+      4.times { clump.clump_links.build }
+    end
   end
 
   def create
@@ -46,8 +48,19 @@ class ClumpsController < Comfy::Admin::Cms::BaseController
     redirect_to clumps_path
   end
 
+  PERMITTED_PARAMS = [
+    :name_en, :name_cy,
+    :description_en, :description_cy,
+    clump_links_attributes: [
+      :id,
+      :text_en, :text_cy,
+      :url_en, :url_cy,
+      :style
+    ]
+  ]
+
   def clump_params
-    params.require(:clump).permit(:name_en, :name_cy, :description_en, :description_cy)
+    params.require(:clump).permit(PERMITTED_PARAMS)
   end
 
 end

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -5,6 +5,8 @@ class Clump < ActiveRecord::Base
   # Category model has a default scope on label, so have to override this
   has_many :categories, -> { reorder('clumpings.ordinal ASC') }, through: :clumpings
 
+  has_many :clump_links
+
   validates :name_en, presence: true
   validates :name_cy, presence: true
   validates :description_en, presence: true

--- a/app/models/clump.rb
+++ b/app/models/clump.rb
@@ -7,6 +7,8 @@ class Clump < ActiveRecord::Base
 
   has_many :clump_links
 
+  accepts_nested_attributes_for :clump_links
+
   validates :name_en, presence: true
   validates :name_cy, presence: true
   validates :description_en, presence: true

--- a/app/models/clump_link.rb
+++ b/app/models/clump_link.rb
@@ -1,0 +1,5 @@
+class ClumpLink < ActiveRecord::Base
+
+  belongs_to :clump
+
+end

--- a/app/models/clump_link.rb
+++ b/app/models/clump_link.rb
@@ -12,4 +12,8 @@ class ClumpLink < ActiveRecord::Base
     [text_en, text_cy, url_en, url_cy, style].all?(&:blank?)
   end
 
+  def complete?
+    [text_en, text_cy, url_en, url_cy, style].all?(&:present?)
+  end
+
 end

--- a/app/models/clump_link.rb
+++ b/app/models/clump_link.rb
@@ -2,4 +2,14 @@ class ClumpLink < ActiveRecord::Base
 
   belongs_to :clump
 
+  validates :text_en, presence: true, unless: :empty?
+  validates :text_cy, presence: true, unless: :empty?
+  validates :url_en, presence: true, unless: :empty?
+  validates :url_cy, presence: true, unless: :empty?
+  validates :style, presence: true, unless: :empty?
+
+  def empty?
+    [text_en, text_cy, url_en, url_cy, style].all?(&:blank?)
+  end
+
 end

--- a/app/serializers/clump_link_serializer.rb
+++ b/app/serializers/clump_link_serializer.rb
@@ -1,0 +1,13 @@
+class ClumpLinkSerializer < ActiveModel::Serializer
+  attributes :id, :text, :url, :style
+
+  private
+
+  def text
+    scope == 'en' ? object.text_en : object.text_cy
+  end
+
+  def url
+    scope == 'en' ? object.url_en : object.url_cy
+  end
+end

--- a/app/serializers/clump_serializer.rb
+++ b/app/serializers/clump_serializer.rb
@@ -1,5 +1,5 @@
 class ClumpSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description
+  attributes :id, :name, :description, :links
 
   has_many :categories
 
@@ -13,4 +13,9 @@ class ClumpSerializer < ActiveModel::Serializer
     scope == 'en' ? object.description_en : object.description_cy
   end
 
+  def links
+    object.clump_links.select(&:complete?).map do |link|
+      ClumpLinkSerializer.new(link, scope_name: :locale)
+    end
+  end
 end

--- a/app/views/clumps/_link_fields.html.haml
+++ b/app/views/clumps/_link_fields.html.haml
@@ -1,0 +1,19 @@
+- f.object.clump_links.each_with_index do |link, index|
+  = f.fields_for :clump_links, link do |l|
+    - unless l.object.new_record?
+      = l.hidden_field :id
+
+    .l-panel-content
+      .l-constrained
+        %h2 Link ##{index + 1}
+
+        .l-panel-content__row
+          .l-split-content
+            .l-split-content__col
+              = l.text_field :text_en
+              = l.text_field :url_en
+              = l.text_field :style
+
+            .l-split-content__col
+              = l.text_field :text_cy
+              = l.text_field :url_cy

--- a/app/views/clumps/new.html.haml
+++ b/app/views/clumps/new.html.haml
@@ -1,23 +1,29 @@
-.l-panel-content.l-panel-content--form
-  .l-constrained
-    .l-panel-content__row
-      .l-panel-content__col
-        %h1 Clump Manager
+= comfy_form_for @clump, url: {action: 'create'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
+  .l-panel-content.l-panel-content--form
+    .l-constrained
+      .l-panel-content__row
+        .l-panel-content__col
+          %h1 Clump Manager
 
-.l-panel-content
-  .l-constrained
-    %h2.breadcrumb
-      = @clump.name_en
+  .l-panel-content
+    .l-constrained
+      %h2.breadcrumb
+        = @clump.name_en
 
-    %h2 Clump details
-    = comfy_form_for @clump, url: {action: 'create'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
+      %h2 Clump details
       = f.text_field :name_en
       = f.text_field :name_cy
       = f.text_field :description_en
       = f.text_field :description_cy
 
+  %hr.roomy
+
+  = render partial: 'link_fields', locals: { f: f }
+
+  .l-panel-content
+    .l-constrained
       .form-group
         .form__input-wrapper
           = button_tag class: 'button--action' do
             %span.button__text
-              = t('categories.edit.submit.create')
+              = t('clumps.edit.submit.create')

--- a/app/views/clumps/show.html.haml
+++ b/app/views/clumps/show.html.haml
@@ -1,32 +1,24 @@
-.l-panel-content.l-panel-content--form
-  .l-constrained
-    .l-panel-content__row
-      .l-panel-content__col
-        %h1 Clump Manager
+= comfy_form_for @clump, url: {action: 'update'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
+  .l-panel-content.l-panel-content--form
+    .l-constrained
+      .l-panel-content__row
+        .l-panel-content__col
+          %h1 Clump Manager
 
-.l-panel-content
-  .l-constrained
-    %h2.breadcrumb
-      = @clump.name_en
+  .l-panel-content
+    .l-constrained
+      %h2.breadcrumb
+        = @clump.name_en
 
-    .l-panel-content__row
-      .l-split-content
-        .l-split-content__col
-          %h2 Clump details
-          = comfy_form_for @clump, url: {action: 'update'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
+      .l-panel-content__row
+        .l-split-content
+          .l-split-content__col
+            %h2 Clump details
             = f.text_field :name_en
             = f.text_field :name_cy
             = f.text_field :description_en
             = f.text_field :description_cy
             = hidden_field_tag 'category_order', nil , data: { dough_listsorter_order_field: true, dough_listsorter_context: 'category-order'}
-
-            %hr.roomy
-
-            .form-group
-              .form__input-wrapper
-                = button_tag class: 'button--action' do
-                  %span.button__text
-                    = t('categories.edit.submit.update')
 
         .l-split-content__col
           %h2 Categories
@@ -37,3 +29,17 @@
                   = link_to category.label, category_path(category), class: 'sortable-list__link'
           - else
             %p No categories allocated
+
+  %hr.roomy
+
+  = render partial: 'link_fields', locals: { f: f }
+
+  .l-panel-content
+    .l-constrained
+      %hr.roomy
+
+      .form-group
+        .form__input-wrapper
+          = button_tag class: 'button--action' do
+            %span.button__text
+              = t('categories.edit.submit.update')

--- a/db/migrate/20161207123802_create_clump_links.rb
+++ b/db/migrate/20161207123802_create_clump_links.rb
@@ -1,0 +1,14 @@
+class CreateClumpLinks < ActiveRecord::Migration
+  def change
+    create_table :clump_links do |t|
+      t.integer :clump_id
+      t.string :text_en
+      t.string :text_cy
+      t.string :url_en
+      t.string :url_cy
+      t.string :style
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161208151020_create_links_for_existing_clumps.rb
+++ b/db/migrate/20161208151020_create_links_for_existing_clumps.rb
@@ -1,0 +1,157 @@
+class CreateLinksForExistingClumps < ActiveRecord::Migration
+  def change
+    Clump.find_by(name_en: 'Debt & Borrowing').tap do |clump|
+      clump.clump_links.create! do |link|
+        link.text_en = 'Debt test'
+        link.text_cy = 'Prawf dyled'
+        link.url_en = '/en/tools/debt-test'
+        link.url_cy = '/cy/tools/prawf-dyledion'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Loan calculator'
+        link.text_cy = 'Cyfrifiannell benthyciadau'
+        link.url_en = '/en/tools/loan-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-benthyciadau'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Credit card calculator'
+        link.text_cy = 'Cyfrifiannell cardiau credyd'
+        link.url_en = '/en/tools/credit-card-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-cerdyn-credyd'
+        link.style = 'tool'
+      end
+    end
+
+    Clump.find_by(name_en: 'Homes & Mortgages').tap do |clump|
+      clump.clump_links.create! do |link|
+        link.text_en = 'Mortgage calculator'
+        link.text_cy = 'Cyfrifiannell Morgais'
+        link.url_en = '/en/tools/mortgage-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-morgais'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Mortgage affordability calculator'
+        link.text_cy = 'Cyfrifiannell fforddiadwyedd morgais'
+        link.url_en = '/en/tools/house-buying/mortgage-affordability-calculator'
+        link.url_cy = '/cy/tools/prynu-ty/cyfrifiannell-fforddiadwyedd-morgais'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Stamp Duty calculator'
+        link.text_cy = 'Cyfrifiannell treth stamp'
+        link.url_en = '/en/tools/house-buying/stamp-duty-calculator'
+        link.url_cy = '/cy/tools/prynu-ty/cyfrifiannell-treth-stamp'
+        link.style = 'tool'
+      end
+    end
+
+    Clump.find_by(name_en: 'Managing Money').tap do |clump|
+      clump.clump_links.create! do |link|
+        link.text_en = 'Money Health Check'
+        link.text_cy = 'Gwiriad Iechyd Arian'
+        link.url_en = '/en/tools/health-check'
+        link.url_cy = '/cy/tools/gwiriad-iechyd/start'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Quick cash finder'
+        link.text_cy = 'Canfod arian parod yn gyflym'
+        link.url_en = '/en/tools/quick-cash-finder'
+        link.url_cy = '/cy/tools/canfod-arian-parod-yn-gyflym'
+        link.style = 'tool'
+      end
+    end
+
+    Clump.find_by(name_en: 'Work, Benefits & Pension').tap do |clump|
+      clump.clump_links.create! do |link|
+        link.text_en = 'Pension calculator'
+        link.text_cy = 'Cyfrifiannell pensiwn'
+        link.url_en = '/en/tools/pension-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-pensiwn'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Workplace pension contribution calculator'
+        link.text_cy = 'Cyfrifiannell cyfraniadau pensiwn gweithle'
+        link.url_en = '/en/tools/workplace-pension-contribution-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-cyfraniadau-pensiwn-gweithle'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Redundancy pay calculator'
+        link.text_cy = 'Cyfrifiannell tâl diswyddo'
+        link.url_en = '/en/tools/redundancy-pay-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-tal-diswyddo'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Tax credit calculator'
+        link.text_cy = 'Credyd Treth Gwaith'
+        link.url_en = '/en/articles/working-tax-credit'
+        link.url_cy = '/cy/articles/credyd-treth-gwaith'
+        link.style = 'tool'
+      end
+    end
+
+    Clump.find_by(name_en: 'Family').tap do |clump|
+      clump.clump_links.create! do |link|
+        link.text_en = 'Baby cost calculator'
+        link.text_cy = 'Cyfrifiannell costau babi'
+        link.url_en = '/en/articles/baby-costs-calculator'
+        link.url_cy = '/cy/articles/cyfrifiannell-costau-babi'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Budget planner'
+        link.text_cy = 'Cynlluniwr Cyllideb'
+        link.url_en = '/en/tools/budget-planner'
+        link.url_cy = '/cy/tools/cynllunydd-cyllideb'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Christmas money planner'
+        link.text_cy = 'Cynllunydd Ariannol y Nadolig'
+        link.url_en = '/en/tools/christmas-money-planner'
+        link.url_cy = '/cy/tools/cynllunydd-ariannol-y-nadolig'
+        link.style = 'tool'
+      end
+    end
+
+    Clump.find_by(name_en: 'Cars & Travel').tap do |clump|
+      clump.clump_links.create! do |link|
+        link.text_en = 'Car cost calculator'
+        link.text_cy = 'Cyfrifiannell Costau Car'
+        link.url_en = '/en/tools/car-costs-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-costau-car'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Budget planner'
+        link.text_cy = 'Cynlluniwr Cyllideb'
+        link.url_en = '/en/tools/budget-planner'
+        link.url_cy = '/cy/tools/cynllunydd-cyllideb'
+        link.style = 'tool'
+      end
+      clump.clump_links.create! do |link|
+        link.text_en = 'Credit card calculator'
+        link.text_cy = 'Cyfrifiannell cardiau credyd'
+        link.url_en = '/en/tools/credit-card-calculator'
+        link.url_cy = '/cy/tools/cyfrifiannell-cerdyn-credyd'
+        link.style = 'tool'
+      end
+    end
+
+    Clump.find_by(name_en: 'Insurance').tap do |clump|
+      clump.clump_links.create! do |link|
+        link.text_en = 'Budget planner'
+        link.text_cy = 'Cynlluniwr Cyllideb'
+        link.url_en = '/en/tools/budget-planner'
+        link.url_cy = '/cy/tools/cynllunydd-cyllideb'
+        link.style = 'tool'
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161207123802) do
+ActiveRecord::Schema.define(version: 20161208151020) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161121120920) do
+ActiveRecord::Schema.define(version: 20161207123802) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"
@@ -23,6 +23,17 @@ ActiveRecord::Schema.define(version: 20161121120920) do
   end
 
   add_index "category_promos", ["locale"], name: "index_category_promos_on_locale", using: :btree
+
+  create_table "clump_links", force: true do |t|
+    t.integer  "clump_id"
+    t.string   "text_en"
+    t.string   "text_cy"
+    t.string   "url_en"
+    t.string   "url_cy"
+    t.string   "style"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "clumpings", force: true do |t|
     t.integer  "clump_id"

--- a/spec/models/clump_link_spec.rb
+++ b/spec/models/clump_link_spec.rb
@@ -42,4 +42,28 @@ describe ClumpLink do
       it { should_not be_empty }
     end
   end
+
+  describe '#complete?' do
+    context 'with all attributes are present' do
+      before do
+        subject.text_en = subject.text_cy = subject.url_en = subject.url_cy = subject.style = 'x'
+      end
+
+      it { should be_complete }
+
+      context 'but one is an empty string' do
+        before { subject.text_en = '' }
+        it { should_not be_complete }
+      end
+
+      context 'but one is nil' do
+        before { subject.text_en = nil }
+        it { should_not be_complete }
+      end
+    end
+
+    context 'with no attributes present' do
+      it { should_not be_complete }
+    end
+  end
 end

--- a/spec/models/clump_link_spec.rb
+++ b/spec/models/clump_link_spec.rb
@@ -1,0 +1,45 @@
+describe ClumpLink do
+  describe 'validations' do
+    context 'with no fields complete' do
+      it { should_not validate_presence_of(:text_en) }
+      it { should_not validate_presence_of(:text_cy) }
+      it { should_not validate_presence_of(:url_en) }
+      it { should_not validate_presence_of(:url_cy) }
+      it { should_not validate_presence_of(:style) }
+    end
+
+    context 'with some of the fields complete' do
+      before { subject.text_en = subject.url_en = 'x' }
+
+      it { should validate_presence_of(:text_en) }
+      it { should validate_presence_of(:text_cy) }
+      it { should validate_presence_of(:url_en) }
+      it { should validate_presence_of(:url_cy) }
+      it { should validate_presence_of(:style) }
+    end
+  end
+
+  describe '#empty?' do
+    context 'if all attributes are blank' do
+      it { should be_empty }
+    end
+
+    context 'if an attribute is an empty string' do
+      before { subject.text_en = '' }
+      it { should be_empty }
+    end
+
+    context 'if an attribute is present' do
+      before { subject.text_en = 'x' }
+      it { should_not be_empty }
+    end
+
+    context 'if all attributes are present' do
+      before do
+        subject.text_en = subject.text_cy = subject.url_en = subject.url_cy = subject.style = 'x'
+      end
+
+      it { should_not be_empty }
+    end
+  end
+end


### PR DESCRIPTION
Had a few false starts on this, trying a few different approaches to try and avoid having such a similar model to the existing `Link` model but ended up just going with just that.

The spec for this requires that we can have up to four links in a clump, so in order to simplify the interface we just build four of these when you create a clump and then the interface allows you to edit these but not add or remove any.  Validation allows you to either leave some blank or requires you to populate them entirely, and when rendering the json we  only show the complete ones.

I tried various approaches to reuse the existing model but it wasn't suitable for STI (the subclass of Link would have to remove the validation applied in the parent) and when I tried adding conditionals based on the `linkable` to validation things started to get unnecessarily complex.

The starter clump information was pulled out of the static mock up @davidtrussler did, but I expect will be subject to change in the future.

Also included in the `ClumpLink` model is a `style` field which is intended to be used to style the links, as these links might not always be tools. This is currently free text, but I would hope we can define some permitted values and change the interface to a drop down.