### PR TITLE
[DEV APPROVED] Speed up CMS article requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test, :development do
   gem 'valid_attribute', require: false
   gem 'dotenv-rails'
   gem 'launchy'
+  gem 'ruby-prof', require: false
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
 
-gem 'comfortable_mexican_sofa', '~>2.0.1', path: '../comfortable-mexican-sofa'# git: 'git@github.com:moneyadviceservice/comfortable-mexican-sofa.git'
+gem 'comfortable_mexican_sofa', '2.0.1.79.79', source: 'http://gems.dev.mas.local'
 
 gem 'word-to-markdown', git: 'https://github.com/moneyadviceservice/word-to-markdown.git'
 
@@ -39,7 +39,7 @@ gem 'clockwork'
 gem 'paper_trail'
 gem 'feature'
 gem 'httparty', '~> 0.13.7'
-gem 'mastalk', '~> 0.8.0'
+gem 'mastalk', '0.9.0'
 gem 'mailjet'
 gem 'azure', '0.7.7'
 gem 'paperclip-azure', '~> 0.2'
@@ -65,14 +65,12 @@ group :test do
 end
 
 group :test, :development do
-  gem 'byebug'
   # temporarily pin capybara, the following breaks Rake:
   # https://github.com/jnicklas/capybara/commit/385a7507f6525d9b2d1e23bef0bb2e6fe5ad0c97
   gem 'capybara', '2.4.1'
   gem 'factory_girl_rails', '~> 4.0'
   gem 'faker'
   gem 'pry-rails'
-  gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.0'
   gem 'rubocop', require: false
   gem 'valid_attribute', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
 
-gem 'comfortable_mexican_sofa', '~>2.0.1', git: 'git@github.com:moneyadviceservice/comfortable-mexican-sofa.git'
+gem 'comfortable_mexican_sofa', '~>2.0.1', path: '../comfortable-mexican-sofa'# git: 'git@github.com:moneyadviceservice/comfortable-mexican-sofa.git'
 
 gem 'word-to-markdown', git: 'https://github.com/moneyadviceservice/word-to-markdown.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,31 +24,9 @@ GIT
       premailer (~> 1.8)
       reverse_markdown (~> 0.5)
 
-PATH
-  remote: ../comfortable-mexican-sofa
-  specs:
-    comfortable_mexican_sofa (2.0.1)
-      active_link_to (>= 1.0.0)
-      bootstrap-sass (~> 3.1.0)
-      bootstrap_form (~> 2.1.1)
-      codemirror-rails (>= 3.0.0)
-      coffee-rails (>= 3.1.0)
-      haml-rails (>= 0.3.0)
-      i18n (~> 0.7)
-      jquery-rails (>= 3.0.0)
-      jquery-ui-rails (>= 5.0.0)
-      kaminari (>= 0.14.0)
-      kramdown (~> 1.5)
-      paperclip (>= 4.0.0)
-      rails (>= 4.0.0, <= 4.1.16)
-      rails-i18n (~> 4.0.0)
-      sass-rails (>= 4.0.3)
-      tinymce-rails (>= 4.0.0)
-      transitions (>= 0.1.12)
-
 GEM
-  remote: http://gems.dev.mas.local/
   remote: https://rubygems.org/
+  remote: http://gems.dev.mas.local/
   specs:
     CFPropertyList (2.3.1)
     actionmailer (4.1.16)
@@ -119,10 +97,6 @@ GEM
     bugsnag (2.8.12)
       json (~> 1.7, >= 1.7.7)
     builder (3.2.2)
