### PR TITLE
[DEV APPROVED] - 9179 Amend cms page form to accept data_types attribute

### DIFF
--- a/db/seeds/fincap.seeds.rb
+++ b/db/seeds/fincap.seeds.rb
@@ -24,7 +24,7 @@ english_site = Comfy::Cms::Site.find_or_create_by(
       {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
       {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
       {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
-      {{ cms:page:data_type:collection_check_boxes/Quantitative, Qualitative }}
+      {{ cms:page:data_types:collection_check_boxes/Quantitative, Qualitative }}
     CONTENT
   )
 end

--- a/features/pages_form/fincap_insight_pages.feature
+++ b/features/pages_form/fincap_insight_pages.feature
@@ -28,6 +28,7 @@ Feature: Building Insight Pages
       | countries_of_delivery | usa                  |
       | client_groups         | parents_families     |
       | client_groups         | children             |
+      | data_types            | qualitative          |
 
     And I save and return to the homepage
     And when I click the "Fixing family finances" page
@@ -51,3 +52,5 @@ Feature: Building Insight Pages
       | parents_families         | checked   |
       | children                 | checked   |
       | young_people             | unchecked |
+      | qualitative              | checked   |
+      | quantitative             | unchecked |

--- a/features/step_definitions/fincap_pages_steps.rb
+++ b/features/step_definitions/fincap_pages_steps.rb
@@ -12,7 +12,7 @@ Given(/^I have an insight page layout$/) do
       {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
       {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
       {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
-      {{ cms:page:data_type:collection_check_boxes/Quantitative, Qualitative }}
+      {{ cms:page:data_types:collection_check_boxes/Quantitative, Qualitative }}
     CONTENT
   )
 end

--- a/features/support/ui/pages/edit.rb
+++ b/features/support/ui/pages/edit.rb
@@ -62,6 +62,9 @@ module UI::Pages
     element :children, 'input[value="Children (3-11)"]'
     element :young_people, 'input[value="Young People (12-16)"]'
 
+    element :qualitative, 'input[value="Qualitative"]'
+    element :quantitative, 'input[value="Quantitative"]'
+
     element :hero_image, '.component_hero_image'
     element :hero_description, '.component_hero_description'
     element :cta_links, '.component_cta_links'

--- a/lib/tasks/fincap.rake
+++ b/lib/tasks/fincap.rake
@@ -28,7 +28,7 @@ namespace :fincap do
           {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
           {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
           {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
-          {{ cms:page:data_type:collection_check_boxes/Quantitative, Qualitative }}
+          {{ cms:page:data_types:collection_check_boxes/Quantitative, Qualitative }}
         CONTENT
       )
     end


### PR DESCRIPTION
[TP Task 9179](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiQjRGMUI3NDVDQTgzMEM3QzQ2MDBCNjExRTUxMTQ4OEIifQ==&searchPopup=userstory/9167)

An insight page can present evidence which is qualitative or quantitative or both. The cms new page form needs to include checkboxes for the editor to indicate which type of evidence the page is.

The processing of these checkboxes is completed as part of another pr. This pr amends the attribute name from `data_type` to `data_types` and adds feature test for the ui aspect of creating/editing.