### PR TITLE
9128 fincap button snippet

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor.js
@@ -110,6 +110,7 @@ define([
 
     // FinCap Specific
     this.editorLib.editor.use(scribePluginMastalk('fincap_feedback'));
+    this.editorLib.editor.use(scribePluginMastalk('fincap_primary_button'));
 
     this.setupMarkdownContentResize();
     this._initialisedSuccess(initialised);

--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/snippets-model.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/mastalk/snippets-model.js
@@ -17,7 +17,8 @@ define([], function () {
     costCalculator: '$~cost-calc\r\nCALCULATOR_ID\r\n~$',
 
     // FinCap Specific
-    fincap_feedback: '$fincap_feedback\r\nEMAIL_ADDRESS\r\n$'
+    fincap_feedback: '$fincap_feedback\r\nEMAIL_ADDRESS\r\n$',
+    fincap_primary_button: '$~fincap_primary_button\r\n[LINK_TEXT](LINK_URL)\r\n~$'
   };
 
   return {

--- a/app/views/comfy/admin/cms/pages/_toolbar.haml
+++ b/app/views/comfy/admin/cms/pages/_toolbar.haml
@@ -38,6 +38,8 @@
                 =button_tag('Cost Calculator', type: 'button', class: 'menu__action', data: { dough_snippetinserter_trigger: 'costCalculator', dough_snippetinserter_context: 'markdown-snippets'})
               %li.menu__item
                 =button_tag('FinCap - Feedback', type: 'button', class: 'menu__action', data: { dough_snippetinserter_trigger: 'fincap_feedback', dough_snippetinserter_context: 'markdown-snippets'})
+              %li.menu__item
+                =button_tag('FinCap - Primary Button', type: 'button', class: 'menu__action', data: { dough_snippetinserter_trigger: 'fincap_primary_button', dough_snippetinserter_context: 'markdown-snippets'})
 
           .popover__pointer{:data => {dough_collapsable_pointer: true}}
     .toolbar__item-group.toolbar__item-group--html{data: {dough_maseditor_html_toolbar: true}}
@@ -99,6 +101,8 @@
                 =button_tag('Cost Calculator', type: 'button', class: 'menu__action', data: { 'command-name' => 'mastalk_costCalculator'})
               %li.menu__item
                 =button_tag('FinCap - Feedback', type: 'button', class: 'menu__action', data: { 'command-name' => 'mastalk_fincap_feedback'})
+              %li.menu__item
+                =button_tag('FinCap - Primary Button', type: 'button', class: 'menu__action', data: { 'command-name' => 'mastalk_fincap_primary_button'})
 
           .popover__pointer{:data => {dough_collapsable_pointer: true}}
 


### PR DESCRIPTION
# 9128 - Fincap button snippet

TP Ticket [9128](https://moneyadviceservice.tpondemand.com/entity/9128-primary-button-snippet)

This PR adds the fincap button to the list of snippets:

<img width="377" alt="screen shot 2018-04-19 at 13 46 07" src="https://user-images.githubusercontent.com/13165846/38992237-0f7369cc-43d8-11e8-8874-8986f9e0dc01.png">

[The associated mastalk PR can be found here](https://github.com/moneyadviceservice/mastalk/pull/24)

Screenshot of component rendered in fincap frontend

![image](https://user-images.githubusercontent.com/13165846/38992272-26f44a8a-43d8-11e8-98f0-b405287a5911.png)