### PR TITLE
Add migration to create extra empty clump links

### DIFF
--- a/db/migrate/20170110153128_create_extra_clump_links.rb
+++ b/db/migrate/20170110153128_create_extra_clump_links.rb
@@ -1,0 +1,9 @@
+class CreateExtraClumpLinks < ActiveRecord::Migration
+  def change
+    Clump.all.each do |clump|
+      (4 - clump.clump_links.count).times do
+        clump.clump_links.create!
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161208151020) do
+ActiveRecord::Schema.define(version: 20170110153128) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"


### PR DESCRIPTION
Rather than add validation on the number of links a clump can have (which would have been a more complex UX addition) we went with creating a fixed number of empty links in the db and then showing them based on whether or not they were complete.

This approach wasn't finalised when the migration to create the initial clumps was created, so this adds the missing empty ones so that all clumps have four each.