### PR TITLE
[DEV APPROVED] -8198 - Set published date for scheduled posts

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -48,6 +48,13 @@ class Comfy::Cms::Page < ActiveRecord::Base
 
   scope :unpublished, -> { where(state: 'unpublished') }
 
+  scope :scheduled_today, (lambda do
+    where(
+      arel_table[:state].eq('scheduled')
+      .and(arel_table[:scheduled_on].lt(Time.now.end_of_day))
+    )
+  end)
+
   scope :layout_identifier, (lambda do |identifier|
     joins(:layout).where(comfy_cms_layouts: { identifier: identifier.singularize })
   end)

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -1,6 +1,7 @@
 require 'clockwork'
 require './config/boot'
 require './config/environment'
+require './lib/cms/publish_scheduled_pages_task'
 require './lib/cms/update_page_views_task'
 
 module Clockwork
@@ -12,5 +13,9 @@ module Clockwork
 
   every(1.day, 'update_page_views.job', at: '03:00') do
     ::UpdatePageViewsTask.run
+  end
+
+  every(1.day, 'publish_scheduled_pages.job', at: '04:00') do
+    ::PublishScheduledPagesTask.run
   end
 end

--- a/lib/cms/publish_scheduled_pages_task.rb
+++ b/lib/cms/publish_scheduled_pages_task.rb
@@ -1,0 +1,8 @@
+class PublishScheduledPagesTask
+  def self.run
+    Comfy::Cms::Page.scheduled_today.each do |page|
+      page.published_at = page.scheduled_on
+      page.save!
+    end
+  end
+end

--- a/spec/lib/cms/publish_scheduled_pages_task_spec.rb
+++ b/spec/lib/cms/publish_scheduled_pages_task_spec.rb
@@ -1,0 +1,34 @@
+require Rails.root.join('lib/cms/publish_scheduled_pages_task')
+
+RSpec.describe PublishScheduledPagesTask do
+  describe '.run' do
+    let!(:publish_later_today) do
+      create :page,
+        state: :scheduled,
+        scheduled_on: Time.now.end_of_day - 2.hours
+    end
+    let!(:publish_now) do
+      create :page,
+        state: :scheduled,
+        scheduled_on: Time.now
+    end
+    let!(:publish_tomorrow) do
+      create :page,
+        state: :scheduled,
+        scheduled_on: Time.now.end_of_day + 1.day
+    end
+
+    before(:each) do
+      PublishScheduledPagesTask.run
+    end
+
+    it 'sets published_at for pages scheduled for release today' do
+      expect(publish_later_today.reload.published_at).to eql(publish_later_today.scheduled_on)
+      expect(publish_now.reload.published_at).to eql(publish_now.scheduled_on)
+    end
+
+    it 'does not update any pages scheduled in the future' do
+      expect(publish_tomorrow.published_at).to be_nil
+    end
+  end
+end

--- a/spec/models/comfy/cms/page_spec.rb
+++ b/spec/models/comfy/cms/page_spec.rb
@@ -251,6 +251,24 @@ RSpec.describe Comfy::Cms::Page do
     end
   end
 
+  describe '.scheduled_today' do
+    context 'pages scheduled in the past, present and future' do
+      it 'includes only pages scheduled for today' do
+        page_one = create :page, state: :scheduled, scheduled_on: Time.now.end_of_day - 2.hours
+        page_two = create :page, state: :scheduled, scheduled_on: Time.now
+        create :page, state: :scheduled, scheduled_on: Time.now.end_of_day + 1.day
+        create :page
+        create :page
+        create :page
+
+        expect(Comfy::Cms::Page.scheduled_today).to contain_exactly(
+          page_one,
+          page_two
+        )
+      end
+    end
+  end
+
   describe '#most_popular scope' do
 
     it 'has the three most popular articles' do


### PR DESCRIPTION
### Summary
This pr sets a published date of a page to be when its scheduled to be released.

The CMS app is not revising the published_at date on articles with scheduled revisions upon publication, although the content is updated, the published_at date is required by the web feeds management system to update partners on update articles in their feeds.

[TP link](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=13857292912bd09b911bf771e091f219#page=bug/8198)
