### PR TITLE
Migrate search index task from clockwork to whenever gem

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every :day, at: '5:00am' do
+  command "cd /srv/cms/ && source /etc/mas/environment && RAILS_ENV=production bundle exec rake search:index"
+end

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -18,9 +18,5 @@ module Clockwork
   every(1.day, 'publish_scheduled_pages.job', at: '04:00') do
     ::PublishScheduledPagesTask.run
   end
-
-  every(1.day, 'index_database.job', at: '05:00') do
-    adapter = ENV.fetch('INDEXERS_ADAPTER')
-    ::IndexDatabaseTask.new(adapter).run
-  end
+  
 end


### PR DESCRIPTION
We currently scheduling the Algolia search index rake task using clockwork gem. In the production environment this is causing an issue as the rake task is running on all of the instances of CMS hosts, which is using double to amount of our indexing quota.

To overcome this we will be migrating the scheduling of the rake task to whenever gem - https://github.com/javan/whenever

This will give us the ability to add the task to crontab on a per host basis, enabling us to run the index only once.