### PR TITLE
TP 9090 Only allow a maximum of 26 filters as part of the API request

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -15,7 +15,11 @@ module API
         params[:blocks]
       ).retrieve
 
-      render json: documents, meta: { results: documents.size }, root: 'documents'
+      if documents
+        render json: documents, meta: { results: documents.size }, root: 'documents'
+      else
+        render json: { message: 'Bad request' }, status: 400
+      end
     end
   end
 end

--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -2,6 +2,7 @@ class DocumentProvider
   attr_reader :current_site, :document_type, :keyword, :filters
 
   BLOCKS_TO_SEARCH = %w(content overview)
+  FILTER_LIMIT = 26
 
   def initialize(current_site, document_type, keyword, filters)
     @current_site = current_site
@@ -11,6 +12,8 @@ class DocumentProvider
   end
 
   def retrieve
+    return if filters && filters.count > FILTER_LIMIT
+
     @documents = current_site.pages.published
 
     filter_by_document_type

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -7,17 +7,36 @@ RSpec.describe API::DocumentsController, type: :request do
   let(:documents) { [] }
   
   describe 'GET /:locale/documents' do
-    it 'returns all documents' do
-      expect(DocumentProvider)
-        .to receive(:new)
-        .with(site, 'insight', 'insurance', nil)
-        .and_return(document_provider)
+    context 'good request' do
+      it 'returns all documents' do
+        expect(DocumentProvider)
+          .to receive(:new)
+          .with(site, 'insight', 'insurance', nil)
+          .and_return(document_provider)
 
-      expect(document_provider)
-        .to receive(:retrieve)
-        .and_return(documents)
+        expect(document_provider)
+          .to receive(:retrieve)
+          .and_return(documents)
 
-      get "/api/en/documents?document_type=insight&keyword=insurance"
+        get "/api/en/documents?document_type=insight&keyword=insurance"
+      end
+    end
+
+    context 'bad request' do
+      it 'returns a 400 status code' do
+        allow(DocumentProvider)
+          .to receive(:new)
+          .with(site, nil, nil, nil)
+          .and_return(document_provider)
+
+        allow(document_provider)
+          .to receive(:retrieve)
+          .and_return(nil)
+
+        get "/api/en/documents"
+
+        expect(response.status).to eq 400
+      end
     end
   end
 end

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -132,7 +132,6 @@ RSpec.describe DocumentProvider do
     context 'when the search term is a phrase' do
       let!(:page_with_phrase) { create(:insight_page, site: site, layout: insight_layout) }
       let!(:page_without_phrase) { create(:page, site: site, layout: insight_layout) }
-
       let(:keyword) { 'Financial well being: the employee view' }
 
       it 'returns an array of documents which contain the phrase' do
@@ -228,6 +227,14 @@ RSpec.describe DocumentProvider do
           [page_with_3_filter_types_and_keyword, page_with_a_diff_filter_and_keyword]
         )
       end
+    end
+  end
+
+  describe 'when there are too many filters' do
+    let(:filters) { (1..27).to_a }
+    
+    it 'returns nothing' do
+      expect(subject).to be_nil
     end
   end
 end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe 'documents endpoint', type: :request do
+  describe 'GET api/en/documents' do
+    let!(:site) { create(:site, path: 'en') }
+
+    context 'when filters is less than maximum number allowed' do
+      let(:blocks) { [{ identifier: 'bar', value: 'bar' }] }
+
+      it 'returns success' do
+        get 'api/en/documents', blocks: blocks
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when filters is greater than maximum number allowed' do
+      let(:blocks) do
+        27.times.map { { identifier: 'bar', value: 'bar' } }
+      end
+
+      it 'returns bad request' do
+        get 'api/en/documents', blocks: blocks
+
+        expect(response.status).to eq(400)
+      end
+    end 
+  end
+end


### PR DESCRIPTION
[TP 9090 ](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9090)

It is technically possible to provide an unlimited number of filters which would affect the database query since each filter generates a subquery. This pr limits the number of subqueries generated to 26. Refer to the TP card as to why its limited to 26.