### PR TITLE
Mention cloning QA database and other tidy-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Or for the direct command:
 
 Use `--single-run` if you only want it to run once.
 
+## Using for front-end development
+
+When developing [the front end](https://github.com/moneyadviceservice/frontend) it is usual to point it to a locally running instance of this CMS. In this case it is useful to clone the QA database to your local database.
+
+```
+mysqldump -h az2-tst-qa01.dev.mas.local -u cms -p cms_qa > cms_qa.sql
+
+mysql -u root cms_development < cms_qa.sql
+
+```
+
+The credentials for the QA database are kept in Keepass under "MAS QA" --> "mysql password".
+
+Note that the database is quite large, so it may take a while.
+
 ## Deploying
 
 This can easily be deployed to Heroku but the MAS organisation uses its own deployment infrastructure. If you're a MAS employee, you can deploy this to QA by triggering the `cms_commit` pipeline . Refer to the organisational [wiki](https://moneyadviceserviceuk.atlassian.net/wiki/display/TEAMB/Contento+CMS) on how to deploy to our production environment.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The MAS CMS.
 - MySQL
 - Node.js (for Bower)
 - Bower (Install via NPM)
-- an entry for `gems.test.mas` in your `/etc/hosts` file and access to the MAS network (so that you can bundle install the gems)
+- Access to the MAS network (so that you can bundle install the private gems)
 
 ## Installation
 
@@ -72,9 +72,8 @@ Use `--single-run` if you only want it to run once.
 
 When developing [the front end](https://github.com/moneyadviceservice/frontend) it is usual to point it to a locally running instance of this CMS. In this case it is useful to clone the QA database to your local database.
 
-```
+```sh
 mysqldump -h az2-tst-qa01.dev.mas.local -u cms -p cms_qa > cms_qa.sql
-
 mysql -u root cms_development < cms_qa.sql
 
 ```


### PR DESCRIPTION
In order to use a local instance of this for development we need content. The suggestion to clone the QA database is in the Wiki, but it is not obvious that we need to look there when following setup instructions in the `frontend` and `cms` READMEs.

I am not 100% sure about including the instructions in this public repository, but there are references to other private servers in the `frontend` README.

(I also noticed a reference to `gems.test.mas` here, which I've taken out.