### PR TITLE
[DEV APPROVED] Add feature tests for indexing cms database

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development do
 end
 
 group :test do
+  gem 'aruba', '~> 0.14.5'
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'poltergeist', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,13 @@ GEM
       httpclient (~> 2.8.3)
       json (>= 1.5.1)
     arel (5.0.1.20140414130214)
+    aruba (0.14.5)
+      childprocess (>= 0.6.3, < 0.10.0)
+      contracts (~> 0.9)
+      cucumber (>= 1.3.19)
+      ffi (~> 1.9.10)
+      rspec-expectations (>= 2.99)
+      thor (~> 0.19)
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
@@ -106,6 +113,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     climate_control (0.0.3)
       activesupport (>= 3.0)
@@ -143,6 +152,7 @@ GEM
       sass-rails (>= 4.0.3)
       tinymce-rails (>= 4.0.0)
       transitions (>= 0.1.12)
+    contracts (0.16.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     css_parser (1.3.5)
@@ -196,6 +206,7 @@ GEM
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
     feature (1.3.0)
+    ffi (1.9.23)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (1.28.0)
@@ -555,6 +566,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   algoliasearch
+  aruba (~> 0.14.5)
   autoprefixer-rails
   azure (= 0.7.7)
   better_errors

--- a/bin/rake
+++ b/bin/rake
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/features/index_database.rake
+++ b/features/index_database.rake
@@ -1,0 +1,56 @@
+Feature: Index Database for Site Search
+  As a user
+  I want to search through the site
+  So I can find the content I am looking for
+
+  Scenario: Index Categories
+    Given I have the category
+      | Field          | Value                            |
+      | label          | budgeting-and-managing-money     |
+      | title_en       | Budgeting and managing money     |
+      | title_cy       | Cyllidebu a rheoli arian         |
+      | description_en | Advice on running a bank account |
+      | description_cy | Cyngor ar redeg cyfrif banc      |
+    When I run `rake search:index`
+    Then the output should contain:
+    """
++-------------------------------------------------+------------------------------------------------+
+|                                Index: pages - 2 number of indices                                |
++-------------------------------------------------+------------------------------------------------+
+| Field                                           | Value                                          |
++-------------------------------------------------+------------------------------------------------+
+| objectID                                        | /en/categories/budgeting-and-managing-money    |
+| title                                           | Budgeting and managing money                   |
+| description                                     | Advice on running a bank account               |
+| links                                           | []                                             |
++-------------------------------------------------+------------------------------------------------+
+| objectID                                        | /cy/categories/budgeting-and-managing-money    |
+| title                                           | Cyllidebu a rheoli arian                       |
+| description                                     | Cyngor ar redeg cyfrif banc                    |
+| links                                           | []                                             |
++-------------------------------------------------+------------------------------------------------+
+    """
+
+  Scenario: Index Pages
+    Given I have the page
+      | Field            | Value                                                         |
+      | label            | Budget planner                                                |
+      | page_type        | tool                                                          |
+      | slug             | budget-planner                                                |
+      | meta_description | Use the free online Money Advice Service Budget Planner tools |
+      | content          | some content                                                  |
+    When I run `rake search:index`
+    Then the output should contain:
+    """
++----------------------------------+---------------------------------------------------------------+
+|                                Index: pages - 1 number of indices                                |
++----------------------------------+---------------------------------------------------------------+
+| Field                            | Value                                                         |
++----------------------------------+---------------------------------------------------------------+
+| objectID                         | /en/tools/budget-planner                                      |
+| title                            | Budget planner                                                |
+| description                      | Use the free online Money Advice Service Budget Planner tools |
+| content                          | some content                                                  |
+| published_at                     |                                                               |
++----------------------------------+---------------------------------------------------------------+
+    """

--- a/features/step_definitions/indexing_steps.rb
+++ b/features/step_definitions/indexing_steps.rb
@@ -1,0 +1,29 @@
+Given(/^I have the category$/) do |table|
+  category = build(:category)
+
+  table.rows.each do |row|
+    category.send("#{row[0]}=", row[1])
+  end
+
+  category.save!
+end
+
+Given(/^I have the page$/) do |table|
+  page = build(:page)
+
+  page_data = table.rows.to_h.symbolize_keys
+
+  page_data.except(:content, :page_type).each do |attribute, value|
+    page.send("#{attribute}=", value)
+  end
+
+  page.layout = build(:layout, identifier: page_data[:page_type])
+
+  page.blocks << Comfy::Cms::Block.new(
+    identifier: 'content',
+    content: page_data[:content],
+    processed_content: page_data[:content]
+  )
+
+  page.save!
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ROOT'] = File.expand_path('../../../', __FILE__)
 require 'cucumber/rails'
 require 'capybara/rails'
 require 'capybara/poltergeist'
+require 'aruba/cucumber'
 
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
@@ -19,3 +20,7 @@ Capybara.ignore_hidden_elements = false
 World(FactoryGirl::Syntax::Methods)
 
 DatabaseCleaner.strategy = :truncation
+
+Aruba.configure do |config|
+  config.command_runtime_environment = { 'INDEXERS_ADAPTER' => 'local' }
+end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9095-cms-add-feature-tests-for-indexing)

## Context

We are missing feature tests to check the proper indexing of our pages from our CMS system.  
 
This PR provides feature tests to make sure we are sending the right objects to be indexed on the site search.

## Technical Approach

Since the indexing is performed by command line rake tasks, I added the [aruba gem](https://github.com/cucumber/aruba) which adds feature tests for command line apps. 
To make this approach work, I needed to force an environment variable option which I set to the `local` adapter because we don't want to index anything to Algolia on our feature tests.

### Caveat
Aruba clashes with Spring because aruba uses the tmp directory to run the CLI interface and Spring needs to be in the Rails root directory. The following error was generated:

```
spring was unable to find your config/application.rb file on /tmp/aruba.
```

**I deleted spring from the rake script to resolve this issue.**