### PR TITLE
Allow block collection to return all values

### DIFF
--- a/app/serializers/block_serializer.rb
+++ b/app/serializers/block_serializer.rb
@@ -2,9 +2,14 @@ require 'active_model_serializers'
 
 class BlockSerializer < ActiveModel::Serializer
   attributes :identifier, :content, :created_at, :updated_at
+  CONTENT_IDENTIFIER = 'content'
 
   def content
-    block = BlocksRetriever.new(object, scope).retrieve || return
+    block = if object.identifier == CONTENT_IDENTIFIER
+              BlocksRetriever.new(object, scope).retrieve || return
+            else
+              object
+            end
 
     if block[:processed_content].present?
       Rails.logger.info("Cache HIT for #{page.slug}")

--- a/spec/serializers/block_serializer_spec.rb
+++ b/spec/serializers/block_serializer_spec.rb
@@ -17,6 +17,39 @@ describe BlockSerializer do
     end
   end
 
+  context 'when a collection is the identifier' do
+    let(:page) { create(:page, state: 'published') }
+
+    let!(:topics_saving) do
+      create(:block, identifier: 'topics', content: 'Saving', blockable: page)
+    end
+    let!(:topics_pension) do
+      create(:block, identifier: 'topics', content: 'Pension', blockable: page)
+    end
+
+    before { page.reload }
+
+    context 'when requesting first element' do
+      subject(:content) do
+        described_class.new(topics_saving).content
+      end
+
+      it 'returns first element from the collection' do
+        expect(content).to eq("<p>Saving</p>\n")
+      end
+    end
+
+    context 'when requesting second element' do
+      subject(:content) do
+        described_class.new(topics_pension).content
+      end
+
+      it 'returns second element from the collection' do
+        expect(content).to eq("<p>Pension</p>\n")
+      end
+    end
+  end
+
   context 'when "content" is the identifier' do
     let(:scheduled_on) { nil }
     let(:published_revision) { nil }


### PR DESCRIPTION
## Issue

Before this PR, given we had the following blocks:
```
<Comfy::Cms::Block id: 13, identifier: "topics", content: "Saving",
  blockable_id: 2, blockable_type: "Comfy::Cms::Page">
<Comfy::Cms::Block id: 14, identifier: "topics", content: "Financial
  Capability", blockable_id: 2, blockable_type: "Comfy::Cms::Page">
```

**Then the API were return two topics but with duplicated "Saving" as value.**:

```
{
"identifier": "topics",
"content": "<p>Saving</p>
",
"created_at": "2018-05-10T14:26:47.000Z",
"updated_at": "2018-05-10T14:26:47.000Z"
},
{
"identifier": "topics",
"content": "<p>Saving</p>
",
"created_at": "2018-05-10T14:26:47.000Z",
"updated_at": "2018-05-10T14:26:47.000Z"
},
```

## Investigation

This was returning duplicated values because the Block retriever class was using Array#find for all blocks even when the topics is a collection.

## Solution

After reading the class I realised that the blocks retriever only exists to retrieve the live page body content and from nothing else, so then it makes sense for me to "use block retriever for content
and nothing from the other blocks".