### PR TITLE
[DEV APPROVED] 8997 API Search by keyword - Insight

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -16,11 +16,20 @@ module API
       params[:document_type]
     end
 
+    def keyword
+      params[:keyword]
+    end
+
     def filter_documents
       if document_type.present?
         @documents = @documents.joins(:layout)
           .where('comfy_cms_layouts.identifier' => document_type)
       end
+
+      if keyword.present?
+        @documents = @documents.with_content_like(keyword)
+      end
     end
+
   end
 end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -6,38 +6,71 @@ RSpec.describe API::DocumentsController, type: :request do
   let(:response_body) { JSON.load(response.body) }
   let(:documents) { response_body['documents'] }
   let(:meta_data) { response_body['meta'] }
-  let(:url) { "/api/en/documents#{params}" }
+  let(:url) { '/api/en/documents' }
+  let(:review_layout)  { create :layout, identifier: 'review' }
+  let(:insight_layout)  { create :layout, identifier: 'insight' }
+  let!(:insight_page) { create(:insight_page_about_financial_wellbeing, site: site, layout: insight_layout) }
+  let!(:insight_page_1) { create(:insight_page_about_debt, site: site, layout: insight_layout) }
+  let!(:insight_page_2) { create(:insight_page_about_pensions, site: site, layout: insight_layout) }
+  let!(:review_page_1) { create(:page, site: site, layout: review_layout) }
 
   before do
     allow_any_instance_of(PageSerializer)
       .to receive(:related_content).and_return({})
+
+    get url, params
   end
 
   describe 'GET /:locale/documents' do
-    let(:review_layout)  { create :layout, identifier: 'review' }
-    let(:insight_layout)  { create :layout, identifier: 'insight' }
-
-    let!(:insight_page_1) { create(:page, site: site, layout: insight_layout) }
-    let!(:insight_page_2) { create(:page, site: site, layout: insight_layout) }
-    let!(:review_page_1) { create(:page, site: site, layout: review_layout) }
-
-    before { get url }
-
     context 'when all documents are requested' do
-      let(:params) {''}
+      let(:params) { {} }
 
       it 'returns all documents' do
-        expect(meta_data['results']).to eq 3
-        expect(documents.count).to eq 3
+        expect(meta_data['results']).to eq 4
+        expect(documents.count).to eq 4
       end
     end
 
     context 'when documents of type insight are requested' do
-      let(:params) {'?document_type=insight'}
-
+      let(:params) { { document_type: 'insight' } }
       it 'returns all insight documents' do
-        expect(meta_data['results']).to eq 2
-        expect(documents.count).to eq 2
+        expect(meta_data['results']).to eq 3
+        expect(documents.count).to eq 3
+      end
+    end
+  end
+
+  describe 'keyword search' do
+    context 'when the document_type is specified' do
+      context 'when a keyword is provided' do
+        let(:params) { { document_type: 'insight', keyword: 'pension' } }
+
+        it 'returns an array of documents which contain the keyword' do
+          expect(meta_data['results']).to eq 1
+          expect(documents.count).to eq 1
+        end
+
+      context 'when the keyword is not found' do
+        let(:params) { { document_type: 'insight', keyword: 'nosuchterm' } }
+
+        it 'returns an empty array' do
+          expect(meta_data['results']).to eq 0
+          expect(documents.count).to eq 0
+        end
+      end
+
+      context 'when the search term is a phrase' do
+        let(:params) do
+          {
+            document_type: 'insight', 
+            keyword: 'Financial well being: the employee view' 
+          }
+        end
+
+        it 'returns an array of documents which contain the phrase' do
+          expect(meta_data['results']).to eq 1
+          expect(documents.count).to eq 1
+        end
       end
     end
   end

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -1,7 +1,19 @@
 FactoryGirl.define do
   factory :block, class: Comfy::Cms::Block do
     identifier { 'content' }
-    content { 'some block content' }
+    content { 'financial' }
     association :blockable, factory: :page
+
+    trait :debt_content do
+      content { 'debt' }
+    end
+
+    trait :pension_content do
+      content { 'pension' }
+    end
+
+    trait :financial_wellbeing_content do
+      content { 'Financial well being: the employee view' }
+    end
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -39,6 +39,27 @@ FactoryGirl.define do
         page.reload
       end
     end
+
+    factory :insight_page_about_debt do
+      site { create :site, identifier: 'test-documents'}
+      after(:create) do |page|
+        create :block, :debt_content, identifier: 'content', blockable: page
+      end
+    end
+
+    factory :insight_page_about_pensions do
+      site { create :site, identifier: 'test-documents'}
+      after(:create) do |page|
+        create :block, :pension_content, identifier: 'content', blockable: page
+      end
+    end
+
+    factory :insight_page_about_financial_wellbeing do
+      site { create :site, identifier: 'test-documents'}
+      after(:create) do |page|
+        create :block, :financial_wellbeing_content, identifier: 'content', blockable: page
+      end
+    end
   end
 
   factory :child_page, class: Comfy::Cms::Page do


### PR DESCRIPTION
[TP 8997](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/8997)

Uses the `keyword` parameter from the request to search page content and return an array of documents which contain the `keyword`

### Technical
The [Comfortable Mexican Sofa gem](https://github.com/moneyadviceservice/comfortable-mexican-sofa) provides scopes which the api can use for cleaner looking queries. We've used the [with_content_like](https://github.com/moneyadviceservice/comfortable-mexican-sofa/blob/master/app/models/comfy/cms/page.rb#L104) scope to implement the keyword search.

### Next Steps
1. Search title
2. Search overview