### PR TITLE
Clump link changes to go with the new ‘Retirement’ clump

### DIFF
--- a/db/migrate/20170112102402_retirement_clump_extras.rb
+++ b/db/migrate/20170112102402_retirement_clump_extras.rb
@@ -1,0 +1,14 @@
+class RetirementClumpExtras < ActiveRecord::Migration
+  def change
+    work_and_benefits = Clump.find_by!(name_en: 'Work & Benefits')
+    retirement = Clump.find_by!(name_en: 'Retirement')
+
+    # First move retirement related links from the clump that used to be 'Work, Benefits & Pensions' to the 'Retirement' clump
+    work_and_benefits.clump_links.find_by!(text_en: 'Pension calculator').update_attribute(:clump_id, retirement.id)
+    work_and_benefits.clump_links.find_by!(text_en: 'Workplace pension contribution calculator').update_attribute(:clump_id, retirement.id)
+
+    # Now create replacement/missing empty clump links for these clumps
+    2.times { work_and_benefits.clump_links.create! }
+    2.times { retirement.clump_links.create! }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170111102641) do
+ActiveRecord::Schema.define(version: 20170112102402) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"


### PR DESCRIPTION
I rushed the PR to create the new Retirement clump and unfortunately forgot to consider the clump links.

The migration in this PR moves retirement related links over to the Retirement clump and then creates extra empty ones so that both the old and new clumps have four each.
