### PR TITLE
[WIP] Fincap documents search for evidence types only

### DIFF
--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -1,6 +1,7 @@
 class DocumentProvider
   attr_reader :current_site, :document_type, :keyword, :filters
 
+  EVIDENCE_TYPES = %w(insight evaluation review)
   BLOCKS_TO_SEARCH = %w(content overview)
   FILTER_LIMIT = 26
 
@@ -24,10 +25,13 @@ class DocumentProvider
   private
 
   def filter_by_document_type
-    return @documents if document_type.blank?
-
-    @documents = @documents.joins(:layout)
-      .where('comfy_cms_layouts.identifier' => document_type)
+    if document_type.blank?
+      @documents = @documents.joins(:layout)
+        .where('comfy_cms_layouts.identifier' => EVIDENCE_TYPES)
+    else
+      @documents = @documents.joins(:layout)
+        .where('comfy_cms_layouts.identifier' => document_type)
+    end
   end
 
   def filter_by_keyword

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe DocumentProvider do
 
   let(:insight_layout) { create :layout, identifier: 'insight' }
   let(:review_layout)  { create :layout, identifier: 'review' }
-  let(:review_layout)  { create :layout, identifier: 'review' }
 
   describe 'no filtering' do
     let!(:insight_page) { create(:insight_page, site: site, layout: insight_layout) }
@@ -25,14 +24,25 @@ RSpec.describe DocumentProvider do
   end
 
   describe 'filter_by_type' do
+    let(:article_layout)  { create :layout, :article }
+
     let!(:insight_page) { create(:insight_page, site: site, layout: insight_layout) }
     let!(:review_page) { create(:page, site: site, layout: review_layout) }
+    let!(:article_page) { create(:page, site: site, layout: article_layout ) }
 
-    let(:document_type) { 'review' }
+    context 'when there is no document_type' do
+      it 'returns all evidence documents' do
+        expect(subject.size).to eq(2)
+        expect(subject).to match_array([insight_page, review_page])
+      end
+    end
 
-    it 'returns all documents of a given type' do
-      expect(subject.size).to eq(1)
-      expect(subject).to match_array([review_page])
+    context 'when there is a document_type' do
+      let(:document_type) { 'review' }
+      it 'returns all documents of the given type' do
+        expect(subject.size).to eq(1)
+        expect(subject).to match_array([review_page])
+      end
     end
   end
 


### PR DESCRIPTION
This pr fixes a bug where all documents were being returned for the evidence hub. Only documents of type Evaluation, Insight or Review should be returned.