### PR TITLE
TP 8999 api search filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development do
 end
 
 group :test do
+  gem 'brakeman', require: false
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'poltergeist', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     bootstrap-sass (3.1.1.1)
       sass (~> 3.2)
     bootstrap_form (2.1.1)
+    brakeman (4.2.0)
     bugsnag (2.8.12)
       json (~> 1.7, >= 1.7.7)
     builder (3.2.2)
@@ -552,6 +553,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bowndler!
+  brakeman
   bugsnag
   capybara (= 2.4.1)
   clockwork

--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -6,9 +6,13 @@ module API
     param :locale, String, required: true
     param :page_type, String, required: false
     param :keyword, String, required: false
+    param :blocks, Array, required: false
     def index
       documents = DocumentProvider.new(
-        current_site, params[:document_type], params[:keyword]
+        current_site, 
+        params[:document_type], 
+        params[:keyword], 
+        params[:blocks]
       ).retrieve
 
       render json: documents, meta: { results: documents.count }, root: 'documents'

--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -2,43 +2,16 @@ module API
   class DocumentsController < APIController
     before_action :find_site
 
-    BLOCKS_TO_SEARCH = %w[content overview]
-
     api :GET, '/:locale/documents'
     param :locale, String, required: true
     param :page_type, String, required: false
     param :keyword, String, required: false
     def index
-      @documents = current_site.pages.published
+      documents = DocumentProvider.new(
+        current_site, params[:document_type], params[:keyword]
+      ).retrieve
 
-      filter_documents
-
-      render json: @documents, meta: { results: @documents.count }, root: 'documents'
+      render json: documents, meta: { results: documents.count }, root: 'documents'
     end
-
-    private
-
-    def document_type
-      params[:document_type]
-    end
-
-    def keyword
-      params[:keyword]
-    end
-
-    def filter_documents
-      if document_type.present?
-        @documents = @documents.joins(:layout)
-          .where('comfy_cms_layouts.identifier' => document_type)
-      end
-
-      if keyword.present?
-        @documents = @documents
-          .joins(:blocks)
-          .where('comfy_cms_blocks.identifier' => BLOCKS_TO_SEARCH)
-          .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%").uniq
-      end
-    end
-
   end
 end

--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -1,12 +1,13 @@
 class DocumentProvider
-  attr_reader :current_site, :document_type, :keyword
+  attr_reader :current_site, :document_type, :keyword, :filters
 
   BLOCKS_TO_SEARCH = %w[content overview]
 
-  def initialize(current_site, document_type, keyword)
+  def initialize(current_site, document_type, keyword, filters)
     @current_site = current_site
     @document_type = document_type
     @keyword = keyword
+    @filters = filters
   end
 
   def retrieve
@@ -14,6 +15,7 @@ class DocumentProvider
 
     filter_by_type
     filter_by_keyword
+    filter_documents
   end
 
   private
@@ -22,8 +24,7 @@ class DocumentProvider
     return @documents if document_type.blank?
     
     @documents = @documents.joins(:layout)
-        .where('comfy_cms_layouts.identifier' => document_type)
-
+      .where('comfy_cms_layouts.identifier' => document_type)
   end
 
   def filter_by_keyword
@@ -33,5 +34,26 @@ class DocumentProvider
       .joins(:blocks)
       .where('comfy_cms_blocks.identifier' => BLOCKS_TO_SEARCH)
       .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%").uniq
+  end
+
+  def filter_documents
+    return @documents if filters.blank?
+    
+    filters_to_hash.each do |filter, value|
+      @documents = @documents
+        .joins(:blocks)
+        .where('comfy_cms_blocks.identifier ? = AND comfy_cms_blocks.content = ?', filter, value)
+    end
+  end
+
+  def filters_to_hash
+    filters.reduce({}) do |acc, filter|
+      if acc[filter[:identifier]]
+        acc[filter[:identifier]] << acc[filter[:value]]
+      else
+        acc[filter[:identifier]] = acc[filter[:value]]
+      end
+      acc
+    end
   end
 end

