### PR TITLE
Feature/9000 - add authentication to the documents API

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -4,6 +4,7 @@ module API
     PER_PAGE = 20
 
     before_action :find_site
+    before_action API::AuthenticationFilter
 
     api :GET, '/:locale/documents'
     param :locale, String, required: true

--- a/db/seeds/fincap.seeds.rb
+++ b/db/seeds/fincap.seeds.rb
@@ -236,6 +236,10 @@ productivity.
       CONTENT
     ),
     Comfy::Cms::Block.new(
+      identifier: 'year_of_publication',
+      content: '2015'
+    ),
+    Comfy::Cms::Block.new(
       identifier: 'topics',
       content: 'Saving'
     ),

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -3,10 +3,19 @@ RSpec.describe API::DocumentsController, type: :request do
     create(:site, path: 'en', locale: 'en', is_mirrored: true)
   end
 
+  let(:headers) do
+    {
+      'HTTP_AUTHORIZATION' =>
+        ActionController::HttpAuthentication::Token.encode_credentials(
+          'mytoken'
+        )
+    }
+  end
+
   describe 'GET /:locale/documents' do
     context 'when requesting all documents' do
       it 'returns all documents' do
-        get '/api/en/documents'
+        get '/api/en/documents', {}, headers
         expect(response.status).to be(200)
       end
     end
@@ -26,7 +35,7 @@ RSpec.describe API::DocumentsController, type: :request do
       end
 
       before do
-        get '/api/en/documents', page: page, per_page: 1
+        get '/api/en/documents', { page: page, per_page: 1 }, headers
       end
 
       context 'requesting first page' do
@@ -79,7 +88,7 @@ RSpec.describe API::DocumentsController, type: :request do
           .to receive(:retrieve)
           .and_return(nil)
 
-        get "/api/en/documents"
+        get '/api/en/documents', {}, headers
 
         expect(response.status).to eq 400
       end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -2,11 +2,20 @@ RSpec.describe 'documents endpoint', type: :request do
   describe 'GET api/en/documents' do
     let!(:site) { create(:site, path: 'en') }
 
+    let(:headers) do
+      {
+        'HTTP_AUTHORIZATION' =>
+          ActionController::HttpAuthentication::Token.encode_credentials(
+            'mytoken'
+          )
+      }
+    end
+
     context 'when filters is less than maximum number allowed' do
       let(:blocks) { [{ identifier: 'bar', value: 'bar' }] }
 
       it 'returns success' do
-        get 'api/en/documents', blocks: blocks
+        get 'api/en/documents', { blocks: blocks }, headers
 
         expect(response.status).to eq(200)
       end
@@ -18,10 +27,10 @@ RSpec.describe 'documents endpoint', type: :request do
       end
 
       it 'returns bad request' do
-        get 'api/en/documents', blocks: blocks
+        get 'api/en/documents', { blocks: blocks }, headers
 
         expect(response.status).to eq(400)
       end
-    end 
+    end
   end
 end


### PR DESCRIPTION
## Context

There was a test that was failing on fincap because there was an insight page without year of publication. It was there but maybe it was deleted by accident. This PR addresses this fix.

Other thing that I address on this PR is adding authentication to the Documents API. This route is starting to become very important. It sounds safe to me to add a token auth to it.

I also found that the documents API has two files as requests spec. One living in the controller dir and another on the request dir. I don't know why is that so but I prefer to leave as it is for now and ask @margOnline the reason about it when she is back.