### PR TITLE
[DEV APPROVED] 8913 add text fields

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,4 +1,8 @@
 module PagesHelper
+  def fields_from_layout(comfortable_mexican_sofa_tag)
+    Cms::LayoutField.map(comfortable_mexican_sofa_tag['default'])
+  end
+
   def tag_for_identifier(tags, identifier, cms_blocks, index)
     tag = tags.find { |t| t.identifier == identifier }
     cms_blocks.send(tag.class.to_s.demodulize.underscore, tag, index)

--- a/app/views/pages/form_blocks/_insight.html.haml
+++ b/app/views/pages/form_blocks/_insight.html.haml
@@ -1,0 +1,3 @@
+%div
+  - fields_from_layout(namespace).each_with_index do |layout_field, index|
+    = layout_field.input_tag_for(form_builder: cms_blocks, index: index)

--- a/features/pages_form/fincap_insight_pages.feature
+++ b/features/pages_form/fincap_insight_pages.feature
@@ -1,0 +1,31 @@
+Feature: Building Insight Pages
+  As an Editor
+  In order to the build an Insights Page
+  I want to be able to fill out all the text fields on the form
+
+  Background:
+    Given I have an insight page layout
+    And I am logged in
+
+  Scenario: Creating an insight page
+    Given I am on the homepage
+    And I click on "Create new page"
+    And I select "Insight" on the creation page
+    And I create a page "Fixing family finances"
+    When I edit the page "Fixing family finances"
+    And I fill in
+      | FIELD               | VALUE               |
+      | overview            | this is an overview |
+      | countries           | Brazingland         |
+      | links_to_research   | http://foo          |
+      | contact_details     | call Chuck Norris   |
+      | year_of_publication | 1066                |
+    And I save and return to the homepage
+    And when I click the "Fixing family finances" page
+    Then I should see the fields filled with the content
+      | FIELD               | VALUE               |
+      | overview            | this is an overview |
+      | countries           | Brazingland         |
+      | links_to_research   | http://foo          |
+      | contact_details     | call Chuck Norris   |
+      | year_of_publication | 1066                |

--- a/features/step_definitions/fincap_pages_steps.rb
+++ b/features/step_definitions/fincap_pages_steps.rb
@@ -1,0 +1,67 @@
+Given(/^I have an insight page layout$/) do
+  english_site = Comfy::Cms::Site.find_or_create_by(
+    label: 'en',
+    identifier: 'money-advice-service-en',
+    hostname: 'localhost:3000',
+    path: 'en',
+    locale: 'en',
+    is_mirrored: true
+  )
+
+  english_site.layouts.find_or_create_by(
+    identifier: 'insight',
+    label: 'Insight',
+    content:  <<-CONTENT
+      {{ cms:page:content:rich_text }}
+      {{ cms:page:overview }}
+      {{ cms:page:countries }}
+      {{ cms:page:links_to_research }}
+      {{ cms:page:contact_details }}
+      {{ cms:page:year_of_publication }}
+    CONTENT
+  )
+end
+
+Given(/^I am on the homepage$/) do
+  home_page.load
+end
+
+Given(/^I click on "([^"]*)"$/) do |button|
+  click_on(button)
+end
+
+Given(/^I select "([^"]*)" on the creation page$/) do |option|
+  new_page.select(option)
+end
+
+Given(/^I create a page "([^"]*)"$/) do |title|
+  new_page.page_name.set(title)
+  new_page.save_button.click
+end
+
+When(/^I edit the page "([^"]*)"$/) do |title|
+  home_page.load
+  page.first(:link, title).click
+end
+
+When(/^I fill in$/) do |table|  # table is a Cucumber::Core::Ast::DataTable
+  table.rows.each do |row|
+    edit_page.send(row[0]).set(row[1])
+  end
+end
+
+When(/^I save and return to the homepage$/) do
+  edit_page.save_changes_to_draft.click
+  home_page.load
+end
+
+When(/^when I click the "([^"]*)" page$/) do |title|
+  step(%(I edit the page "#{title}"))
+end
+
+Then(/^I should see the fields filled with the content$/) do |table|
+  # table is a Cucumber::Core::Ast::DataTable
+  table.rows.each do |row|
+    expect(edit_page.send(row[0]).value).to eq(row[1])
+  end
+end

--- a/features/support/ui/pages/edit.rb
+++ b/features/support/ui/pages/edit.rb
@@ -42,5 +42,11 @@ module UI::Pages
         end
       end
     end
