### PR TITLE
modify query to select distinct pages

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -36,7 +36,7 @@ module API
         @documents = @documents
           .joins(:blocks)
           .where('comfy_cms_blocks.identifier' => BLOCKS_TO_SEARCH)
-          .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%")
+          .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%").uniq
       end
     end
 

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe API::DocumentsController, type: :request do
   let!(:insight_page4) { create(:insight_page_titled_annuity, insight_page_params) }
   let!(:insight_page5) { create(:insight_page_titled_annuity2, insight_page_params) }
   let!(:insight_page6) { create(:insight_page_about_annuity, insight_page_params) }
-  let!(:insight_page7) { create(:insight_page_with_overview_block, insight_page_params) }
+  let!(:insight_page7) { create(:insight_page_with_lotsa_blocks, insight_page_params) }
   let!(:insight_page8) { create(:insight_page_with_raw_cta_text_block, insight_page_params) }
   let!(:review_page1) { create(:page, site: site, layout: review_layout) }
 
@@ -67,6 +67,7 @@ RSpec.describe API::DocumentsController, type: :request do
             expect(params[:keyword]).to be_in(
               documents.first["blocks"].first["content"]
             )
+            expect(documents.count).to eq 1
           end
         end
 

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -26,6 +26,16 @@ FactoryGirl.define do
       content { 'redundancy overview' }
     end
 
+    trait :redundancy_content do
+      identifier { 'content' }
+      content { 'redundancy content' }
+    end
+
+    trait :redundancy_topic do
+      identifier { 'topic' }
+      content { 'redundancy topic' }
+    end
+
     trait :raw_cta_text_content do
       identifier { 'raw_cta_text' }
       content { 'random content' }

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -85,11 +85,13 @@ FactoryGirl.define do
       end
     end
 
-    factory :insight_page_with_overview_block do
+    factory :insight_page_with_lotsa_blocks do
       site { create :site, identifier: 'test-documents'}
-      label 'Page with overview block'
+      label 'Redundancy overview'
       after(:create) do |page|
         create :block, :redundancy_overview, blockable: page
+        create :block, :redundancy_content, blockable: page
+        create :block, :redundancy_topic, blockable: page
       end
     end
 


### PR DESCRIPTION
Fix for a bug in the search which was returning a page twice if the keyword was found in the title and the content block. By adding the `uniq` qualify we ensure that a page is only returned once.