-    byebug (3.5.1)
-      columnize (~> 0.8)
-      debugger-linecache (~> 1.2)
-      slop (~> 3.6)
     capybara (2.4.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -147,19 +121,20 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    columnize (0.8.9)
+    comfortable_mexican_sofa (2.0.1.79.79)
       active_link_to (>= 1.0.0)
       bootstrap-sass (~> 3.1.0)
       bootstrap_form (~> 2.1.1)
       codemirror-rails (>= 3.0.0)
       coffee-rails (>= 3.1.0)
       haml-rails (>= 0.3.0)
+      i18n (~> 0.7)
       jquery-rails (>= 3.0.0)
       jquery-ui-rails (>= 5.0.0)
       kaminari (>= 0.14.0)
-      kramdown (>= 1.0.0)
+      kramdown (>= 1.13)
       paperclip (>= 4.0.0)
-      rails (>= 4.0.0)
+      rails (>= 4.0.0, <= 4.1.16)
       rails-i18n (~> 4.0.0)
       sass-rails (>= 4.0.3)
       tinymce-rails (>= 4.0.0)
@@ -187,7 +162,6 @@ GEM
     cucumber-wire (0.0.1)
     database_cleaner (1.5.0)
     debug_inspector (0.0.2)
-    debugger-linecache (1.2.0)
     descriptive_statistics (1.1.5)
     devise (3.4.0)
       bcrypt (~> 3.0)
@@ -351,7 +325,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.2)
-    kramdown (1.5.0)
+    kramdown (1.13)
     launchy (2.4.2)
       addressable (~> 2.3)
     legato (0.4.0)
@@ -362,9 +336,9 @@ GEM
       activesupport (>= 3.1.0)
       rack (>= 1.4.0)
       rest-client
-    mastalk (0.8.1)
+    mastalk (0.9.0)
       htmlentities (~> 4.3.2, >= 4.3.2)
-      kramdown (~> 1.5.0, >= 1.5.0)
+      kramdown (~> 1.13, >= 1.13)
     method_source (0.8.2)
     mime-types (2.99.3)
     mimemagic (0.3.0)
@@ -420,9 +394,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.0.1)
-      byebug (~> 3.4)
-      pry (~> 0.10)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     public_suffix (2.0.4)
@@ -576,11 +547,10 @@ DEPENDENCIES
   binding_of_caller
   bowndler!
   bugsnag
-  byebug
   capybara (= 2.4.1)
   clockwork
   coffee-rails (~> 4.0.0)
-  comfortable_mexican_sofa (~> 2.0.1)!
+  comfortable_mexican_sofa (= 2.0.1.79.79)!
   cucumber-rails
   database_cleaner
   devise
@@ -598,14 +568,13 @@ DEPENDENCIES
   launchy
   legato (= 0.4.0)
   mailjet
-  mastalk (~> 0.8.0)
+  mastalk (= 0.9.0)
   mysql2
   newrelic_rpm
   oauth2 (= 1.0.0)
   paper_trail
   paperclip-azure (~> 0.2)
   poltergeist (~> 1.3)
