### PR TITLE
[WIP] 8997 with title like scope

### DIFF
--- a/app/models/comfy/cms/page.rb
+++ b/app/models/comfy/cms/page.rb
@@ -59,6 +59,10 @@ class Comfy::Cms::Page < ActiveRecord::Base
     joins(:layout).where(comfy_cms_layouts: { identifier: identifier.singularize })
   end)
 
+  scope :with_title_like, ->(phrase) {
+    where('comfy_cms_pages.label LIKE ?', "%#{phrase}%")
+  }
+
   def self.in_category(category_id)
     joins(
       'INNER JOIN comfy_cms_categorizations

--- a/spec/models/comfy/cms/page_spec.rb
+++ b/spec/models/comfy/cms/page_spec.rb
@@ -312,6 +312,33 @@ RSpec.describe Comfy::Cms::Page do
     end
   end
 
+  describe 'with_title_like scope' do
+    let!(:page1) { create(:page, label: label1) }
+    let!(:page2) { create(:page, label: label2) }
+    let(:label1) { 'Financial well being: the employee view' }
+    let(:label2) { 'Financial well being: the employer view' }
+
+    context 'when a search term has been provided' do
+      let(:results) { Comfy::Cms::Page.with_title_like(search_term) }
+      let(:search_term) { 'the employee view' }
+
+      it 'returns pages which have a title containing the search term' do
+        expect(results.first).to eq page1
+        expect(results.count).to eq 1
+      end
+    end
+
+    context 'when no search term has been provided' do
+      let(:results) { Comfy::Cms::Page.with_title_like(search_term) }
+      let(:search_term) { '' }
+
+      it 'returns pages which have a title containing the search term' do
+        expect(results).to eq [ page1, page2 ]
+        expect(results.count).to eq 2
+      end
+    end
+  end
+
   describe 'has ever been published' do
     let(:page) { create(:page) }
 


### PR DESCRIPTION
[TP 8997](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/8997)

The FinCap search facility requires that page titles are searched for specific content. This pr adds a scope for serving FinCap search requests.

### Technical
* Add a scope to the page model, `with_title_like`
* Use this scope for searching through page titles e.g. `pages.published.with_title_like(search_term)`
