### PR TITLE
8997 API: Search page titles for search term

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -31,7 +31,9 @@ module API
       end
 
       if keyword.present?
-        @documents = @documents.with_content_like(keyword)
+        @documents = @documents
+          .joins(:blocks)
+          .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%")
       end
     end
 

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -7,12 +7,16 @@ RSpec.describe API::DocumentsController, type: :request do
   let(:documents) { response_body['documents'] }
   let(:meta_data) { response_body['meta'] }
   let(:url) { '/api/en/documents' }
+  let(:insight_page_params) { {site: site, layout: insight_layout } }
   let(:review_layout)  { create :layout, identifier: 'review' }
-  let(:insight_layout)  { create :layout, identifier: 'insight' }
-  let!(:insight_page) { create(:insight_page_about_financial_wellbeing, site: site, layout: insight_layout) }
-  let!(:insight_page_1) { create(:insight_page_about_debt, site: site, layout: insight_layout) }
-  let!(:insight_page_2) { create(:insight_page_about_pensions, site: site, layout: insight_layout) }
-  let!(:review_page_1) { create(:page, site: site, layout: review_layout) }
+  let(:insight_layout) { create :layout, identifier: 'insight' }
+  let!(:insight_page1) { create(:insight_page_about_financial_wellbeing, insight_page_params) }
+  let!(:insight_page2) { create(:insight_page_about_debt, insight_page_params) }
+  let!(:insight_page3) { create(:insight_page_about_pensions, insight_page_params) }
+  let!(:insight_page4) { create(:insight_page_titled_annuity, insight_page_params) }
+  let!(:insight_page5) { create(:insight_page_titled_annuity2, insight_page_params) }
+  let!(:insight_page6) { create(:insight_page_about_annuity, insight_page_params) }
+  let!(:review_page1) { create(:page, site: site, layout: review_layout) }
 
   before do
     allow_any_instance_of(PageSerializer)
@@ -26,16 +30,16 @@ RSpec.describe API::DocumentsController, type: :request do
       let(:params) { {} }
 
       it 'returns all documents' do
-        expect(meta_data['results']).to eq 4
-        expect(documents.count).to eq 4
+        expect(meta_data['results']).to eq 7
+        expect(documents.count).to eq 7
       end
     end
 
     context 'when documents of type insight are requested' do
       let(:params) { { document_type: 'insight' } }
       it 'returns all insight documents' do
-        expect(meta_data['results']).to eq 3
-        expect(documents.count).to eq 3
+        expect(meta_data['results']).to eq 6
+        expect(documents.count).to eq 6
       end
     end
   end
@@ -43,11 +47,48 @@ RSpec.describe API::DocumentsController, type: :request do
   describe 'keyword search' do
     context 'when the document_type is specified' do
       context 'when a keyword is provided' do
-        let(:params) { { document_type: 'insight', keyword: 'pension' } }
+        context 'and the keyword is found in the content' do
+          let(:params) { { document_type: 'insight', keyword: 'pension' } }
 
-        it 'returns an array of documents which contain the keyword' do
-          expect(meta_data['results']).to eq 1
-          expect(documents.count).to eq 1
+          it 'returns an array of documents which contain the keyword' do
+            expect(meta_data['results']).to eq 1
+            expect(params[:keyword]).to be_in(
+              documents.first["blocks"].first["content"]
+            )
+          end
+        end
+
+        context 'and the keyword is found in the middle of the title' do
+          let(:params) { { document_type: 'insight', keyword: 'stress' } }
+
+          it 'returns documents with the keyword in the title' do
+            expect(params[:keyword]).to be_in(documents.first["label"])
+          end
+        end
+
+        context 'and the keyword is found at the start of the title' do
+          let(:params) { { document_type: 'insight', keyword: 'annuity' } }
+
+          it 'returns documents with the keyword at the start of the title' do
+            expect(documents.first["label"]).to start_with(params[:keyword])
+          end
+        end
+
+        context 'when the keyword is in the title of one document and content of another' do
+          let(:params) { { document_type: 'insight', keyword: 'annuity' } }
+
+          it 'returns all the documents' do
+            documents.each do |doc|
+              doc_title = doc['label']
+              doc_content = doc['blocks'].select do |block|
+                block['identifier'] =='content' && block['content']
+              end.map{|block| block['content']}
+
+              results = [doc_title, doc_content].flatten
+
+              expect(results.any?{|result| result.include?(params[:keyword])}).to be_truthy
+            end
+          end
         end
       end
 
@@ -69,8 +110,9 @@ RSpec.describe API::DocumentsController, type: :request do
         end
 
         it 'returns an array of documents which contain the phrase' do
-          expect(meta_data['results']).to eq 1
-          expect(documents.count).to eq 1
+          expect(params[:keyword]).to be_in(
+            documents.first["blocks"].first["content"]
+          )
         end
       end
     end

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -15,5 +15,9 @@ FactoryGirl.define do
     trait :financial_wellbeing_content do
       content { 'Financial well being: the employee view' }
     end
+
+    trait :annuity_content do
+      content { 'What does annuity mean?' }
+    end
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -42,6 +42,7 @@ FactoryGirl.define do
 
     factory :insight_page_about_debt do
       site { create :site, identifier: 'test-documents'}
+      label 'Debt, stress and pay levels'
       after(:create) do |page|
         create :block, :debt_content, identifier: 'content', blockable: page
       end
@@ -58,6 +59,29 @@ FactoryGirl.define do
       site { create :site, identifier: 'test-documents'}
       after(:create) do |page|
         create :block, :financial_wellbeing_content, identifier: 'content', blockable: page
+      end
+    end
+
+    factory :insight_page_about_annuity do
+      site { create :site, identifier: 'test-documents'}
+      after(:create) do |page|
+        create :block, :annuity_content, identifier: 'content', blockable: page
+      end
+    end
+
+    factory :insight_page_titled_annuity do
+      site { create :site, identifier: 'test-documents'}
+      label 'annuity'
+      after(:create) do |page|
+        create :block, identifier: 'raw_tile_1_heading', blockable: page
+      end
+    end
+
+    factory :insight_page_titled_annuity2 do
+      site { create :site, identifier: 'test-documents'}
+      label 'Page about annuity stuff'
+      after(:create) do |page|
+        create :block, identifier: 'raw_tile_1_heading', blockable: page
       end
     end
   end


### PR DESCRIPTION
[TP 8997](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/8997)

This pr adds searching through page titles for a given keyword.

### Technical
The query needs to return pages where the keyword is in the title OR the content. Since chaining scopes only works for 'AND' search queries, it is necessary to use the more wordy `where` syntax.

### Next Steps
1. Search only blocks which are 'content' or 'overview'
2. Refactor the documents_controller#filter_documents method