### PR TITLE
[DEV APPROVED] apipie param is not required

### DIFF
--- a/app/controllers/api/content_controller.rb
+++ b/app/controllers/api/content_controller.rb
@@ -5,7 +5,7 @@ module API
 
     api :GET, '/:locale/:page_type/(*slug)'
     param :locale, /[en|cy]/, required: true
-    param :page_type, String, required: true
+    param :page_type, String, required: false
     param :slug, String, required: false
     def show
       page = if slug.present?


### PR DESCRIPTION
Addresses an error from the apipie gem - specifically the parameter for the route is optional and was incorrectly set to required [when the apipie gem was originally implemented](https://github.com/moneyadviceservice/cms/pull/406).