### PR TITLE
Add pagination to API /documents

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -1,5 +1,8 @@
 module API
   class DocumentsController < APIController
+    PAGE_NUMBER = 1
+    PER_PAGE = 20
+
     before_action :find_site
 
     api :GET, '/:locale/documents'
@@ -8,18 +11,43 @@ module API
     param :keyword, String, required: false
     param :blocks, Array, required: false
     def index
-      documents = DocumentProvider.new(
-        current_site, 
-        params[:document_type], 
-        params[:keyword], 
-        params[:blocks]
-      ).retrieve
-
       if documents
-        render json: documents, meta: { results: documents.size }, root: 'documents'
+        render json: paginated_documents, meta: meta_data, root: 'documents'
       else
         render json: { message: 'Bad request' }, status: 400
       end
+    end
+
+    private
+
+    def documents
+      @documents ||= DocumentProvider.new(
+        current_site,
+        params[:document_type],
+        params[:keyword],
+        params[:blocks]
+      ).retrieve
+    end
+
+    def paginated_documents
+      documents.page(page).per(per_page)
+    end
+
+    def meta_data
+      {
+        results: documents.size,
+        page: page,
+        per_page: per_page,
+        total_pages: paginated_documents.total_pages
+      }
+    end
+
+    def page
+      Integer(params[:page] || PAGE_NUMBER)
+    end
+
+    def per_page
+      Integer(params[:per_page] || PER_PAGE)
     end
   end
 end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -3,26 +3,72 @@ RSpec.describe API::DocumentsController, type: :request do
     create(:site, path: 'en', locale: 'en', is_mirrored: true)
   end
 
-  let(:document_provider) { double(DocumentProvider) }
-  let(:documents) { [] }
-  
   describe 'GET /:locale/documents' do
-    context 'good request' do
+    context 'when requesting all documents' do
       it 'returns all documents' do
-        expect(DocumentProvider)
-          .to receive(:new)
-          .with(site, 'insight', 'insurance', nil)
-          .and_return(document_provider)
+        get '/api/en/documents'
+        expect(response.status).to be(200)
+      end
+    end
 
-        expect(document_provider)
-          .to receive(:retrieve)
-          .and_return(documents)
+    context 'when requesting pages for pagination' do
+      let!(:insight_page_titled_pensions) do
+        create(:insight_page_titled_pensions, site: site)
+      end
+      let!(:uk_study_about_work_and_stress) do
+        create(:uk_study_about_work_and_stress, site: site)
+      end
+      let(:response_body) do
+        JSON.parse(response.body)
+      end
+      subject(:documents) do
+        response_body['documents']
+      end
 
-        get "/api/en/documents?document_type=insight&keyword=insurance"
+      before do
+        get '/api/en/documents', page: page, per_page: 1
+      end
+
+      context 'requesting first page' do
+        let(:page) { 1 }
+
+        it 'returns documents from first page' do
+          expect(documents.first).to include('label' => 'pensions')
+        end
+
+        it 'returns meta information' do
+          expect(response_body['meta'].symbolize_keys).to eq({
+            results: 2,
+            per_page: 1,
+            page: 1,
+            total_pages: 2
+          })
+        end
+      end
+
+      context 'requesting last page' do
+        let(:page) { 2 }
+
+        it 'returns documents from last page' do
+          expect(documents.first).to include(
+            'label' => 'Debt, stress and pay levels in the UK'
+          )
+        end
+
+        it 'returns meta information' do
+          expect(response_body['meta'].symbolize_keys).to eq({
+            results: 2,
+            per_page: 1,
+            page: 2,
+            total_pages: 2
+          })
+        end
       end
     end
 
     context 'bad request' do
+      let(:document_provider) { double }
+
       it 'returns a 400 status code' do
         allow(DocumentProvider)
           .to receive(:new)


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9000-cms-api-search-pagination)

## context

This PRs adds pagination to the CMS API.

So now you can pass the page parameter:

`http://localhost:3000/api/en/documents.json?page=1`

And more information will be provided on the meta key:

```
"meta": {
  "results": 5,
  "page": 1,
  "per_page": 20,
  "total_pages": 1
}
```