### PR TITLE
thematic_reviews_landing_page route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
     end
 
     get '/:locale/thematic_reviews' => 'documents#index'
+    get '/:locale/thematic_reviews_landing_pages' => 'documents#index'
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
     get '/preview/:locale/(*slug)(.:format)' => 'content#preview', as: 'preview_content'

--- a/db/seeds/fincap.seeds.rb
+++ b/db/seeds/fincap.seeds.rb
@@ -97,6 +97,8 @@ thematic_reviews_landing_page_layout = english_site.layouts.find_or_create_by(
   label: 'Thematic Reviews Landing Page',
   content:  <<-CONTENT
     {{ cms:page:content:rich_text }}
+    {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+    {{ cms:page:hero_description:simple_component/Thematic Reviews }}
   CONTENT
 )
 

--- a/lib/tasks/fincap.rake
+++ b/lib/tasks/fincap.rake
@@ -102,6 +102,8 @@ namespace :fincap do
       label: 'Thematic Reviews Landing Page',
       content:  <<-CONTENT
         {{ cms:page:content:rich_text }}
+        {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+        {{ cms:page:hero_description:simple_component/Thematic Reviews }}
       CONTENT
     )
   end


### PR DESCRIPTION
[TP 9202](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9202)

## Context
There is a requirement for Fincap to have a page which shows summaries of all the thematic reviews.

## Summary
- new route for thematic_reviews_landing_page
- add hero image and hero description components for thematic_reviews_landing_page

### Technical
[Related fin_cap pr](https://github.com/moneyadviceservice/fin_cap/pull/143)

We need a new route for thematic_reviews_landing_page because another route matched the thematic_reviews_landing_page request via the `:page_type` parameter and was sending it to `contents_controller#show`. 

The new route makes use of `documents_controller#index` because in fin_cap when we call this new route we give it a `:page_type` parameter.