-  pry-byebug
   pry-rails
   rails (= 4.1.16)
   remotipart (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,29 +6,6 @@ GIT
       thor
 
 GIT
-  remote: git@github.com:moneyadviceservice/comfortable-mexican-sofa.git
-  revision: 979234fc966d65b7b4a842192a4761a5e88d04d5
-  specs:
-    comfortable_mexican_sofa (2.0.1)
-      active_link_to (>= 1.0.0)
-      bootstrap-sass (~> 3.1.0)
-      bootstrap_form (~> 2.1.1)
-      codemirror-rails (>= 3.0.0)
-      coffee-rails (>= 3.1.0)
-      haml-rails (>= 0.3.0)
-      i18n (~> 0.6.11)
-      jquery-rails (>= 3.0.0)
-      jquery-ui-rails (>= 5.0.0)
-      kaminari (>= 0.14.0)
-      kramdown (>= 1.0.0)
-      paperclip (>= 4.0.0)
-      rails (>= 4.0.0, <= 4.1.16)
-      rails-i18n (~> 4.0.0)
-      sass-rails (>= 4.0.3)
-      tinymce-rails (>= 4.0.0)
-      transitions (>= 0.1.12)
-
-GIT
   remote: https://github.com/moneyadviceservice/dough.git
   revision: cf4e4cbd5ee86ef49b2db16fc44dde1ed9f2c0f4
   specs:
@@ -46,6 +23,28 @@ GIT
       nokogiri-styles (~> 0.1)
       premailer (~> 1.8)
       reverse_markdown (~> 0.5)
+
+PATH
+  remote: ../comfortable-mexican-sofa
+  specs:
+    comfortable_mexican_sofa (2.0.1)
+      active_link_to (>= 1.0.0)
+      bootstrap-sass (~> 3.1.0)
+      bootstrap_form (~> 2.1.1)
+      codemirror-rails (>= 3.0.0)
+      coffee-rails (>= 3.1.0)
+      haml-rails (>= 0.3.0)
+      i18n (~> 0.7)
+      jquery-rails (>= 3.0.0)
+      jquery-ui-rails (>= 5.0.0)
+      kaminari (>= 0.14.0)
+      kramdown (~> 1.5)
+      paperclip (>= 4.0.0)
+      rails (>= 4.0.0, <= 4.1.16)
+      rails-i18n (~> 4.0.0)
+      sass-rails (>= 4.0.3)
+      tinymce-rails (>= 4.0.0)
+      transitions (>= 0.1.12)
 
 GEM
   remote: http://gems.dev.mas.local/
@@ -212,7 +211,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faker (1.4.3)
+    faker (1.7.2)
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -335,7 +334,7 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    i18n (0.6.11)
+    i18n (0.7.0)
     inflecto (0.0.2)
     ipaddress (0.8.0)
     jbuilder (2.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,6 +491,7 @@ GEM
       powerpack (~> 0.0.6)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
+    ruby-prof (0.16.2)
     ruby-progressbar (1.6.0)
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
@@ -613,6 +614,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rspec_junit_formatter
   rubocop
+  ruby-prof
   sass-rails (~> 4.0.3)
   shoulda-matchers
   site_prism

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -23,7 +23,7 @@ module API
     end
 
     def published
-      pages = current_site.pages.published.layout_identifier(params[:page_type])
+      pages = current_site.pages.published.layout_identifier(params[:page_type]).includes(:site, :layout, :categories, :blocks)
 
       render json: pages, each_serializer: FeedPageSerializer
     end

--- a/app/models/alternate_page_blocks_register.rb
+++ b/app/models/alternate_page_blocks_register.rb
@@ -4,39 +4,8 @@
 #
 # See the comments atop of PageBlocksRegister for a deeper explanation.
 #
-class AlternatePageBlocksRegister
+class AlternatePageBlocksRegister < PageContentRegister
   class Error < StandardError
-  end
-
-  attr_accessor :page, :author
-
-  attr_writer :new_blocks_attributes
-
-  def initialize(page, author:, new_blocks_attributes:)
-    @page = page
-    @author = author
-    @new_blocks_attributes = new_blocks_attributes
-  end
-
-  # If passed in via params, attributes can be a hash rather than array,
-  # so this is just a custom reader to handle that.
-  def new_blocks_attributes
-    blocks_attributes = if @new_blocks_attributes.is_a?(Hash)
-      @new_blocks_attributes.values
-    else
-      @new_blocks_attributes
-    end
-
-    processed_content = ContentComposer.new(
-      @page.site.locale,
-      blocks_attributes.first['content']
-    ).to_html
-
-    blocks_attributes.first.merge!(
-      processed_content: processed_content
-    )
-
-    blocks_attributes
   end
 
   def save!

--- a/app/models/alternate_page_blocks_register.rb
+++ b/app/models/alternate_page_blocks_register.rb
@@ -21,11 +21,22 @@ class AlternatePageBlocksRegister
   # If passed in via params, attributes can be a hash rather than array,
   # so this is just a custom reader to handle that.
   def new_blocks_attributes
-    if @new_blocks_attributes.is_a?(Hash)
+    blocks_attributes = if @new_blocks_attributes.is_a?(Hash)
       @new_blocks_attributes.values
     else
       @new_blocks_attributes
     end
+
+    processed_content = ContentComposer.new(
+      @page.site.locale,
+      blocks_attributes.first['content']
+    ).to_html
+
+    blocks_attributes.first.merge!(
+      processed_content: processed_content
+    )
+
+    blocks_attributes
   end
 
   def save!

--- a/app/models/alternate_page_blocks_retriever.rb
+++ b/app/models/alternate_page_blocks_retriever.rb
@@ -26,7 +26,9 @@ class AlternatePageBlocksRetriever
     end
   end
 
-  def block_content(identifier)
-    blocks_attributes.find { |block_attributes| block_attributes[:identifier] == identifier.to_s }[:content]
+  def block(identifier)
+    blocks_attributes.find do |block_attributes|
+      block_attributes[:identifier] == identifier.to_s
+    end
   end
 end

--- a/app/models/blocks_retriever.rb
+++ b/app/models/blocks_retriever.rb
@@ -1,0 +1,39 @@
+class BlocksRetriever
+  attr_reader :block, :scope
+
+  def initialize(block, scope)
+    @block = block
+    @scope = scope
+  end
+
+  # If we're previewing, we want to recognise when a live article
+  # has a draft new version in progress.
+  #
+  def retrieve
+    if scope == 'preview'
+      if alternate_blocks_retriever.blocks_attributes.present?
+        alternate_blocks_retriever.block(identifier)
+      else
+        blocks_retriever.block(identifier)
+      end
+    else
+      blocks_retriever.block(identifier) if blocks_retriever.live?
+    end
+  end
+
+  def blocks_retriever
+    @blocks_retriever ||= PageBlocksRetriever.new(page)
+  end
+
+  def alternate_blocks_retriever
+    @alternate_blocks_retriever ||= AlternatePageBlocksRetriever.new(page)
+  end
+
+  def page
+    block.blockable
+  end
+
+  def identifier
+    block.identifier
+  end
+end

--- a/app/models/page_blocks_register.rb
+++ b/app/models/page_blocks_register.rb
@@ -21,38 +21,7 @@
 #      During the process the time for the update to go live passes by and when you hit submit
 #      the article has gone back to having only a single version, the live update.
 #
-class PageBlocksRegister
-  attr_accessor :page, :author
-
-  attr_writer :new_blocks_attributes
-
-  def initialize(page, author:, new_blocks_attributes: nil)
-    @page = page
-    @author = author
-    @new_blocks_attributes = new_blocks_attributes
-  end
-
-  # If passed in via params, attributes can be a hash rather than array,
-  # so this is just a custom reader to handle that.
-  def new_blocks_attributes
-    blocks_attributes = if @new_blocks_attributes.is_a?(Hash)
-      @new_blocks_attributes.values
-    else
-      @new_blocks_attributes
-    end
-
-    processed_content = ContentComposer.new(
-      @page.site.locale,
-      blocks_attributes.first['content']
-    ).to_html
-
-    blocks_attributes.first.merge!(
-      processed_content: processed_content
-    )
-
-    blocks_attributes
-  end
-
+class PageBlocksRegister < PageContentRegister
   def save!
     # If a page is has not been saved before, we always want to put the
     # new data straight into the first blocks.

--- a/app/models/page_blocks_register.rb
+++ b/app/models/page_blocks_register.rb
@@ -46,7 +46,7 @@ class PageBlocksRegister
       blocks_attributes.first['content']
     ).to_html
 
-    blocks_attributes.first.merge(
+    blocks_attributes.first.merge!(
       processed_content: processed_content
     )
 

--- a/app/models/page_blocks_register.rb
+++ b/app/models/page_blocks_register.rb
@@ -35,11 +35,22 @@ class PageBlocksRegister
   # If passed in via params, attributes can be a hash rather than array,
   # so this is just a custom reader to handle that.
   def new_blocks_attributes
-    if @new_blocks_attributes.is_a?(Hash)
+    blocks_attributes = if @new_blocks_attributes.is_a?(Hash)
       @new_blocks_attributes.values
     else
       @new_blocks_attributes
     end
+
+    processed_content = ContentComposer.new(
+      @page.site.locale,
+      blocks_attributes.first['content']
+    ).to_html
+
+    blocks_attributes.first.merge(
+      processed_content: processed_content
+    )
+
+    blocks_attributes
   end
 
   def save!

--- a/app/models/page_blocks_retriever.rb
+++ b/app/models/page_blocks_retriever.rb
@@ -71,16 +71,22 @@ class PageBlocksRetriever
     end
   end
 
-  def block_content(identifier)
-    block = blocks_attributes.find { |block_attributes| block_attributes[:identifier] == identifier.to_s }
-
-    block[:processed_content] || block[:content]
+  def block(identifier)
+    blocks_attributes.find do |block_attributes|
+      block_attributes[:identifier] == identifier.to_s
+    end
   end
 
   private
 
   def return_page_blocks_attributes
-    page.blocks.collect { |block| { identifier: block.identifier, content: block.content }.with_indifferent_access }
+    page.blocks.map do |block|
+      {
+        identifier: block.identifier,
+        content: block.content,
+        processed_content: block.processed_content
+      }.with_indifferent_access
+    end
   end
 
   def return_active_revision_blocks_attributes

--- a/app/models/page_blocks_retriever.rb
+++ b/app/models/page_blocks_retriever.rb
@@ -72,7 +72,9 @@ class PageBlocksRetriever
   end
 
   def block_content(identifier)
-    blocks_attributes.find { |block_attributes| block_attributes[:identifier] == identifier.to_s }[:content]
+    block = blocks_attributes.find { |block_attributes| block_attributes[:identifier] == identifier.to_s }
+
+    block[:processed_content] || block[:content]
   end
 
   private

--- a/app/models/page_content_register.rb
+++ b/app/models/page_content_register.rb
@@ -1,0 +1,35 @@
+class PageContentRegister
+  attr_accessor :page, :author
+
+  attr_writer :new_blocks_attributes
+
+  def initialize(page, author:, new_blocks_attributes: nil)
+    @page = page
+    @author = author
+    @new_blocks_attributes = new_blocks_attributes
+  end
+
+  # If passed in via params, attributes can be a hash rather than array,
+  # so this is just a custom reader to handle that.
+  def new_blocks_attributes
+    blocks_attributes = if @new_blocks_attributes.is_a?(Hash)
+      @new_blocks_attributes.values
+    else
+      @new_blocks_attributes
+    end
+
+    markdown_content = ActiveSupport::HashWithIndifferentAccess.new(
+      blocks_attributes.first
+    )[:content]
+    processed_content = ContentComposer.new(
+      @page.site.locale,
+      markdown_content
+    ).to_html
+
+    blocks_attributes.first.merge!(
+      processed_content: processed_content
+    )
+
+    blocks_attributes
+  end
+end

--- a/app/models/page_content_register.rb
+++ b/app/models/page_content_register.rb
@@ -13,14 +13,28 @@ class PageContentRegister
   # so this is just a custom reader to handle that.
   def new_blocks_attributes
     blocks_attributes = if @new_blocks_attributes.is_a?(Hash)
-      @new_blocks_attributes.values
-    else
-      @new_blocks_attributes
-    end
+                          @new_blocks_attributes.values
+                        else
+                          @new_blocks_attributes
+                        end
+    return @new_blocks_attributes if home_page?
 
+    convert_content_to_html(blocks_attributes)
+
+    blocks_attributes
+  end
+
+  private
+
+  def home_page?
+    @page.layout.try(:identifier) == 'home_page'
+  end
+
+  def convert_content_to_html(blocks_attributes)
     markdown_content = ActiveSupport::HashWithIndifferentAccess.new(
       blocks_attributes.first
     )[:content]
+
     processed_content = ContentComposer.new(
       @page.site.locale,
       markdown_content
@@ -29,7 +43,5 @@ class PageContentRegister
     blocks_attributes.first.merge!(
       processed_content: processed_content
     )
-
-    blocks_attributes
   end
 end

--- a/app/models/page_content_register.rb
+++ b/app/models/page_content_register.rb
@@ -17,7 +17,7 @@ class PageContentRegister
                         else
                           @new_blocks_attributes
                         end
-    return @new_blocks_attributes if home_page?
+    return @new_blocks_attributes if home_page? || footer?
 
     convert_content_to_html(blocks_attributes)
 
@@ -27,7 +27,15 @@ class PageContentRegister
   private
 
   def home_page?
-    @page.layout.try(:identifier) == 'home_page'
+     layout_identifier == 'home_page'
+  end
+
+  def footer?
+    layout_identifier == 'footer'
+  end
+
+  def layout_identifier
+    @page.layout.try(:identifier)
   end
 
   def convert_content_to_html(blocks_attributes)

--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -4,7 +4,7 @@ class BlockSerializer < ActiveModel::Serializer
   attributes :identifier, :content, :created_at, :updated_at
 
   def content
-    block = BlocksRetriever.new(object, scope).retrieve
+    block = BlocksRetriever.new(object, scope).retrieve || return
 
     if block[:processed_content].present?
       Rails.logger.info("Cache HIT for #{page.slug}")
@@ -29,7 +29,7 @@ class BlockSerializer < ActiveModel::Serializer
     if identifier.start_with?('raw_')
       ContentComposer.new(locale, block[:content], RawParser).to_html
     else
-      ContentComposer.new(locale, block[:content]).to_html if block
+      ContentComposer.new(locale, block[:content]).to_html
     end
   end
 end

--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -34,7 +34,6 @@ class BlockSerializer < ActiveModel::Serializer
       else
         blocks_retriever.block_content(identifier)
       end
-
     else
       blocks_retriever.block_content(identifier) if blocks_retriever.live?
     end

--- a/db/migrate/20161229133318_add_processed_content_to_comfy_cms_blocks.rb
+++ b/db/migrate/20161229133318_add_processed_content_to_comfy_cms_blocks.rb
@@ -1,0 +1,5 @@
+class AddProcessedContentToComfyCmsBlocks < ActiveRecord::Migration
+  def change
+    add_column :comfy_cms_blocks, :processed_content, :text, limit: 16.megabytes - 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,12 +54,13 @@ ActiveRecord::Schema.define(version: 20170202130530) do
   end
 
   create_table "comfy_cms_blocks", force: true do |t|
-    t.string   "identifier",                      null: false
-    t.text     "content",        limit: 16777215
+    t.string   "identifier",                         null: false
+    t.text     "content",           limit: 16777215
     t.integer  "blockable_id"
     t.string   "blockable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "processed_content", limit: 16777215
   end
 
   add_index "comfy_cms_blocks", ["blockable_id", "blockable_type"], name: "index_comfy_cms_blocks_on_blockable_id_and_blockable_type", using: :btree

--- a/lib/tasks/page_conversion.rake
+++ b/lib/tasks/page_conversion.rake
@@ -1,0 +1,13 @@
+namespace :page_conversion do
+  desc 'Convert all pages from Markdown to HTML'
+  task to_html: :environment do
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    ActiveRecord::Base.transaction do
+      blocks = Comfy::Cms::Block.where(identifier: 'content').includes(:blockable)
+      blocks.find_each do |block|
+        processed_content = Mastalk::Document.new(block.content).to_html
+        block.update(processed_content: processed_content)
+      end
+    end
+  end
+end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -5,6 +5,12 @@ FactoryGirl.define do
     end
 
     association :record, factory: :page
-    data { { blocks_attributes: [{ identifier: 'content', content: content }] } }
+    data {
+      {
+        blocks_attributes: [
+          { identifier: 'content', content: content }
+        ]
+      }
+    }
   end
 end

--- a/spec/models/alternate_page_blocks_register_spec.rb
+++ b/spec/models/alternate_page_blocks_register_spec.rb
@@ -27,7 +27,15 @@ RSpec.describe AlternatePageBlocksRegister do
   describe '#save!' do
     let(:author) { create(:user) }
     let(:new_content) { 'new content' }
-    let(:new_blocks_attributes) { [{ identifier: 'content', content: new_content }] }
+    let(:new_blocks_attributes) do
+      [
+        {
+          identifier: 'content',
+          content: new_content,
+          processed_content: "<p>new content</p>\n"
+        }
+      ]
+    end
 
     context 'when the page state is unsaved' do
       let(:state) { 'unsaved' }

--- a/spec/models/alternate_page_blocks_remover_spec.rb
+++ b/spec/models/alternate_page_blocks_remover_spec.rb
@@ -59,7 +59,20 @@ RSpec.describe AlternatePageBlocksRemover do
 
     context 'when the page state is published_being_edited' do
       let(:state) { 'published_being_edited' }
-      let(:published_revision) { create(:revision, record: page) }
+      let(:published_revision) do
+        create(:revision,
+               record: page,
+               data: {
+                 blocks_attributes: [
+                   {
+                     identifier: 'content',
+                     content: 'some content',
+                     processed_content: "<p>some content</p>\n"
+                   }
+                 ]
+               }
+              )
+      end
 
       before do
         described_class.new(page, remover: remover).remove!

--- a/spec/models/page_content_register_spec.rb
+++ b/spec/models/page_content_register_spec.rb
@@ -35,5 +35,13 @@ describe PageContentRegister do
         expect(subject).to eq(new_blocks_attributes)
       end
     end
+
+    context 'when page is footer' do
+      let(:layout) { double(identifier: 'footer') }
+
+      it 'returns processed content as blank' do
+        expect(subject).to eq(new_blocks_attributes)
+      end
+    end
   end
 end

--- a/spec/models/page_content_register_spec.rb
+++ b/spec/models/page_content_register_spec.rb
@@ -1,0 +1,39 @@
+describe PageContentRegister do
+  describe '#new_blocks_attributes' do
+    let(:site) { double(locale: 'en') }
+    let(:page) { double(layout: layout, site: site) }
+    let(:author) { double }
+    let(:new_blocks_attributes) do
+      [{ content: 'super awesome content' }]
+    end
+
+    subject do
+      PageContentRegister.new(
+        page,
+        author: author,
+        new_blocks_attributes: new_blocks_attributes
+      ).new_blocks_attributes
+    end
+
+    context 'when page is an article' do
+      let(:layout) { double(identifier: 'article') }
+
+      it 'converts content to html as processed content' do
+        expect(subject).to eq([
+          {
+            content: 'super awesome content',
+            processed_content: "<p>super awesome content</p>\n"
+          }
+        ])
+      end
+    end
+
+    context 'when page is the homepage' do
+      let(:layout) { double(identifier: 'home_page') }
+
+      it 'returns processed content as blank' do
+        expect(subject).to eq(new_blocks_attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

Webfeeds request to the CMS on `/en/articles/published` and it takes almost 2 minutes to finish the whole request. You can see on TP as 7833.

Further investigation were found that there was a lot of N+1 queries and a lot of markdown processing to html. Detailed explanation is below.

So removing the n+1 queries and add a 'sort of cache' (convert the html only when you save the page and not when you request the page) will solve half of the problem.

These are the tasks to complete related to this PR:

- [x] Remove N+1 queries
- [x] Create the Comfortable Mexican sofa PR
- [x] Create the Mastalk PR
- [x] Cache the html of all articles (or in the database or in the cache)
- [x] Create a data migration to convert all markdown to html

## Consequences

*This will affect all apps that are using the CMS (the site and the webfeeds and probably universal credit).*

## Related PRs

This PR is waiting for two PR's to be merged. After the merge I will address on the Gemfile: 

- https://github.com/moneyadviceservice/comfortable-mexican-sofa/pull/24
- https://github.com/moneyadviceservice/mastalk/pull/23

What: The above description is related to the performance of the following cms requests:

- /en/articles/published 
- /:locale/:layout/:slug (e.g /en/articles/benefit-changes or en/corporate/corporate-news etc)

## N+1 Queries

There were some queries that was not optimised. 

Categories: It took 28 seconds to gather the categories for all the articles in the database. This was 8% of the total time of the request. On these 8% the ruby-prof shows above the total amount of time and the percentage of that 8% in each method.

<img width="1413" alt="cms-2" src="https://cloud.githubusercontent.com/assets/27509/21095845/31f2e6f6-c055-11e6-9f45-43fea8aa84f4.png">

After the removal of N+1 queries, you can see the method category names is so fast that it took only miliseconds now:

<img width="1400" alt="category_names" src="https://cloud.githubusercontent.com/assets/27509/21149510/985b5c80-c153-11e6-8b2a-42a4264e29c3.png">

Site and layout: This was not make too much difference but it takes 0.03% of the total and 0.14% of the total time. Add includes to make sure 

## Markdown processing

As you can see in the image below the markdown processing was taking 50% of the time to complete every request. This PR address the "cache" solution to solve the problem. Basically every time you save a page, cms will convert the markdown to html and on then serve the html on the request.

I opened a Mastalk PR to speed up the conversion too. You can see more details here: moneyadviceservice/mastalk#23

<img width="613" alt="blocks" src="https://cloud.githubusercontent.com/assets/27509/21149607/e8e59ecc-c153-11e6-92d3-44f2cb111c6d.png">

## Benchmarks

*Disclaimer*: The benchmarks should not be takens as the same numbers as production since thins benchmarks were runned as "development" mode, but they demonstrate the optimisations of this PR.

## Before the PR

⤷  ab -n 200 -c 15 http://localhost:3000/en/articles/the-best-ways-to-pay-bills
Concurrency Level:      15
Time taken for tests:   41.304 seconds
Complete requests:      200
Requests per second:    4.0 [#/sec] (mean)

## After the PR

⤷  ab -n 200 -c 15 http://localhost:3000/en/articles/the-best-ways-to-pay-bills
Concurrency Level:      15
Time taken for tests:   20.680 seconds
Complete requests:      200
Requests per second:    8.45 [#/sec] (mean)
