### PR TITLE
Amend parameter type for categories api

### DIFF
--- a/app/controllers/api/category_contents_controller.rb
+++ b/app/controllers/api/category_contents_controller.rb
@@ -14,7 +14,7 @@ module API
 
     api :GET, '/:locale/categories/:id'
     param :locale, /[en|cy]/, required: true
-    param :id, :number, required: true
+    param :id, String, required: true
     def show
       @category = Comfy::Cms::Category.find_by(label: params[:id])
       render json: @category, scope: locale


### PR DESCRIPTION
This pr fixes a bug initiated by installing a gem to facilitate documenting the cms api. 

Specifically the categories controller takes a parameter which is of type `string` and the documentation had been set to `number`. Hence an error was generated when the category api was invoked with a string. This pr changes the parameter type to be `string`.