### PR TITLE
[DEV APPROVED] 8603 Disable category from being selected as the parent

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,6 +8,7 @@ class CategoriesController < Comfy::Admin::Cms::BaseController
   def show
     @category.links.build
     @category.category_promos.build
+    @categories = Comfy::Cms::Category.where(site_id: 1).reorder(:label)
     @english_pages, @welsh_pages =
       Comfy::Cms::Page
         .in_category(@category.id)

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -25,7 +25,7 @@
         .l-split-content__col
           %h2 Category details
           = comfy_form_for @category, url: {action: 'update'}, html: {class: 'form form--vertical'}, label_col: 'form__label-heading', control_col: 'form__input-wrapper' do |f|
-            = f.collection_select :parent_id, Comfy::Cms::Category.where(site_id: 1).reorder(:label), :id, :label, include_blank: true
+            = f.select(:parent_id, options_for_select(@categories.map{|c| [c.label, c.id]}, disabled: @category.id), {include_blank: true})
             = f.collection_select :clump_id, Clump.reorder(:name_en), :id, :name_en, include_blank: true
             = f.text_field :title_en
             = f.text_field :title_cy

--- a/features/categories_admin.feature
+++ b/features/categories_admin.feature
@@ -1,0 +1,10 @@
+Feature: Categories
+  As a content editor
+  I want to be able to change the parent category of an existing category
+  so that website visitors can find the content under the relevant section on the site
+
+@categories_admin
+Scenario: Cannot make a category the parent of itself
+  When I visit the categories admin page
+  And I select a category
+  Then I should not be able to select that category as the parent category

--- a/features/step_definitions/categories_admin_page_steps.rb
+++ b/features/step_definitions/categories_admin_page_steps.rb
@@ -1,0 +1,33 @@
+When(/^I visit the categories admin page$/) do
+  cms_site
+  create_categories
+  @page = categories_admin_page
+  step("I am logged in")
+  @page.load
+  define_bind rescue nil
+  wait_for_ajax_complete
+  expect(@page).to be_displayed
+end
+
+When(/^I select a category$/) do
+  @page.category_links.first.click
+end
+
+Then(/^I should not be able to select that category as the parent category$/) do
+  @page = category_details_page
+  @page.load(id: Comfy::Cms::Category.first.id)
+  expect(@page.parent_options[1].disabled?).to be_truthy
+  expect(@page.parent_options[2].disabled?).to be_falsey
+end
+
+def create_categories
+  2.times do |n| 
+    Comfy::Cms::Category.create(
+      site: cms_site,
+      label: "label-#{n}",
+      title_en: "en-label-#{n}",
+      title_cy: "cy-label-#{n}",
+      categorized_type: "Comfy::Cms::Page"
+    )
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,3 +17,5 @@ Capybara.default_wait_time = 20
 Capybara.ignore_hidden_elements = false
 
 World(FactoryGirl::Syntax::Methods)
+
+DatabaseCleaner.strategy = :truncation

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -15,3 +15,6 @@ After do |scenario|
   end
 end
 
+After '@categories_admin' do |scenario|
+  DatabaseCleaner.clean
+end

--- a/features/support/ui/pages/categories_admin.rb
+++ b/features/support/ui/pages/categories_admin.rb
@@ -1,0 +1,11 @@
+require_relative '../page'
+require_relative '../sections/header'
+
+module UI::Pages
+  class CategoriesAdmin < UI::Page
+    set_url         '/admin/categories'
+    set_url_matcher /\/admin\/categories/
+
+    elements :category_links, '.sortable-list__link'
+  end
+end

--- a/features/support/ui/pages/category_details.rb
+++ b/features/support/ui/pages/category_details.rb
@@ -1,0 +1,11 @@
+require_relative '../page'
+require_relative '../sections/header'
+
+module UI::Pages
+  class CategoryDetails < UI::Page
+    set_url         '/admin/categories/{id}'
+    set_url_matcher /\/admin\/categories\/\d+/
+
+    elements :parent_options, '#comfy_cms_category_parent_id option'
+  end
+end


### PR DESCRIPTION
### Objective
This pr addresses [TP8603](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=ddd7f3a626844ab8d1bee3f06ec28efa#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=bug/8603).  A user design flaw in production allows a content editor or admin user to assign a category as the parent category to itself. If the user then tries to view that category page, he'll experience a timeout. Technically, the cause is an infinite loop in the code.

The short term approach is to disable a category from being selected as its own parent in the drop down list on the form for editing categories. A better approach is to validate the parent category when the form is submitted. This latter approach needs to be prioritised. In the interim, the solution of disabling the parent category from being selected should prevent an immediate recurrence of the error.

### Technical
Cucumber scenario to specifically test that a category is not able to be selected as its parent category:

* New feature for editing a category specifically to change the parent category
* To populate the parent categories dropdown menu, categories were being selected on the basis of the site id equalling 1. Consequently, the test database needs to be reset, otherwise the tests will fail after the first time since the site id will continually be incremented.
* Tagged the scenario for use with an after hook so the database cleaner will only kick in for this test. Not sure if this is necessary but added it so the entire test suite is not slowed down.