--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -1,0 +1,37 @@
+class DocumentProvider
+  attr_reader :current_site, :document_type, :keyword
+
+  BLOCKS_TO_SEARCH = %w[content overview]
+
+  def initialize(current_site, document_type, keyword)
+    @current_site = current_site
+    @document_type = document_type
+    @keyword = keyword
+  end
+
+  def retrieve
+    @documents = current_site.pages.published
+
+    filter_by_type
+    filter_by_keyword
+  end
+
+  private
+
+  def filter_by_type
+    return @documents if document_type.blank?
+    
+    @documents = @documents.joins(:layout)
+        .where('comfy_cms_layouts.identifier' => document_type)
+
+  end
+
+  def filter_by_keyword
+    return @documents if keyword.blank?
+   
+    @documents = @documents
+      .joins(:blocks)
+      .where('comfy_cms_blocks.identifier' => BLOCKS_TO_SEARCH)
+      .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%").uniq
+  end
+end

--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -1,7 +1,7 @@
 class DocumentProvider
   attr_reader :current_site, :document_type, :keyword, :filters
 
-  BLOCKS_TO_SEARCH = %w[content overview]
+  BLOCKS_TO_SEARCH = %w(content overview)
 
   def initialize(current_site, document_type, keyword, filters)
     @current_site = current_site
@@ -13,45 +13,54 @@ class DocumentProvider
   def retrieve
     @documents = current_site.pages.published
 
-    filter_by_type
+    filter_by_document_type
     filter_by_keyword
     filter_documents
   end
 
   private
 
-  def filter_by_type
+  def filter_by_document_type
     return @documents if document_type.blank?
-    
+
     @documents = @documents.joins(:layout)
       .where('comfy_cms_layouts.identifier' => document_type)
   end
 
   def filter_by_keyword
     return @documents if keyword.blank?
-   
+
     @documents = @documents
       .joins(:blocks)
-      .where('comfy_cms_blocks.identifier' => BLOCKS_TO_SEARCH)
-      .where('comfy_cms_pages.label LIKE ? OR comfy_cms_blocks.content LIKE ?', "%#{keyword}%", "%#{keyword}%").uniq
+      .where(
+        'comfy_cms_pages.label LIKE ? OR
+          (comfy_cms_blocks.content LIKE ? AND comfy_cms_blocks.identifier IN (?))',
+          "%#{keyword}%", "%#{keyword}%", BLOCKS_TO_SEARCH
+      ).uniq
   end
 
   def filter_documents
     return @documents if filters.blank?
-    
+
     filters_to_hash.each do |filter, value|
