### PR TITLE
[DEV APPROVED] Broken mysql query

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -15,7 +15,7 @@ module API
         params[:blocks]
       ).retrieve
 
-      render json: documents, meta: { results: documents.count }, root: 'documents'
+      render json: documents, meta: { results: documents.size }, root: 'documents'
     end
   end
 end


### PR DESCRIPTION
[TP 8774](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/8774)

### Summary
As part of the mysql query to search for documents which contain only the blocks which meet the filter conditions, we use a complex subquery. The mysql SELECT COUNT function to determine the number of documents returned by the complex subquery is failing with a mysql syntax error. This pr provides a short term fix by using the ruby method 'size'. 

This issue will be revisited as part of [TP 9000](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&boardPopup=userstory/9000/silent), paginating search results.