### PR TITLE
Document api with Apipie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://gems.dev.mas.local'
 source 'https://rubygems.org'
 
 gem 'active_model_serializers'
+gem 'apipie-rails', '~> 0.5.6'
 gem 'autoprefixer-rails'
 gem 'azure', '0.7.7'
 gem 'bowndler', git: 'git@github.com:moneyadviceservice/bowndler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    apipie-rails (0.5.6)
+      rails (>= 4.1)
     arel (5.0.1.20140414130214)
     ast (2.0.0)
     astrolabe (1.3.0)
@@ -544,6 +546,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  apipie-rails (~> 0.5.6)
   autoprefixer-rails
   azure (= 0.7.7)
   better_errors
@@ -603,4 +606,4 @@ DEPENDENCIES
   word-to-markdown!
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ This can easily be deployed to Heroku but the MAS organisation uses its own depl
 ### Technical Docs
 [CMS](https://github.com/moneyadviceservice/technical-docs/tree/master/cms)
 
+We use [apipie](https://github.com/Apipie/apipie-rails) to document the cms api. Once you've set up the project and started a server, you can view the docs by visiting `http://localhost:3000/apipie`
+
 ### Component Styleguide
 
 [The styleguide](http://0.0.0.0:3000/styleguide) lists all HTML/CSS components used within the CMS.

--- a/app/controllers/api/category_contents_controller.rb
+++ b/app/controllers/api/category_contents_controller.rb
@@ -5,11 +5,16 @@ module API
     skip_before_action :load_cms_page
     around_filter :validate_locale
 
+    api :GET, '/:locale/categories'
+    param :locale, /[en|cy]/, required: true
     def index
       @primary_navigation, @secondary_navigation = Comfy::Cms::Category.navigation_categories
       render json: @primary_navigation, scope: locale
     end
 
+    api :GET, '/:locale/categories/:id'
+    param :locale, /[en|cy]/, required: true
+    param :id, :number, required: true
     def show
       @category = Comfy::Cms::Category.find_by(label: params[:id])
       render json: @category, scope: locale

--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -3,6 +3,10 @@ module API
     before_action :find_site
     before_action :verify_page_type, only: :show, if: -> { slug.present? }
 
+    api :GET, '/:locale/:page_type/(*slug)'
+    param :locale, /[en|cy]/, required: true
+    param :page_type, String, required: true
+    param :slug, String, required: false
     def show
       page = if slug.present?
                current_site.pages
@@ -16,12 +20,18 @@ module API
       render_page(page)
     end
 
+    api :GET, '/preview/:locale/(*slug)'
+    param :locale, /[en|cy]/, required: true
+    param :slug, String, required: false
     def preview
       page = current_site.pages.find_by(slug: params[:slug])
 
       render_page(page, scope: 'preview')
     end
 
+    api :GET, '/:locale/:page_type/published'
+    param :locale, /[en|cy]/, required: true
+    param :page_type, String, required: true
     def published
       pages = current_site.pages
         .published
@@ -31,6 +41,9 @@ module API
       render json: pages, each_serializer: FeedPageSerializer
     end
 
+    api :GET, '/:locale/:page_type/unpublished'
+    param :locale, /[en|cy]/, required: true
+    param :page_type, String, required: true
     def unpublished
       pages = current_site.pages.unpublished.layout_identifier(params[:page_type])
 

--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -2,6 +2,10 @@ module API
   class DocumentsController < APIController
     before_action :find_site
 
+    api :GET, '/:locale/documents'
+    param :locale, String, required: true
+    param :page_type, String, required: false
+    param :keyword, String, required: false
     def index
       @documents = current_site.pages.published
 

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -1,0 +1,8 @@
+Apipie.configure do |config|
+  config.app_name                = "Cms"
+  config.api_base_url            = "/api"
+  config.doc_base_url            = "/apipie"
+  config.api_controllers_matcher = "#{Rails.root}/app/controllers/**/*.rb"
+  config.default_locale          = 'en'
+  config.languages               = ['en']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  apipie
+  
   devise_for :users, class_name: 'Comfy::Cms::User'
 
   resources :word_documents

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe API::DocumentsController, type: :request do
           expect(meta_data['results']).to eq 1
           expect(documents.count).to eq 1
         end
+      end
 
       context 'when the keyword is not found' do
         let(:params) { { document_type: 'insight', keyword: 'nosuchterm' } }


### PR DESCRIPTION
This pr explores one option for documenting the cms api, namely using [Apipie](https://github.com/Apipie/apipie-rails).

Documentation for some of the api methods has been included as an example. This approach is open for discussion and is merely a response to a request to look into how we document the cms api.