-      @documents = @documents
-        .joins(:blocks)
-        .where('comfy_cms_blocks.identifier ? = AND comfy_cms_blocks.content = ?', filter, value)
+      @documents = Comfy::Cms::Page
+        .unscoped
+        .select("pages.*").from("(#{@documents.to_sql}) as pages")
+        .joins("INNER JOIN comfy_cms_blocks ON comfy_cms_blocks.blockable_id = pages.id AND
+          comfy_cms_blocks.blockable_type = 'Comfy::Cms::Page'")
+        .where('comfy_cms_blocks.identifier' => filter)
+        .where('comfy_cms_blocks.content' => value)
     end
+
+    @documents
   end
 
   def filters_to_hash
     filters.reduce({}) do |acc, filter|
       if acc[filter[:identifier]]
-        acc[filter[:identifier]] << acc[filter[:value]]
+        acc[filter[:identifier]] << filter[:value]
       else
-        acc[filter[:identifier]] = acc[filter[:value]]
+        acc[filter[:identifier]] = [filter[:value]]
       end
       acc
     end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe API::DocumentsController, type: :request do
     it 'returns all documents' do
       expect(DocumentProvider)
         .to receive(:new)
-        .with(site, 'insight', 'insurance')
+        .with(site, 'insight', 'insurance', nil)
         .and_return(document_provider)
 
-      expect(document_provider).to receive(:retrieve).and_return(documents)
+      expect(document_provider)
+        .to receive(:retrieve)
+        .and_return(documents)
 
       get "/api/en/documents?document_type=insight&keyword=insurance"
     end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -3,139 +3,19 @@ RSpec.describe API::DocumentsController, type: :request do
     create(:site, path: 'en', locale: 'en', is_mirrored: true)
   end
 
-  let(:response_body) { JSON.load(response.body) }
-  let(:documents) { response_body['documents'] }
-  let(:meta_data) { response_body['meta'] }
-  let(:url) { '/api/en/documents' }
-  let(:insight_page_params) { {site: site, layout: insight_layout } }
-  let(:review_layout)  { create :layout, identifier: 'review' }
-  let(:insight_layout) { create :layout, identifier: 'insight' }
-  let!(:insight_page1) { create(:insight_page_about_financial_wellbeing, insight_page_params) }
-  let!(:insight_page2) { create(:insight_page_about_debt, insight_page_params) }
-  let!(:insight_page3) { create(:insight_page_about_pensions, insight_page_params) }
-  let!(:insight_page4) { create(:insight_page_titled_annuity, insight_page_params) }
-  let!(:insight_page5) { create(:insight_page_titled_annuity2, insight_page_params) }
-  let!(:insight_page6) { create(:insight_page_about_annuity, insight_page_params) }
-  let!(:insight_page7) { create(:insight_page_with_lotsa_blocks, insight_page_params) }
-  let!(:insight_page8) { create(:insight_page_with_raw_cta_text_block, insight_page_params) }
-  let!(:review_page1) { create(:page, site: site, layout: review_layout) }
-
-  before do
-    allow_any_instance_of(PageSerializer)
-      .to receive(:related_content).and_return({})
-
-    get url, params
-  end
-
+  let(:document_provider) { double(DocumentProvider) }
+  let(:documents) { [] }
+  
   describe 'GET /:locale/documents' do
-    context 'when all documents are requested' do
-      let(:params) { {} }
+    it 'returns all documents' do
+      expect(DocumentProvider)
+        .to receive(:new)
+        .with(site, 'insight', 'insurance')
+        .and_return(document_provider)
 
-      it 'returns all documents' do
-        expect(meta_data['results']).to eq 9
-        expect(documents.count).to eq 9
-      end
-    end
+      expect(document_provider).to receive(:retrieve).and_return(documents)
 
-    context 'when documents of type insight are requested' do
-      let(:params) { { document_type: 'insight' } }
-
-      it 'returns all insight documents' do
-        expect(meta_data['results']).to eq 8
-        expect(documents.count).to eq 8
-      end
-    end
-  end
-
-  describe 'keyword search' do
-    context 'when the document_type is specified' do
-      context 'when a keyword is provided' do
-        context 'and the keyword is found in a "content" block' do
-          let(:params) { { document_type: 'insight', keyword: 'pension' } }
-
-          it 'returns documents which contain the keyword' do
-            expect(params[:keyword]).to be_in(
-              documents.first["blocks"].first["content"]
-            )
-          end
-        end
-
-        context 'and the keyword is found in an "overview" block' do
-          let(:params) { { document_type: 'insight', keyword: 'redundancy' } }
-
-          it 'returns documents which contain the keyword' do
-            expect(params[:keyword]).to be_in(
-              documents.first["blocks"].first["content"]
-            )
-            expect(documents.count).to eq 1
-          end
-        end
-
-        context 'and the keyword is found in a block that is not content or overview' do
-          let(:params) { { document_type: 'insight', keyword: 'random' } }
-
-          it 'does not return the document' do
-            expect(documents.count).to eq 0
-          end
-        end
-
-        context 'and the keyword is found in the middle of the title' do
-          let(:params) { { document_type: 'insight', keyword: 'stress' } }
-
-          it 'returns documents with the keyword in the title' do
-            expect(params[:keyword]).to be_in(documents.first["label"])
-          end
-        end
-
-        context 'and the keyword is found at the start of the title' do
-          let(:params) { { document_type: 'insight', keyword: 'annuity' } }
-
-          it 'returns documents with the keyword at the start of the title' do
-            expect(documents.first["label"]).to start_with(params[:keyword])
-          end
-        end
-
-        context 'when the keyword is in the title of one document and content of another' do
-          let(:params) { { document_type: 'insight', keyword: 'annuity' } }
-
-          it 'returns all the documents' do
-            documents.each do |doc|
-              doc_title = doc['label']
-              doc_content = doc['blocks'].select do |block|
-                block['identifier'] =='content' && block['content']
-              end.map{|block| block['content']}
-
-              results = [doc_title, doc_content].flatten
-
-              expect(results.any?{|result| result.include?(params[:keyword])}).to be_truthy
-            end
-          end
-        end
-      end
-
-      context 'when the keyword is not found' do
-        let(:params) { { document_type: 'insight', keyword: 'nosuchterm' } }
-
-        it 'returns an empty array' do
-          expect(meta_data['results']).to eq 0
-          expect(documents.count).to eq 0
-        end
-      end
-
-      context 'when the search term is a phrase' do
-        let(:params) do
-          {
-            document_type: 'insight', 
-            keyword: 'Financial well being: the employee view' 
-          }
-        end
-
-        it 'returns an array of documents which contain the phrase' do
-          expect(params[:keyword]).to be_in(
-            documents.first["blocks"].first["content"]
-          )
-        end
-      end
+      get "/api/en/documents?document_type=insight&keyword=insurance"
     end
   end
 end

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -5,14 +5,17 @@ FactoryGirl.define do
     association :blockable, factory: :page
 
     trait :debt_content do
+      identifier { 'content' }
       content { 'debt' }
     end
 
     trait :pension_content do
+      identifier { 'content' }
       content { 'pension' }
     end
 
     trait :financial_wellbeing_content do
+      identifier { 'content' }
       content { 'Financial well being: the employee view' }
     end
 
@@ -39,6 +42,26 @@ FactoryGirl.define do
     trait :raw_cta_text_content do
       identifier { 'raw_cta_text' }
       content { 'random content' }
+    end
+
+    trait :working_age_client_group do
+      identifier { 'client_groups' }
+      content { 'Working age (18 - 65)' }
+    end
+
+    trait :young_adults_client_group do
+      identifier { 'client_groups' }
+      content { 'Young adults (17 - 24)' }
+    end
+
+    trait :saving_topic do
+      identifier { 'topic' }
+      content { 'Saving' }
+    end
+
+    trait :published_by_uk do
+      identifier { 'country_of_delivery' }
+      content { 'United Kingdom' }
     end
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -40,57 +40,62 @@ FactoryGirl.define do
       end
     end
 
-    factory :insight_page_about_debt do
+    factory :page_abt_debt_and_stress do
       site { create :site, identifier: 'test-documents'}
       label 'Debt, stress and pay levels'
       after(:create) do |page|
-        create :block, :debt_content, identifier: 'content', blockable: page
+        create :block, :debt_content, blockable: page
+        create :block, :working_age_client_group, blockable: page
+      end
+    end
+
+    factory :uk_study_about_work_and_stress do
+      site { create :site, identifier: 'test-documents'}
+      label 'Debt, stress and pay levels in the UK'
+      after(:create) do |page|
+        create :block, :debt_content, blockable: page
+        create :block, :working_age_client_group, blockable: page
+        create :block, :saving_topic, blockable: page
+        create :block, :published_by_uk, blockable: page
+
       end
     end
 
     factory :insight_page_about_pensions do
       site { create :site, identifier: 'test-documents'}
       after(:create) do |page|
-        create :block, :pension_content, identifier: 'content', blockable: page
+        create :block, :pension_content, blockable: page
       end
     end
 
-    factory :insight_page_about_financial_wellbeing do
+    factory :insight_page_titled_pensions do
+      site { create :site, identifier: 'test-documents'}
+      label 'pensions'
+      after(:create) do |page|
+        create :block, :debt_content, blockable: page
+      end
+    end
+
+    factory :insight_page do
       site { create :site, identifier: 'test-documents'}
       after(:create) do |page|
-        create :block, :financial_wellbeing_content, identifier: 'content', blockable: page
+        create :block, :financial_wellbeing_content, blockable: page
       end
     end
 
-    factory :insight_page_about_annuity do
+    factory :insight_page_titled_annuities do
       site { create :site, identifier: 'test-documents'}
-      after(:create) do |page|
-        create :block, :annuity_content, blockable: page
-      end
-    end
-
-    factory :insight_page_titled_annuity do
-      site { create :site, identifier: 'test-documents'}
-      label 'annuity'
-      after(:create) do |page|
-        create :block, identifier: 'content', blockable: page
-      end
-    end
-
-    factory :insight_page_titled_annuity2 do
-      site { create :site, identifier: 'test-documents'}
-      label 'Page about annuity stuff'
+      label 'Annuities'
       after(:create) do |page|
         create :block, identifier: 'content', blockable: page
       end
     end
 
-    factory :insight_page_with_lotsa_blocks do
+    factory :insight_page_with_overview_block do
       site { create :site, identifier: 'test-documents'}
-      label 'Redundancy overview'
+      label 'Overview'
       after(:create) do |page|
         create :block, :redundancy_overview, blockable: page
-        create :block, :redundancy_content, blockable: page
         create :block, :redundancy_topic, blockable: page
       end
     end
@@ -100,6 +105,14 @@ FactoryGirl.define do
       label 'Page with block other than content or identifier'
       after(:create) do |page|
         create :block, :raw_cta_text_content, blockable: page
+      end
+    end
+
+    factory :young_adults_page do
+      site { create :site, identifier: 'test-documents'}
+      label 'Debt about young adults and stress'
+      after(:create) do |page|
+        create :block, :young_adults_client_group, blockable: page
       end
     end
   end

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -1,16 +1,12 @@
 RSpec.describe DocumentProvider do
-  subject { described_class.new(site, document_type, keyword)}
+  subject { described_class.new(site, document_type, keyword, filters)}
   let!(:site) do
     create(:site, path: 'en', locale: 'en', is_mirrored: true)
   end
 
   let(:document_type) { nil }
   let(:keyword) { nil }
-
-  # let(:response_body) { JSON.load(response.body) }
-  # let(:documents) { response_body['documents'] }
-  # let(:meta_data) { response_body['meta'] }
-  # let(:url) { '/api/en/documents' }
+  let(:filters) { nil }
 
   let(:insight_page_params) { {site: site, layout: insight_layout } }
   

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -1,0 +1,131 @@
+RSpec.describe DocumentProvider do
+  subject { described_class.new(site, document_type, keyword)}
+  let!(:site) do
+    create(:site, path: 'en', locale: 'en', is_mirrored: true)
+  end
+
+  let(:document_type) { nil }
+  let(:keyword) { nil }
+
+  # let(:response_body) { JSON.load(response.body) }
+  # let(:documents) { response_body['documents'] }
+  # let(:meta_data) { response_body['meta'] }
+  # let(:url) { '/api/en/documents' }
+
+  let(:insight_page_params) { {site: site, layout: insight_layout } }
+  
+  let(:review_layout)  { create :layout, identifier: 'review' }
+  let(:insight_layout) { create :layout, identifier: 'insight' }
+
+  let!(:insight_page1) { create(:insight_page_about_financial_wellbeing, insight_page_params) }
+  let!(:insight_page2) { create(:insight_page_about_debt, insight_page_params) }
+  let!(:insight_page3) { create(:insight_page_about_pensions, insight_page_params) }
+  let!(:insight_page4) { create(:insight_page_titled_annuity, insight_page_params) }
+  let!(:insight_page5) { create(:insight_page_titled_annuity2, insight_page_params) }
+  let!(:insight_page6) { create(:insight_page_about_annuity, insight_page_params) }
+  let!(:insight_page7) { create(:insight_page_with_lotsa_blocks, insight_page_params) }
+  let!(:insight_page8) { create(:insight_page_with_raw_cta_text_block, insight_page_params) }
+  let!(:review_page1) { create(:page, site: site, layout: review_layout) }
+
+  describe '#retrieve' do
+    let(:documents) { subject.retrieve }
+
+    context 'when all documents are requested' do
+      it 'returns all documents' do
+        expect(documents.size).to eq(9)
+      end
+    end
+
+    context 'when documents of type insight are requested' do
+      let(:document_type) { 'review' }
+
+      it 'returns all insight documents' do
+        expect(documents).to match_array([review_page1])
+      end
+    end
+  end
+
+  describe 'keyword search' do
+    let(:documents) { subject.retrieve }
+
+    context 'when the document_type is specified' do
+      context 'when a keyword is provided' do
+        context 'and the keyword is found in a "content" block' do
+          let(:document_type) { 'insight' }
+          let(:keyword) { 'pension' }
+
+          it 'returns documents which contain the keyword' do
+            expect(documents.size).to eq(1)
+            expect(keyword).to be_in(documents.first.blocks.first.content)
+          end
+        end
+
+        context 'and the keyword is found in an "overview" block' do
+          let(:document_type) { 'insight' }
+          let(:keyword) { 'redundancy' }
+
+          it 'returns documents which contain the keyword' do
+            expect(documents.size).to eq(1)
+            expect(documents.first.label).to eq('Redundancy overview')
+            expect(documents).to match_array([insight_page7])
+          end
+        end
+
+        context 'and the keyword is found in a block that is not content or overview' do
+          let(:document_type) { 'insight' }
+          let(:keyword) { 'random' }
+
+          it 'does not return the document' do
+            expect(documents.count).to eq(0)
+          end
+        end
+
+        context 'and the keyword is found in the middle of the title' do
+          let(:document_type) { 'insight' }
+          let(:keyword) { 'stress' }
+
+          it 'returns documents with the keyword in the title' do
+            expect(documents.count).to eq(1)
+            expect(documents.first.label).to eq('Debt, stress and pay levels')
+          end
+        end
+
+        context 'and the keyword is found at the start of the title' do
+          let(:document_type) { 'insight' }
+          let(:keyword) { 'annuity' }
+
+          it 'returns documents with the keyword at the start of the title' do
+            expect(documents.first.label).to eq('annuity')
+          end
+        end
+
+        context 'and the keyword is in the title of one document and content of another' do
+          let(:document_type) { 'insight' }
+          let(:keyword) { 'annuity' }
+
+          it 'returns both documents' do
+            expect(documents).to match_array([insight_page4, insight_page5, insight_page6])
+          end
+        end
+      end
+
+      context 'when the keyword is not found' do
+        let(:document_type) { 'insight' }
+        let(:keyword) { 'nosuchterm' }
+
+        it 'returns an empty array' do
+          expect(documents.count).to eq(0) 
+        end
+      end
+
+      context 'when the search term is a phrase' do
+        let(:document_type) { 'insight' }
+        let(:keyword) { 'Financial well being: the employee view' }
+
+        it 'returns an array of documents which contain the phrase' do
+          expect(documents).to match_array([insight_page1])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP 8999](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/8794&searchPopup=userstory/8999)

This pr adds filtering to the search. It takes an optional `blocks` parameter formatted as an array of hashes e.g.

`[{identifier: 'client_group', value: 'Working age (18 - 65)'}] `

The search query is complex so it has been moved out of the controller into a class solely responsible for retrieving the documents.

I added brakeman to the gemfile to test that the sql query is secure. 

NEXT STEP
- [ ] Add validation on the number of filters that can be passed in the query