### PR TITLE
Fix broken test

### DIFF
--- a/spec/lib/cms/form_builder_spec.rb
+++ b/spec/lib/cms/form_builder_spec.rb
@@ -7,7 +7,7 @@ describe Cms::FormBuilder do
   before { template.instance_variable_set('@blocks_attributes', [block_attributes]) }
 
   subject do
-    described_class.new(:model, block_attributes, template, {})
+    described_class.new(:model, [block_attributes], template, {})
   end
 
   describe '#page_image' do


### PR DESCRIPTION
This error came about from our refactor for form_builder 
https://github.com/moneyadviceservice/cms/blob/fincap/lib/cms/form_builder.rb#L112
blocks_attributes should be an array of hashes, but in the test it was just a hash that was passed in.