### PR TITLE
Return evidence summaries in descending order of creation date

### DIFF
--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -21,6 +21,7 @@ class DocumentProvider
     filter_by_keyword
     filter_by_tag
     filter_documents
+    order_documents
   end
 
   private
@@ -76,5 +77,9 @@ class DocumentProvider
       end
       acc
     end
+  end
+
+  def order_documents
+    @documents = @documents.order('created_at DESC')
   end
 end

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -239,6 +239,16 @@ RSpec.describe DocumentProvider do
     end
   end
 
+  describe 'ordering search results' do
+    let!(:insight_page) { create(:insight_page, site: site, layout: insight_layout, created_at: Date.today) }
+    let!(:review_page) { create(:page, site: site, layout: review_layout, created_at: Date.yesterday) }
+
+    it 'pages in descending order of creation date' do
+      expect(subject.size).to eq(2)
+      expect(subject.first).to eq(insight_page)
+    end
+  end
+
   describe 'when there are too many filters' do
     let(:filters) { (1..27).to_a }
 


### PR DESCRIPTION
[TP 8761](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&boardPopup=userstory/8761/silent)

### Requirement
Summaries should be displayed in descending order of creation date, in other words, most recently created. Creation date is used for ordering to ensure summaries created months ago but **edited** more recently do not edge out more recently **created** summaries.