### PR TITLE
[DEV APPROVED] 9155 cms article component

### DIFF
--- a/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ArticleComponents.js
+++ b/app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ArticleComponents.js
@@ -1,0 +1,81 @@
+define(['jquery','DoughBaseComponent'], function ($, DoughBaseComponent) {
+  'use strict';
+
+  var ArticleComponentsProto,
+      defaultConfig = {};
+
+  function ArticleComponents($el, config) {
+    ArticleComponents.baseConstructor.call(this, $el, config, defaultConfig);
+
+    this.$articleComponents = $el.find('[data-dough-article-component]');
+    this.activeClass = 'is-active';
+  }
+
+  DoughBaseComponent.extend(ArticleComponents);
+
+  ArticleComponents.componentName = 'ArticleComponents';
+
+  ArticleComponentsProto = ArticleComponents.prototype;
+
+  ArticleComponentsProto.init = function(initialised) {
+    this._initialisedSuccess(initialised);
+    this._setUpComponent();
+    this._checkInitialState();
+
+    return this;
+  };
+
+  ArticleComponentsProto._setUpComponent = function() {
+    var self = this,
+        component_add =
+          '<button class="article-component--add button button--secondary button--action">' +
+            '<span class="button__text" data-dough-article-component-add>Add</a>' +
+          '</button>',
+        component_remove =
+          '<a data-dough-article-component-remove class="article-component--remove" href="#">' +
+            '<span class="fa fa-remove remove--icon"></span><span>Remove</span>' +
+          '</a>';
+
+    this.$articleComponents.each(function() {
+      var component = this;
+
+      $(this)
+        .append(component_remove)
+        .children('label').append(component_add);
+
+      var add = $(component).find('[data-dough-article-component-add]');
+      var remove = $(component).find('[data-dough-article-component-remove]');
+
+      $(add).on('click', function(e) {
+        e.preventDefault();
+        self._addComponent(component);
+      });
+
+      $(remove).on('click', function(e) {
+        e.preventDefault();
+        self._removeComponent(component);
+      });
+    });
+  };
+
+  ArticleComponentsProto._checkInitialState = function() {
+    var self = this;
+
+    this.$articleComponents.each(function() {
+      if ($(this).children('textarea').val() !== '') {
+        $(this).addClass(self.activeClass);
+      }
+    });
+  };
+
+  ArticleComponentsProto._addComponent = function(component) {
+    $(component).addClass(this.activeClass);
+  }
+
+  ArticleComponentsProto._removeComponent = function(component) {
+    $(component).removeClass(this.activeClass);
+    $(component).children('textarea').val('');
+  }
+
+  return ArticleComponents;
+});

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -21,6 +21,7 @@ requirejs.config({
     'mutationobserver-shim': '<%= requirejs_path("mas-cms-editor/src/app/shims/mutationobserver.min") %>',
 
     // Application modules
+    'ArticleComponents': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/ArticleComponents") %>',
     'URLToggler': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/URLToggler") %>',
     'MASEditor': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/MASEditor") %>',
     'ElementHider': '<%= requirejs_path("comfortable_mexican_sofa/admin/modules/ElementHider") %>',

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_article_component.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_article_component.scss
@@ -1,0 +1,49 @@
+.article-components {
+  @include column(4);
+}
+
+.article-component {
+  @include clearfix;
+
+  margin-bottom: $baseline-unit*2;
+
+  textarea,
+  label,
+  .article-component--remove {
+    @include column(12);
+  }
+
+  textarea,
+  .article-component--remove {
+    display: none;
+  }
+
+  .remove--icon {
+    color: $color-icon-remove;
+    margin-right: $baseline-unit/2;
+  }
+
+  .article-component--add {
+    margin-left: $baseline-unit;
+
+    .button__text {
+      padding: $baseline-unit 10px;
+    }
+  }
+
+  &.is-active {
+    background: $color-panel-content-form-background;
+
+    textarea {
+      display: inline;
+    }
+
+    .article-component--remove {
+      display: block;
+    }
+
+    .article-component--add {
+      display: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_editor.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/components/_editor.scss
@@ -7,6 +7,10 @@
 
   &.is-active {
     @extend %is-active;
+
+    .article-editor & {
+      @include column(8);
+    }
   }
 }
 

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/layout/_editor.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/layout/_editor.scss
@@ -3,7 +3,9 @@
 // Styleguide Editor
 
 .l-editor {
-  margin-bottom: $baseline-unit*20;
+  p {
+    margin-top: 0;
+  }
 }
 
 .inline_checkboxes {

--- a/app/assets/stylesheets/comfortable_mexican_sofa/admin/lib/_variables.scss
+++ b/app/assets/stylesheets/comfortable_mexican_sofa/admin/lib/_variables.scss
@@ -188,6 +188,7 @@ $color-image-flag-separator: $color-silver-chalice;
 
 // Icons
 $color-icon-warning: $color-saffron;
+$color-icon-remove: $color-persian-red;
 
 // Breadcrumb
 $color-breadcrumb-border: $color-concrete;

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -8,6 +8,12 @@ module PagesHelper
     cms_blocks.send(tag.class.to_s.demodulize.underscore, tag, index)
   end
 
+  def content_field(tags, cms_blocks)
+    tag = tags.find { |t| t.identifier == 'content' }
+    tag_index = tags.index { |t| t.identifier == 'content' }
+    cms_blocks.send(tag.class.to_s.demodulize.underscore, tag, tag_index)
+  end
+
   def page_form_component(condition, default: [], optional: [], display: true)
     return {} unless display
     { dough_component: components(condition, default, optional).join(' ') }

--- a/app/views/pages/form_blocks/_article.html.haml
+++ b/app/views/pages/form_blocks/_article.html.haml
@@ -1,1 +1,8 @@
-= render 'pages/form_blocks/dynamic_page_type', namespace: namespace, cms_blocks: cms_blocks
+%div{ class: "article-editor"}
+  = content_field(namespace['default'], cms_blocks)
+
+%div{ class: "article-components", data: { dough_component: 'ArticleComponents' }}
+  - fields_from_layout(namespace).each_with_index do |layout_field, index|
+    - next if layout_field.tag.identifier == 'content'
+    %div{class: "article-component", data: { dough_article_component: true }}
+      = layout_field.input_tag_for(form_builder: cms_blocks, index: index)

--- a/spec/javascripts/fixtures/ArticleComponents.html
+++ b/spec/javascripts/fixtures/ArticleComponents.html
@@ -1,0 +1,13 @@
+<div>
+  <div data-dough-component="ArticleComponents">
+    <div data-dough-article-component>
+      <label>Label for first component</label>
+      <textarea></textarea>
+    </div>
+
+    <div data-dough-article-component>
+      <label>Label for second component</label>
+      <textarea></textarea>
+    </div>
+  </div>
+</div>

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -35,6 +35,7 @@ requirejs.config({
     'mutationobserver-shim': bowerPath + 'mas-cms-editor/src/app/shims/mutationobserver.min',
 
     // Application modules
+    'ArticleComponents': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ArticleComponents',
     'URLToggler': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/URLToggler',
     'MASEditor': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/MASEditor',
     'ElementHider': 'app/assets/javascripts/comfortable_mexican_sofa/admin/modules/ElementHider',

--- a/spec/javascripts/tests/ArticleComponents_spec.js
+++ b/spec/javascripts/tests/ArticleComponents_spec.js
@@ -1,0 +1,87 @@
+describe('Article Components', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    requirejs([
+      'jquery',
+      'ArticleComponents'
+    ],
+    function(
+      $,
+      ArticleComponents
+    ) {
+      self.$html = $(window.__html__['spec/javascripts/fixtures/ArticleComponents.html']).appendTo('body');
+      self.$fixture = self.$html.find('[data-dough-component="ArticleComponents"]');
+      self.ArticleComponents = ArticleComponents;
+      self.$articleComponents = self.$fixture.find('[data-dough-article-component]');
+      self.activeClass = 'is-active';
+
+      done();
+    }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('Set up component', function () {
+    beforeEach(function(done) {
+      this.component = new this.ArticleComponents(this.$fixture);
+      this.component.init();
+      done();
+    });
+
+    it('Should add the add/remove controls to the component', function() {
+      var self = this;
+
+      this.$articleComponents.each(function() {
+        expect($(this).find('[data-dough-article-component-add]').length).to.equal(1);
+        expect($(this).find('[data-dough-article-component-remove]').length).to.equal(1);
+      });
+    });
+  });
+
+  describe('Initial state', function() {
+    beforeEach(function(done) {
+      this.component = new this.ArticleComponents(this.$fixture);
+      done();
+    });
+
+    it('Should set the appropriate active/inactive state on the component', function() {
+      var self = this;
+
+      this.$articleComponents.each(function() {
+        self.component.init();
+        expect($(this).hasClass(self.activeClass)).to.be.false;
+        $(this).children('textarea').val('some content');
+        self.component.init();
+        expect($(this).hasClass(self.activeClass)).to.be.true;
+      });
+    });
+  });
+
+  describe('Add/Remove events', function() {
+    beforeEach(function(done) {
+      this.component = new this.ArticleComponents(this.$fixture);
+      this.component.init();
+      this.$control_add = this.$fixture.find('[data-dough-article-component-add]');
+      this.$control_remove = this.$fixture.find('[data-dough-article-component-remove]');
+      done();
+    });
+
+    it('Should add and remove components', function() {
+      var self = this;
+
+      this.$articleComponents.each(function() {
+        self.$control_add.trigger('click');
+        expect($(this).hasClass(self.activeClass)).to.be.true;
+        $(this).children('textarea').val('some content');
+        self.$control_remove.trigger('click');
+        expect($(this).hasClass(self.activeClass)).to.be.false;
+        expect($(this).children('textarea').val() === '').to.be.true
+      });
+    });
+  });
+});


### PR DESCRIPTION
[TP9155](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/9155)

This work is to enhance the CMS to make it more user-friendly when adding/editing article pages. Currently the inputs for the components (hero image, CTA list etc.) are displayed at the bottom of the page: 

![image](https://user-images.githubusercontent.com/6080548/41464074-d50a3c94-7090-11e8-933a-5eb2e6328923.png)

This PR changes the layout a little to display them at the side of the main editor and makes them fully visible only when there is content already saved or the editor wishes to add some new content: 

![image](https://user-images.githubusercontent.com/6080548/41464154-39690e22-7091-11e8-8f0b-114222d18288.png)

Could probably benefit from some more consideration to the look and feel though. 