### PR TITLE
Update cron schedule for search:index to stay within quota

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,6 @@
 
 # Learn more: http://github.com/javan/whenever
 
-every :day, at: '5:00am' do
+every 4.days, at: '5:00am' do
   command "cd /srv/cms/ && source /etc/mas/environment && RAILS_ENV=production bundle exec rake search:index"
 end


### PR DESCRIPTION
To keep within our index operations quota on Algolia, we need to run the cron job every four days. The job will run on the 21st, 25th and 29th.

Following this we will return to a daily schedule.

https://moneyadviceservice.tpondemand.com/entity/9154-migrate-algolia-indexing-from-clockwork-to