### PR TITLE
[DEV APPROVED] - Fix bug in defining ClumpLinkSerializer scope

### DIFF
--- a/app/serializers/clump_serializer.rb
+++ b/app/serializers/clump_serializer.rb
@@ -15,7 +15,7 @@ class ClumpSerializer < ActiveModel::Serializer
 
   def links
     object.clump_links.select(&:complete?).map do |link|
-      ClumpLinkSerializer.new(link, scope_name: :locale)
+      ClumpLinkSerializer.new(link, scope: scope)
     end
   end
 end


### PR DESCRIPTION
Picked up on and fixed while working on that ticket 7747 (plumb the api into the frontend interface).

Wasn't defining the scope (locale) properly when instantiating the `ClumpLinkSeralizer` from `ClumpSerializer`, this fixes that.