### PR TITLE
[Dev Approved] Only search content or overview blocks

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -2,6 +2,8 @@ module API
   class DocumentsController < APIController
     before_action :find_site
 
+    BLOCKS_TO_SEARCH = %w[content overview]
+
     api :GET, '/:locale/documents'
     param :locale, String, required: true
     param :page_type, String, required: false
@@ -33,6 +35,7 @@ module API
       if keyword.present?
         @documents = @documents
           .joins(:blocks)
+          .where('comfy_cms_blocks.identifier' => BLOCKS_TO_SEARCH)
           .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%")
       end
     end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe API::DocumentsController, type: :request do
   let!(:insight_page4) { create(:insight_page_titled_annuity, insight_page_params) }
   let!(:insight_page5) { create(:insight_page_titled_annuity2, insight_page_params) }
   let!(:insight_page6) { create(:insight_page_about_annuity, insight_page_params) }
+  let!(:insight_page7) { create(:insight_page_with_overview_block, insight_page_params) }
+  let!(:insight_page8) { create(:insight_page_with_raw_cta_text_block, insight_page_params) }
   let!(:review_page1) { create(:page, site: site, layout: review_layout) }
 
   before do
@@ -30,16 +32,17 @@ RSpec.describe API::DocumentsController, type: :request do
       let(:params) { {} }
 
       it 'returns all documents' do
-        expect(meta_data['results']).to eq 7
-        expect(documents.count).to eq 7
+        expect(meta_data['results']).to eq 9
+        expect(documents.count).to eq 9
       end
     end
 
     context 'when documents of type insight are requested' do
       let(:params) { { document_type: 'insight' } }
+
       it 'returns all insight documents' do
-        expect(meta_data['results']).to eq 6
-        expect(documents.count).to eq 6
+        expect(meta_data['results']).to eq 8
+        expect(documents.count).to eq 8
       end
     end
   end
@@ -47,14 +50,31 @@ RSpec.describe API::DocumentsController, type: :request do
   describe 'keyword search' do
     context 'when the document_type is specified' do
       context 'when a keyword is provided' do
-        context 'and the keyword is found in the content' do
+        context 'and the keyword is found in a "content" block' do
           let(:params) { { document_type: 'insight', keyword: 'pension' } }
 
-          it 'returns an array of documents which contain the keyword' do
-            expect(meta_data['results']).to eq 1
+          it 'returns documents which contain the keyword' do
             expect(params[:keyword]).to be_in(
               documents.first["blocks"].first["content"]
             )
+          end
+        end
+
+        context 'and the keyword is found in an "overview" block' do
+          let(:params) { { document_type: 'insight', keyword: 'redundancy' } }
+
+          it 'returns documents which contain the keyword' do
+            expect(params[:keyword]).to be_in(
+              documents.first["blocks"].first["content"]
+            )
+          end
+        end
+
+        context 'and the keyword is found in a block that is not content or overview' do
+          let(:params) { { document_type: 'insight', keyword: 'random' } }
+
+          it 'does not return the document' do
+            expect(documents.count).to eq 0
           end
         end
 

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -17,7 +17,18 @@ FactoryGirl.define do
     end
 
     trait :annuity_content do
+      identifier { 'content' }
       content { 'What does annuity mean?' }
+    end
+
+    trait :redundancy_overview do
+      identifier { 'overview' }
+      content { 'redundancy overview' }
+    end
+
+    trait :raw_cta_text_content do
+      identifier { 'raw_cta_text' }
+      content { 'random content' }
     end
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -65,7 +65,7 @@ FactoryGirl.define do
     factory :insight_page_about_annuity do
       site { create :site, identifier: 'test-documents'}
       after(:create) do |page|
-        create :block, :annuity_content, identifier: 'content', blockable: page
+        create :block, :annuity_content, blockable: page
       end
     end
 
@@ -73,7 +73,7 @@ FactoryGirl.define do
       site { create :site, identifier: 'test-documents'}
       label 'annuity'
       after(:create) do |page|
-        create :block, identifier: 'raw_tile_1_heading', blockable: page
+        create :block, identifier: 'content', blockable: page
       end
     end
 
@@ -81,7 +81,23 @@ FactoryGirl.define do
       site { create :site, identifier: 'test-documents'}
       label 'Page about annuity stuff'
       after(:create) do |page|
-        create :block, identifier: 'raw_tile_1_heading', blockable: page
+        create :block, identifier: 'content', blockable: page
+      end
+    end
+
+    factory :insight_page_with_overview_block do
+      site { create :site, identifier: 'test-documents'}
+      label 'Page with overview block'
+      after(:create) do |page|
+        create :block, :redundancy_overview, blockable: page
+      end
+    end
+
+    factory :insight_page_with_raw_cta_text_block do
+      site { create :site, identifier: 'test-documents'}
+      label 'Page with block other than content or identifier'
+      after(:create) do |page|
+        create :block, :raw_cta_text_content, blockable: page
       end
     end
   end


### PR DESCRIPTION
[TP 8997](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/8997)

This pr addresses part of the 4th expectation in the user story, namely performing the search on the **content** or the **overview** blocks of a page.

PRs #410 and #405 address the other parts of the story.