### PR TITLE
9205 - Thematic review

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -8,9 +8,10 @@ module API
 
     api :GET, '/:locale/documents'
     param :locale, String, required: true
-    param :page_type, String, required: false
+    param :document_type, Array, required: false
     param :keyword, String, required: false
     param :blocks, Array, required: false
+    param :tag, String, required: false
     def index
       if documents
         render json: paginated_documents, meta: meta_data, root: 'documents'
@@ -23,10 +24,12 @@ module API
 
     def documents
       @documents ||= DocumentProvider.new(
-        current_site,
-        params[:document_type],
-        params[:keyword],
-        params[:blocks]
+        params.permit(
+          :keyword,
+          :tag,
+          document_type: [],
+          blocks: [:identifier, :value]
+        ).merge(current_site: current_site)
       ).retrieve
     end
 

--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -1,14 +1,15 @@
 class DocumentProvider
-  attr_reader :current_site, :document_type, :keyword, :filters
+  attr_reader :current_site, :document_type, :keyword, :filters, :tag
 
   BLOCKS_TO_SEARCH = %w(content overview)
   FILTER_LIMIT = 26
 
-  def initialize(current_site, document_type, keyword, filters)
-    @current_site = current_site
-    @document_type = document_type
-    @keyword = keyword
-    @filters = filters
+  def initialize(params = {})
+    @current_site = params[:current_site]
+    @document_type = params[:document_type]
+    @keyword = params[:keyword]
+    @filters = params[:blocks]
+    @tag = params[:tag]
   end
 
   def retrieve
@@ -18,6 +19,7 @@ class DocumentProvider
 
     filter_by_document_type
     filter_by_keyword
+    filter_by_tag
     filter_documents
   end
 
@@ -40,6 +42,13 @@ class DocumentProvider
           (comfy_cms_blocks.content LIKE ? AND comfy_cms_blocks.identifier IN (?))',
           "%#{keyword}%", "%#{keyword}%", BLOCKS_TO_SEARCH
       ).uniq
+  end
+
+  def filter_by_tag
+    return @documents if tag.blank?
+
+    @documents = @documents
+      .joins(:keywords).where('tags.value = ?', tag)
   end
 
   def filter_documents

--- a/db/seeds/fincap.seeds.rb
+++ b/db/seeds/fincap.seeds.rb
@@ -79,7 +79,7 @@ article_layout = english_site.layouts.find_or_create_by(
 )
 
 thematic_review_layout = english_site.layouts.find_or_create_by(
-  identifier: 'thematic-review',
+  identifier: 'thematic_review',
   label: 'Thematic Review',
   content:  <<-CONTENT
     {{ cms:page:content:rich_text }}
@@ -530,7 +530,7 @@ english_site.pages.create!(
   blocks: [
     Comfy::Cms::Block.new(
       identifier: 'content',
-      content: 'Some content'
+      content: 'Thematic Review content'
     ),
     Comfy::Cms::Block.new(
       identifier: 'overview',
@@ -547,19 +547,14 @@ english_site.pages.create!(
     Comfy::Cms::Block.new(
       identifier: 'component_cta_links',
       content: <<-CONTENT
-        [Evidence Hub](/general_info)
-        [Evaluation Toolkit](/common-evaluation-toolkit)
-        [The Steering Groups](/steering-groups)
-        [2015 Financial Capability Survey](/financial-capability-survey)
+        [Evidence Summaries Associated with this Thematic Review](/en/evidence_hub?tag=how-can-we-improve-the-financial-capability-of-young-adults)
+        [All Evidence Summaries](/en/evidence_hub)
       CONTENT
     ),
     Comfy::Cms::Block.new(
       identifier: 'component_download',
       content: <<-CONTENT
-      [UK Strategy](/financial+capability+strategy.pdf)
-      [UK Detailed Strategy](/detailed-strategy.pdf)
-      [Key statistics on Financial Capability](/key-statistics.pdf)
-      [Financial Capability Progress Report 2017](/fincap+progress+report+2017.pdf)
+      [Young Adults Thematic review](/financial+capability+strategy.pdf)
       CONTENT
     ),
     Comfy::Cms::Block.new(

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe API::DocumentsController, type: :request do
         create(:page_with_tag, site: site, tag_name: 'sorry-not-a-pensions')
       end
 
-      context 'when searching by a tag' do
+      context 'when searching an existent tag' do
         before do
           get '/api/en/documents', { tag: 'pensions' }, headers
         end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -19,6 +19,17 @@ FactoryGirl.define do
       layout_content_c
     )
 
+    transient do
+      tag_name 'tag'
+    end
+
+    factory :page_with_tag do
+      after(:create) do |page, evaluator|
+        page.keywords << create(:tag, value: evaluator.tag_name)
+        page.reload
+      end
+    end
+
     factory :english_article do
       site { create :site, label: 'en' }
       layout { create :layout, identifier: 'article' }

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :tag, class: Tag do
+    sequence(:value) { |n| "a-tag-#{n}" }
+  end
+end

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -1,5 +1,13 @@
 RSpec.describe DocumentProvider do
-  subject { described_class.new(site, document_type, keyword, filters).retrieve }
+  subject do
+    described_class.new(
+      current_site: site,
+      document_type: document_type,
+      keyword: keyword,
+      blocks: filters,
+      tag: tag
+    ).retrieve
+  end
 
   let!(:site) do
     create(:site, path: 'en', locale: 'en', is_mirrored: true)
@@ -8,6 +16,7 @@ RSpec.describe DocumentProvider do
   let(:document_type) { nil }
   let(:keyword) { nil }
   let(:filters) { nil }
+  let(:tag) { nil }
 
   let(:insight_layout) { create :layout, identifier: 'insight' }
   let(:review_layout)  { create :layout, identifier: 'review' }
@@ -232,7 +241,7 @@ RSpec.describe DocumentProvider do
 
   describe 'when there are too many filters' do
     let(:filters) { (1..27).to_a }
-    
+
     it 'returns nothing' do
       expect(subject).to be_nil
     end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9205-thematic-reviews-content-association)

## Context

This PR addresses the search through pages by tag.

Allowing the documents API  to search by tag means that on CMS we can search all summaries that are within a tag. The tag will be associated with a Thematic review because the name of the tag and the name of the slug are the same.

## Example

Given that I have the thematic review:
```
Type: Thematic Review
Slug: my-awesome-thematic-review-page
```

and an Insight:

```
Type: Insight
slug: some-insight
tag: my-awesome-thematic-review-page
```

Note that the Insight above  **should** have a tag with the same name as the thematic review's slug.

When we search for the tag "my-awesome-thematic-review-page", the pages which have this tag will be returned. On this example,  the "some-insight" page will be included.

## Technical

This PR includes real data to the components of the thematic review to facilitate navigating to the hub with the real tag.

#### Refactoring
I refactored the DocumentProvider names. The terms `page type`  and `document type` were being used interchangeably,  making debugging more difficult. I think now it is more concise.