### PR TITLE
Route for thematic_reviews

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
       resources :documents, only: :index
     end
 
+    get '/:locale/thematic_reviews' => 'documents#index'
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
     get '/preview/:locale/(*slug)(.:format)' => 'content#preview', as: 'preview_content'


### PR DESCRIPTION
[TP 9202](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9202)

## Description
There is a requirement for Fincap to have a page which shows summaries of all the thematic reviews.

### Technical
[Related fin_cap pr](https://github.com/moneyadviceservice/fin_cap/pull/143)

We need a new route for thematic_reviews because another route matched the thematic_reviews request via the `:page_type` parameter and was sending it to `contents_controller#show`. 

The new route makes use of `documents_controller#index` because in fin_cap when we call this new route we give it a `:page_type` parameter.