+
+    element :overview, '#blocks_attributes_1_content'
+    element :countries, '#blocks_attributes_2_content'
+    element :links_to_research, '#blocks_attributes_3_content'
+    element :contact_details, '#blocks_attributes_4_content'
+    element :year_of_publication, '#blocks_attributes_5_content'
   end
 end

--- a/lib/cms/form_builder.rb
+++ b/lib/cms/form_builder.rb
@@ -1,4 +1,5 @@
 class Cms::FormBuilder < ComfortableMexicanSofa::FormBuilder
+
   def page_rich_text(tag, index)
     @template.render(partial: 'comfy/admin/cms/pages/editor', object: tag.block,
         locals: {
@@ -41,7 +42,9 @@ class Cms::FormBuilder < ComfortableMexicanSofa::FormBuilder
 
   # ACHTUNG, HACKY! - looks for the instance variable @blocks_attributes in the view to retrieve the current content
   blocks_attributes = @template.instance_variable_get('@blocks_attributes')
-  current_value = blocks_attributes.find { |block_attributes| block_attributes[:identifier] == tag.identifier.to_s }[:content]
+  current_value = Array(blocks_attributes).find do |block_attributes|
+    block_attributes[:identifier] == tag.identifier.to_s
+  end.try(:[], :content)
 
   case method
   when :file_field_tag

--- a/lib/cms/layout_field.rb
+++ b/lib/cms/layout_field.rb
@@ -1,0 +1,36 @@
+# This class handles the comfortable mexican sofa tags
+# that the Cms::FormBuilder < ComfortableMexicanSofa::FormBuilder
+# requires for rendering the inputs for the form.
+#
+# The comfortable mexican sofa tags are the objects better understood to be
+# the fields on the form.
+# A comfortable mexican sofa tags is an object that
+# responds to  `.identifier` and `.blockable`
+#
+# identifier is the field e.q. contact_details
+# blockable is usually the page object
+#
+# @example
+# ComfortableMexicanSofa::Tag::PageRichText.new
+#
+class Cms::LayoutField
+  def self.map(collection)
+    collection.map { |tag| new(tag) }
+  end
+
+  attr_reader :tag
+
+  def initialize(tag)
+    @tag = tag
+  end
+
+  def input_tag_for(form_builder:, index:)
+    form_builder.send(input_tag_method, tag, index)
+  end
+
+  private
+
+  def input_tag_method
+    @tag.class.to_s.demodulize.underscore
+  end
+end

--- a/lib/tasks/fincap.rake
+++ b/lib/tasks/fincap.rake
@@ -18,7 +18,13 @@ namespace :fincap do
       english_site.layouts.find_or_create_by(
         identifier: layout,
         label: layout.titleize,
-        content: '{{ cms:page:content:rich_text }}'
+        content:  <<-CONTENT
+          {{ cms:page:content:rich_text }}
+          {{ cms:page:overview }}
+          {{ cms:page:countries }}
+          {{ cms:page:links_to_research }}
+          {{ cms:page:contact_details }}
+        CONTENT
       )
     end
   end

--- a/spec/lib/cms/layout_field_spec.rb
+++ b/spec/lib/cms/layout_field_spec.rb
@@ -1,0 +1,25 @@
+describe Cms::LayoutField do
+  subject(:layout_field) do
+    described_class.new(comfortable_mexican_sofa_tag)
+  end
+
+  describe '#input_tag_for' do
+    let(:input_tag_for) do
+      layout_field.input_tag_for(form_builder: form_builder, index: 0)
+    end
+
+    context 'when comfortable mexican sofa tag is rich text' do
+      let(:comfortable_mexican_sofa_tag) do
+        ComfortableMexicanSofa::Tag::PageRichText.new
+      end
+      let(:form_builder) { double }
+
+      it 'renders page rich text input tag from the form builder' do
+        expect(form_builder).to receive(:page_rich_text)
+          .with(comfortable_mexican_sofa_tag, 0)
+
+        input_tag_for
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP8913](https://moneyadviceservice.tpondemand.com/entity/8913-add-text-blocks-to-cms-insights)

Add insight template
Add cucumber feature
Add refactored code for insight partial
Add fields to template!

**refactoring form builder**
The method `default_tag_field` needs to be refactored to be maintainable. Although we have updated some of this method to work a little better we have opted not to refactor this whole method yet. This is down to the fact that we know we will have to do more work to this method with the addition of multiple blocks (checkboxes etc.). It may be unwise to refactor this code before that point as it may make it harder to then apply any new changes from that point. _Therefore_ we will address the refactor of this method in that PR
https://github.com/moneyadviceservice/cms/pull/402/files#diff-0b23ec871fc4b345b5c142d0d9d33424R45
