### PR TITLE
[DEV APPROVED]7995 - Floating Toolbar bug

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/StickyElements.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/StickyElements.js
@@ -1,34 +1,48 @@
-define([
-  'jquery',
-  'DoughBaseComponent',
-  'filament-sticky'
-], function (
+define([ 'jquery', 'DoughBaseComponent'], function (
   $,
   DoughBaseComponent
-) {
+  ) {
   'use strict';
 
   var StickyElementsProto,
-      defaultConfig = {
-        selectors: {
-          stickyElement: '[data-dough-sticky-element-target]'
-        }
-      };
+  defaultConfig = {
+    selectors: {
+      stickyElement: '[data-dough-sticky-element-target]'
+    }
+  };
 
   function StickyElements($el, config) {
     StickyElements.baseConstructor.call(this, $el, config, defaultConfig);
   }
 
   DoughBaseComponent.extend(StickyElements);
-
   StickyElements.componentName = 'StickyElements';
 
   StickyElementsProto = StickyElements.prototype;
 
   StickyElementsProto.init = function(initialised) {
-    $(this.config.selectors.stickyElement).fixedsticky();
+
     this._initialisedSuccess(initialised);
+    this._stickyHandler();
+
+    return this;
   };
+
+  StickyElementsProto._stickyHandler = function() {
+
+    var scrollElement = $(this.config.selectors.stickyElement),
+        distance      = $(scrollElement).offset().top,
+        $window       = $(window);
+
+    $window.scroll(function() {
+      if ( $window.scrollTop() + 10 >= distance ) {
+        scrollElement.addClass('fixedsticky-on');
+      } else {
+        scrollElement.removeClass('fixedsticky-on');
+      }
+    });
+
+  }
 
   return StickyElements;
 });

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -96,8 +96,6 @@ requirejs.config({
     'taggle': '<%= requirejs_path("taggle.js/dist/taggle.min") %>',
     'rangy-core': '<%= requirejs_path("rangy-official/rangy-core") %>',
 	'rangy-selectionsaverestore': '<%= requirejs_path("rangy-official/rangy-selectionsaverestore") %>',
-    'filament-sticky': '<%= requirejs_path("filament-sticky/fixedsticky") %>',
-    'filament-fixed': '<%= requirejs_path("filament-fixed/fixedfixed") %>',
     'html-sortable': '<%= requirejs_path("html.sortable/dist/html.sortable") %>',
     'autosize': '<%= requirejs_path("autosize/src/autosize") %>'
   },
@@ -111,9 +109,6 @@ requirejs.config({
     },
     'dialog-polyfill': {
       exports: 'dialogPolyfill'
-    },
-    'filament-sticky': {
-      deps: ['jquery','filament-fixed']
     }
   }
 });

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/application.css.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/application.css.scss
@@ -27,4 +27,3 @@ $responsive: true;
 
 // 3rd-party libraries
 @import "comfortable_mexican_sofa/lib/chosen-cms";
-@import "filament-sticky/fixedsticky";

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/helpers/_fixedsticky.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/helpers/_fixedsticky.scss
@@ -1,16 +1,18 @@
 // Helper for the filament-sticky plugin
 
-.fixedsticky-page-title {
-  @extend %z-index--fixedsticky;
-  top: 15px;
+.fixedsticky {
+  &.fixedsticky-on {
+    top: 0;
+    position: fixed;
+  }
 }
 
 .fixedsticky-toolbar {
   @extend %z-index--fixedsticky;
-  top: 62px;
 
   &.fixedsticky-on {
     width: 85%;
+    top: 3px;
   }
 }
 
@@ -26,16 +28,6 @@
   }
 }
 
-.fixedsticky-background--page-title {
-  @extend %z-index--fixedsticky;
-
-  &.fixedsticky-on {
-    height: 75px;
-    left: 0;
-    top: 0;
-  }
-}
-
 .fixedsticky-background--toolbar {
   @extend %z-index--fixedsticky;
 
@@ -43,6 +35,6 @@
     box-shadow: 0px 5px 10px rgba(0,0,0,.1);
     height: 50px;
     left: 0;
-    top: 65px;
+    top: 0;
   }
 }

--- a/app/views/pages/_form_title.html.haml
+++ b/app/views/pages/_form_title.html.haml
@@ -1,4 +1,3 @@
-.fixedsticky-background.fixedsticky-background--page-title.fixedsticky.top{"data-dough-sticky-element-target" => true}
 .form-group
   .form__input-wrapper.form__input-wrapper--fill-width
-    = form.text_field :label, hide_label: true, class: 'form__input form__input--inline form__input--inline--page-title fixedsticky top fixedsticky-page-title', placeholder: 'Untitled page', data: {'dough-mirrorinputvalue-trigger' => '', 'dough-sticky-element-target' => true, 'dough-urlformatter-input' => (@page.new_record?)}
+    = form.text_field :label, hide_label: true, class: 'form__input form__input--inline form__input--inline--page-title fixedsticky top fixedsticky-page-title', placeholder: 'Untitled page', data: {'dough-mirrorinputvalue-trigger' => '', 'dough-urlformatter-input' => (@page.new_record?)}

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -18,7 +18,6 @@
     "text": "2.0.12",
     "dialog-polyfill": "0.2.0",
     "rangy-official": "1.3",
-    "filament-sticky": "0.1.3",
     "html.sortable": "0.1.8",
     "autosize": "2.0"
   }


### PR DESCRIPTION
# Floating Toolbar Bug

**Description**

Currently the editor toolbar is floating over the content of the page rather than being fixed at the top, also the background isnt showing:

<img width="1210" alt="screen shot 2017-03-02 at 15 56 57" src="https://cloud.githubusercontent.com/assets/13165846/23515082/1c26accc-ff61-11e6-9a5d-b60dc53b2845.png">

On further investigation I found that we are using the CSS property ``position: sticky`` and a fallback javascript plugin [filament-sticky](https://github.com/filamentgroup/fixed-sticky) AS this is still not supported by IE at all.  We are also using a custom dough component that initiates the plugin.

## The Solution

In order to make this as simple as possible I decided to remove the 3rd party plugin (As this seems to have stopped working anyway) and update the component to do to work of applying a position: fixed property, rather than trying to use position: sticky, then trying to patch in a fix for unsupported browsers.

To give a bit of perspective of the support for each of the CSS properties:

| position: sticky; |
|-----------------------|
|<img width="1253" alt="screen shot 2017-03-03 at 09 00 46" src="https://cloud.githubusercontent.com/assets/13165846/23545076/b76b107a-fff1-11e6-8e3b-2398ed8fd8a8.png">|

| position: fixed; |
|---------------|
|<img width="1255" alt="screen shot 2017-03-03 at 09 00 10" src="https://cloud.githubusercontent.com/assets/13165846/23545087/ca99437e-fff1-11e6-811a-a6a095585f66.png">|

## The Outcome

<img width="1284" alt="screen shot 2017-03-03 at 09 15 27" src="https://cloud.githubusercontent.com/assets/13165846/23545128/feebf00e-fff1-11e6-9815-b8bad0e88a7a.png">
