### PR TITLE
[DEV APPROVED] Add meta keywords field to site search index

### DIFF
--- a/app/views/pages/_form.html.haml
+++ b/app/views/pages/_form.html.haml
@@ -32,6 +32,13 @@
           = render 'tags/shared/form',                         form: form
           = render 'form_meta_description',                    form: form
           = render 'form_meta_title',                          form: form
+          .form-group
+            .form__label-heading
+              = form.label :meta_keywords
+            .form__input-wrapper
+              = form.text_field :meta_keywords, class: 'form__input form__input--has-icon'
+              %span.form__hint
+                = Comfy::Cms::Page.human_attribute_name(:meta_keywords_description)
           = render 'form_additional_options',                  form: form
 
     = render partial: 'form_blocks'

--- a/config/locales/pages.yml
+++ b/config/locales/pages.yml
@@ -2,6 +2,8 @@ en:
   activerecord:
     attributes:
       comfy/cms/page:
+        meta_keywords: Site search keywords
+        meta_keywords_description: Sentences separated by comma
         raw_heading: Heading
         raw_bullet_1: Bullet 1
         raw_bullet_2: Bullet 2

--- a/db/migrate/20180427145114_add_meta_keywords_to_comfy_cms_pages.rb
+++ b/db/migrate/20180427145114_add_meta_keywords_to_comfy_cms_pages.rb
@@ -1,0 +1,5 @@
+class AddMetaKeywordsToComfyCmsPages < ActiveRecord::Migration
+  def change
+    add_column :comfy_cms_pages, :meta_keywords, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202130530) do
+ActiveRecord::Schema.define(version: 20180427145114) do
 
   create_table "category_promos", force: true do |t|
     t.string  "promo_type"
@@ -162,6 +162,7 @@ ActiveRecord::Schema.define(version: 20170202130530) do
     t.boolean  "suppress_from_links_recirculation",                  default: false
     t.datetime "published_at"
     t.boolean  "supports_amp",                                       default: true
+    t.string   "meta_keywords"
   end
 
   add_index "comfy_cms_pages", ["active_revision_id"], name: "index_comfy_cms_pages_on_active_revision_id", using: :btree

--- a/lib/cms/indexers/page.rb
+++ b/lib/cms/indexers/page.rb
@@ -16,6 +16,7 @@ module Indexers
           objectID: serializer.full_path,
           title: serializer.label,
           description: serializer.meta_description,
+          keywords: page.meta_keywords.to_s.split(', '),
           content: content_for(serializer),
           published_at: serializer.published_at
         }

--- a/spec/lib/cms/indexers/page_spec.rb
+++ b/spec/lib/cms/indexers/page_spec.rb
@@ -8,31 +8,69 @@ RSpec.describe Indexers::Page do
   let(:adapter) { 'local' }
 
   describe '#objects' do
-    let(:collection) do
-      [
-        create(:page,
-               label: 'Financial well being',
-               slug: 'financial-well-being',
-               meta_description: 'meta description',
-               published_at: Time.zone.today,
-               layout: create(:layout, :article),
-               blocks: [
-                 create(:block, processed_content: '<p>some content</p>')
-               ]
-              )
-      ]
+    context 'when title, description and keywords are present' do
+      let(:collection) do
+        [
+          create(:page,
+                 label: 'Financial well being',
+                 slug: 'financial-well-being',
+                 meta_description: 'meta description',
+                 meta_keywords: 'financial, well-being',
+                 published_at: Time.zone.today,
+                 layout: create(:layout, :article),
+                 blocks: [
+                   create(:block, processed_content: '<p>some content</p>')
+                 ]
+                )
+        ]
+      end
+
+      it 'index pages with all attributes' do
+        expect(subject.objects).to eq(
+          [
+            {
+              objectID: '/en/articles/financial-well-being',
+              title: 'Financial well being',
+              description: 'meta description',
+              keywords: ['financial', 'well-being'],
+              content: '<p>some content</p>',
+              published_at: Time.zone.today
+            }
+          ]
+        )
+      end
     end
 
-    it 'index pages' do
-      expect(subject.objects).to eq([
-        {
-          objectID: '/en/articles/financial-well-being',
-          title: 'Financial well being',
-          description: 'meta description',
-          content: '<p>some content</p>',
-          published_at: Time.zone.today
-        }
-      ])
+    context 'when keywords are not present' do
+      let(:collection) do
+        [
+          create(:page,
+                 label: 'Financial well being',
+                 slug: 'financial-well-being',
+                 meta_description: 'meta description',
+                 published_at: Time.zone.today,
+                 layout: create(:layout, :article),
+                 blocks: [
+                   create(:block, processed_content: '<p>some content</p>')
+                 ]
+                )
+        ]
+      end
+
+      it 'index pages with empty keywords' do
+        expect(subject.objects).to eq(
+          [
+            {
+              objectID: '/en/articles/financial-well-being',
+              title: 'Financial well being',
+              description: 'meta description',
+              keywords: [],
+              content: '<p>some content</p>',
+              published_at: Time.zone.today
+            }
+          ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9144-site-search-enhancement-add-meta-keywords)

## Context

The Site Search product, Algolia, is working on the site but we are limited in the tools we need in order to influence search results. 
Currently Algolia indexes pages on page title and meta-description.
We could edit meta descriptions in order to help fix searches with missing results, and to help influence what appears towards the top of the results. However, the problem with this is that Meta description is used on Google SERPs, and generally full sentences are better than keyword stuffing for these.

So adding a field to add those keywords makes the site search flexible for the Digital team to influence the search results.

## Solution

So with the solution, I added a field called meta keywords and the way that will work on the site search is creating sentences separated by comma.

So for example Imagine that I have the following on the meta keywords:

![site search](https://user-images.githubusercontent.com/27509/39372891-a72820ee-4a3d-11e8-8692-86039abc57f6.png)

And on Algolia I have the following configuration (keywords the first attribute to be searchable):

![algolia](https://user-images.githubusercontent.com/27509/39373072-4de82dac-4a3e-11e8-8a18-4e00a08d9e1f.png)

When I search for "Budget Planner" the keywords that I added has more relevance so it appears first:

![screen shot 2018-04-27 at 17 10 21](https://user-images.githubusercontent.com/27509/39373103-6b3034e0-4a3e-11e8-821f-fb59a104113e.png)

The same with budgeting:

![screen shot 2018-04-27 at 17 10 37](https://user-images.githubusercontent.com/27509/39373111-72392706-4a3e-11e8-833a-67dbffa69116.png)


