### PR TITLE
9118 news page layout

### DIFF
--- a/app/views/pages/form_blocks/_news.html.haml
+++ b/app/views/pages/form_blocks/_news.html.haml
@@ -1,0 +1,1 @@
+= render 'pages/form_blocks/dynamic_page_type', namespace: namespace, cms_blocks: cms_blocks

--- a/db/seeds/fincap.seeds.rb
+++ b/db/seeds/fincap.seeds.rb
@@ -842,10 +842,7 @@ Policy Statement published in March 2015.
     Comfy::Cms::Block.new(
       identifier: 'component_cta_links',
       content: <<-CONTENT
-        [Evidence Hub](/general_info)
-        [Evaluation Toolkit](/common-evaluation-toolkit)
-        [The Steering Groups](/steering-groups)
-        [2015 Financial Capability Survey](/financial-capability-survey)
+        [Latest News](/news)
       CONTENT
     ),
     Comfy::Cms::Block.new(

--- a/db/seeds/fincap.seeds.rb
+++ b/db/seeds/fincap.seeds.rb
@@ -131,6 +131,18 @@ lifestage_layout = english_site.layouts.find_or_create_by(
   CONTENT
 )
 
+news_layout = english_site.layouts.find_or_create_by(
+  identifier: 'news',
+  label: 'News',
+  content:  <<-CONTENT
+    {{ cms:page:content:rich_text }}
+    {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+    {{ cms:page:hero_description:simple_component/Description }}
+    {{ cms:field:order_by_date:datetime }}
+    {{ cms:page:cta_links:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+  CONTENT
+)
+
 layout = Comfy::Cms::Layout.find_by(identifier: 'insight')
 
 english_site.pages.create!(
@@ -481,6 +493,8 @@ daily lives.
 tag = Tag.create(
   value: 'how-can-we-improve-the-financial-capability-of-young-adults'
 )
+mobile_payments_tag = Tag.create(value: 'mobile-payments')
+secure_payments_tag = Tag.create(value: 'secure-payments')
 
 evaluation_page.keywords << tag
 
@@ -686,6 +700,7 @@ english_site.pages.create!(
   label: 'Young Adults',
   slug: 'young-adults',
   layout: lifestage_layout,
+
   state: 'published',
   blocks: [
     Comfy::Cms::Block.new(
@@ -788,6 +803,60 @@ independence, beginning between the ages of 16 to 18 and continuing to their mid
     ),
   ]
 )
+
+news_page = english_site.pages.create!(
+  label: 'Press Release: A new way to pay!',
+  slug: 'press-release-a-new-way-to-pay',
+  layout: news_layout,
+  state: 'published',
+  blocks: [
+    Comfy::Cms::Block.new(
+      identifier: 'content',
+      content: <<-CONTENT
+The way in which payments are made in the UK is set to undergo the most radical
+change since the 1960s. This follows the [launch of a new strategy](https://www.paymentsforum.uk/final-strategy) to give people
+greater control over how they manage their day-to-day finances and help stamp
+out financial fraud.
+In the first industry-wide initiative of its kind, the Payments Strategy Forum,
+whose members include consumer groups, businesses, fintechs, UK banks and
+building societies, today recommends a new way of making payments that promises
+greater protection and security for consumers and businesses.(2)
+The Strategy gives: 
+*   More control and assurance for consumers over how they manage their finances 
+*   Safer and more secure banking 
+*   Opportunities for new banks and Fintechs to compete and offer innovative services that meet the needs of tomorrow’s users
+Notes to editors 
+1.  Source: The Payment Systems Regulator 
+2.  The Payments Strategy Forum (the Forum) was announced by the Payment Systems Regulator (PSR) in its 
+Policy Statement published in March 2015.
+      CONTENT
+    ),
+    Comfy::Cms::Block.new(
+      identifier: 'component_hero_image',
+      content: '/assets/styleguide/hero-sample.jpg'
+    ),
+    Comfy::Cms::Block.new(
+      identifier: 'component_hero_description',
+      content: 'New strategy launched to make UK payments fit for the 21st Century'
+    ),
+    Comfy::Cms::Block.new(
+      identifier: 'component_cta_links',
+      content: <<-CONTENT
+        [Evidence Hub](/general_info)
+        [Evaluation Toolkit](/common-evaluation-toolkit)
+        [The Steering Groups](/steering-groups)
+        [2015 Financial Capability Survey](/financial-capability-survey)
+      CONTENT
+    ),
+    Comfy::Cms::Block.new(
+      identifier: 'order_by_date',
+      content: DateTime.new(2018, 7, 26)
+    )
+  ]
+)
+[mobile_payments_tag, secure_payments_tag].each do |tag|
+  news_page.keywords << tag
+end
 
 Comfy::Cms::Block.all.each do |block|
   block.update(

--- a/features/pages_form/fincap_news_pages.feature
+++ b/features/pages_form/fincap_news_pages.feature
@@ -1,0 +1,29 @@
+Feature: Building News Pages
+  As an Editor
+  In order to build a News Page
+  I want to be able to fill out all the fields on the form
+
+  Background:
+    Given I have a news page layout setup with components
+    And I am logged in
+
+  Scenario: Creating a news page
+    Given I am on the homepage
+    And I click on "Create new page"
+    And I select "News" on the creation page
+    And I create a page "Press release: A new way to pay!"
+    When I edit the page "Press release: A new way to pay!"
+    And I fill in
+      | FIELD            | VALUE                              |
+      | hero_image       | /assets/styleguide/hero-sample.jpg |
+      | hero_description | Press release: A new way to pay!   |
+      | cta_links        | [Test](/test)                      |
+      | publication_date | Tuesday 29 November 2016           |
+    And I save and return to the homepage
+    And when I click the "Press release: A new way to pay!" page
+    Then I should see the fields filled with the content
+      | FIELD            | VALUE                              |
+      | hero_image       | /assets/styleguide/hero-sample.jpg |
+      | hero_description | Press release: A new way to pay!   |
+      | cta_links        | [Test](/test)                      |
+      | publication_date | Tuesday 29 November 2016           |

--- a/features/pages_form/fincap_news_pages.feature
+++ b/features/pages_form/fincap_news_pages.feature
@@ -18,7 +18,7 @@ Feature: Building News Pages
       | hero_image       | /assets/styleguide/hero-sample.jpg |
       | hero_description | Press release: A new way to pay!   |
       | cta_links        | [Test](/test)                      |
-      | publication_date | Tuesday 29 November 2016           |
+    And I enter an order_by date of "26-07-2018"
     And I save and return to the homepage
     And when I click the "Press release: A new way to pay!" page
     Then I should see the fields filled with the content
@@ -26,4 +26,4 @@ Feature: Building News Pages
       | hero_image       | /assets/styleguide/hero-sample.jpg |
       | hero_description | Press release: A new way to pay!   |
       | cta_links        | [Test](/test)                      |
-      | publication_date | Tuesday 29 November 2016           |
+    And I should see an order_by date of "2018-07-26T00:00:00+00:00"

--- a/features/pages_form/fincap_review_pages.feature
+++ b/features/pages_form/fincap_review_pages.feature
@@ -1,6 +1,6 @@
 Feature: Building Review Pages
   As an Editor
-  In order to the build an Insights Page
+  In order to the build a Review Page
   I want to be able to fill out all the text fields on the form
 
   Background:

--- a/features/preview.feature
+++ b/features/preview.feature
@@ -15,6 +15,6 @@ Feature: Preview
     Then I should be able to preview it in a new window
 
   Scenario: Preview unpublished article
-    Given I have an articles with unpublished changes
+    Given I have an article with unpublished changes
     When I view the live published article
     Then I should see the published Article content

--- a/features/step_definitions/edit_page_steps.rb
+++ b/features/step_definitions/edit_page_steps.rb
@@ -19,7 +19,7 @@ Then(/^I should not be able to see live draft article$/) do
   expect(JSON.load(live_page.text).symbolize_keys).to eq(message: 'Page not found')
 end
 
-Given(/^I have an articles with unpublished changes$/) do
+Given(/^I have an article with unpublished changes$/) do
   load_page_in_editor(site: cms_site, page: build_cms_new_draft_page).slug
   edit_page.content.set("New Published Content")
   edit_page.publish.click

--- a/features/step_definitions/fincap_background_steps.rb
+++ b/features/step_definitions/fincap_background_steps.rb
@@ -1,0 +1,133 @@
+Given(/^I am on the homepage$/) do
+  home_page.load
+end
+
+Given(/^I have an insight page layout$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'insight',
+    label: 'Insight',
+    content:  <<-CONTENT
+      {{ cms:page:content:rich_text }}
+      {{ cms:page:overview }}
+      {{ cms:page:countries }}
+      {{ cms:page:links_to_research }}
+      {{ cms:page:contact_details }}
+      {{ cms:page:year_of_publication }}
+      {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
+      {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
+      {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
+      {{ cms:page:data_types:collection_check_boxes/Quantitative, Qualitative }}
+    CONTENT
+  )
+end
+
+Given(/^I have an evaluation page layout$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'evaluation',
+    label: 'Evaluation',
+    content: <<-CONTENT
+      {{ cms:page:content:rich_text }}
+      {{ cms:page:overview }}
+      {{ cms:page:countries }}
+      {{ cms:page:links_to_research }}
+      {{ cms:page:contact_information }}
+      {{ cms:page:year_of_publication }}
+      {{ cms:page:activities_and_setting }}
+      {{ cms:page:programme_delivery }}
+      {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
+      {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
+      {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
+      {{ cms:page:data_types:collection_check_boxes/Programme Theory, Measured Outcomes, Causality, Process Evaluation, Value for money }}
+      {{ cms:page:measured_outcomes:collection_check_boxes/Financial wellbeing, Financial behaviour, Financial capability (connection), Financial capability (mindset), Financial capability (Ability) }}
+    CONTENT
+  )
+end
+
+Given(/^I have a review page layout$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'review',
+    label: 'Review',
+    content:  <<-CONTENT
+      {{ cms:page:content:rich_text }}
+      {{ cms:page:overview }}
+      {{ cms:page:countries }}
+      {{ cms:page:links_to_research }}
+      {{ cms:page:contact_information }}
+      {{ cms:page:year_of_publication }}
+      {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
+      {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
+      {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
+      {{ cms:page:data_types:collection_check_boxes/Literature review, Systematic review }}
+    CONTENT
+  )
+end
+
+Given(/^I have an article page layout setup with components$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'article',
+    label: 'Article',
+    content:  <<-CONTENT
+      {{ cms:page:content:rich_text }}
+      {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+      {{ cms:page:hero_description:simple_component/Description }}
+      {{ cms:page:cta_links:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+      {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+      {{ cms:page:feedback:simple_component/email@moneyadviceservice.org.uk.org.uk) }}
+    CONTENT
+  )
+end
+
+Given(/^I have an thematic reviews landing page layout setup with components$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'thematic-reviews-landing-page',
+    label: 'Thematic Reviews Landing Page',
+    content:  <<-CONTENT
+      {{ cms:page:content:rich_text }}
+    CONTENT
+  )
+end
+
+Given(/^I have a lifestage page layout setup with components$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'lifestage',
+    label: 'Lifestage',
+    content:  <<-CONTENT
+      {{ cms:page:content:rich_text }}
+      {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+      {{ cms:page:hero_description:simple_component/Description }}
+      {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+      {{ cms:page:teaser1_title }}
+      {{ cms:page:teaser1_image }}
+      {{ cms:page:teaser1_text }}
+      {{ cms:page:teaser1_link }}
+      {{ cms:page:teaser2_title }}
+      {{ cms:page:teaser2_image }}
+      {{ cms:page:teaser2_text }}
+      {{ cms:page:teaser2_link }}
+      {{ cms:page:teaser3_title }}
+      {{ cms:page:teaser3_image }}
+      {{ cms:page:teaser3_text }}
+      {{ cms:page:teaser3_link }}
+      {{ cms:page:strategy_title }}
+      {{ cms:page:strategy_overview }}
+      {{ cms:page:strategy_link }}
+      {{ cms:page:steering_group_list_title }}
+      {{ cms:page:steering_group_links }}
+      {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+    CONTENT
+  )
+end
+
+Given(/^I have a news page layout setup with components$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'news',
+    label: 'News',
+    content:  <<-CONTENT
+    {{ cms:page:content:rich_text }}
+    {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+    {{ cms:page:hero_description:simple_component/Description }}
+    {{ cms:page:order_by_date }}
+    {{ cms:page:cta_links:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+  CONTENT
+  )
+end

--- a/features/step_definitions/fincap_pages_steps.rb
+++ b/features/step_definitions/fincap_pages_steps.rb
@@ -1,137 +1,3 @@
-Given(/^I have an insight page layout$/) do
-  cms_site.layouts.find_or_create_by(
-    identifier: 'insight',
-    label: 'Insight',
-    content:  <<-CONTENT
-      {{ cms:page:content:rich_text }}
-      {{ cms:page:overview }}
-      {{ cms:page:countries }}
-      {{ cms:page:links_to_research }}
-      {{ cms:page:contact_details }}
-      {{ cms:page:year_of_publication }}
-      {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
-      {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
-      {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
-      {{ cms:page:data_types:collection_check_boxes/Quantitative, Qualitative }}
-    CONTENT
-  )
-end
-
-Given(/^I have an evaluation page layout$/) do
-  cms_site.layouts.find_or_create_by(
-    identifier: 'evaluation',
-    label: 'Evaluation',
-    content: <<-CONTENT
-      {{ cms:page:content:rich_text }}
-      {{ cms:page:overview }}
-      {{ cms:page:countries }}
-      {{ cms:page:links_to_research }}
-      {{ cms:page:contact_information }}
-      {{ cms:page:year_of_publication }}
-      {{ cms:page:activities_and_setting }}
-      {{ cms:page:programme_delivery }}
-      {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
-      {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
-      {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
-      {{ cms:page:data_types:collection_check_boxes/Programme Theory, Measured Outcomes, Causality, Process Evaluation, Value for money }}
-      {{ cms:page:measured_outcomes:collection_check_boxes/Financial wellbeing, Financial behaviour, Financial capability (connection), Financial capability (mindset), Financial capability (Ability) }}
-    CONTENT
-  )
-end
-
-Given(/^I have a review page layout$/) do
-  cms_site.layouts.find_or_create_by(
-    identifier: 'review',
-    label: 'Review',
-    content:  <<-CONTENT
-      {{ cms:page:content:rich_text }}
-      {{ cms:page:overview }}
-      {{ cms:page:countries }}
-      {{ cms:page:links_to_research }}
-      {{ cms:page:contact_information }}
-      {{ cms:page:year_of_publication }}
-      {{ cms:page:topics:collection_check_boxes/Saving, Pensions and Retirement Planning, Credit Use and Debt, Budgeting and Keeping Track, Insurance and Protection, Financial Education, Financial Capability }}
-      {{ cms:page:countries_of_delivery:collection_check_boxes/United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other }}
-      {{ cms:page:client_groups:collection_check_boxes/Children (3-11), Young People (12-16), Parents / Families, Young Adults (17-24), Working Age (18-65), Older People (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other }}
-      {{ cms:page:data_types:collection_check_boxes/Literature review, Systematic review }}
-    CONTENT
-  )
-end
-
-Given(/^I have an article page layout setup with components$/) do
-  cms_site.layouts.find_or_create_by(
-    identifier: 'article',
-    label: 'Article',
-    content:  <<-CONTENT
-      {{ cms:page:content:rich_text }}
-      {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
-      {{ cms:page:hero_description:simple_component/Description }}
-      {{ cms:page:cta_links:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
-      {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
-      {{ cms:page:feedback:simple_component/email@moneyadviceservice.org.uk.org.uk) }}
-    CONTENT
-  )
-end
-
-Given(/^I have an thematic reviews landing page layout setup with components$/) do
-  cms_site.layouts.find_or_create_by(
-    identifier: 'thematic-reviews-landing-page',
-    label: 'Thematic Reviews Landing Page',
-    content:  <<-CONTENT
-      {{ cms:page:content:rich_text }}
-    CONTENT
-  )
-end
-
-Given(/^I have a lifestage page layout setup with components$/) do
-  cms_site.layouts.find_or_create_by(
-    identifier: 'lifestage',
-    label: 'Lifestage',
-    content:  <<-CONTENT
-      {{ cms:page:content:rich_text }}
-      {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
-      {{ cms:page:hero_description:simple_component/Description }}
-      {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
-      {{ cms:page:teaser1_title }}
-      {{ cms:page:teaser1_image }}
-      {{ cms:page:teaser1_text }}
-      {{ cms:page:teaser1_link }}
-      {{ cms:page:teaser2_title }}
-      {{ cms:page:teaser2_image }}
-      {{ cms:page:teaser2_text }}
-      {{ cms:page:teaser2_link }}
-      {{ cms:page:teaser3_title }}
-      {{ cms:page:teaser3_image }}
-      {{ cms:page:teaser3_text }}
-      {{ cms:page:teaser3_link }}
-      {{ cms:page:strategy_title }}
-      {{ cms:page:strategy_overview }}
-      {{ cms:page:strategy_link }}
-      {{ cms:page:steering_group_list_title }}
-      {{ cms:page:steering_group_links }}
-      {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
-    CONTENT
-  )
-end
-
-Given(/^I have a news page layout setup with components$/) do
-  cms_site.layouts.find_or_create_by(
-    identifier: 'news',
-    label: 'News',
-    content:  <<-CONTENT
-    {{ cms:page:content:rich_text }}
-    {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
-    {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:field:order_by_date:datetime }}
-    {{ cms:page:cta_links:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
-  CONTENT
-  )
-end
-
-Given(/^I am on the homepage$/) do
-  home_page.load
-end
-
 Given(/^I click on "([^"]*)"$/) do |button|
   click_on(button)
 end
@@ -168,14 +34,8 @@ When(/^I uncheck$/) do |table|
   end
 end
 
-Then(/^I should see the checkbox fields with the value$/) do |table|
-  table.rows.each do |row|
-    if row[1] == 'checked'
-      expect(edit_page.send(row[0])).to be_checked
-    else
-      expect(edit_page.send(row[0])).not_to be_checked
-    end
-  end
+When(/^I enter an order_by date of "([^"]*)"$/) do |date_string|
+  edit_page.order_by_date.set(date_string.to_datetime)
 end
 
 When(/^I save and return to the homepage$/) do
@@ -191,4 +51,18 @@ Then(/^I should see the fields filled with the content$/) do |table|
   table.rows.each do |row|
     expect(edit_page.send(row[0]).value).to eq(row[1])
   end
+end
+
+Then(/^I should see the checkbox fields with the value$/) do |table|
+  table.rows.each do |row|
+    if row[1] == 'checked'
+      expect(edit_page.send(row[0])).to be_checked
+    else
+      expect(edit_page.send(row[0])).not_to be_checked
+    end
+  end
+end
+
+Then(/^I should see an order_by date of "([^"]*)"$/) do |date_string|
+  expect(edit_page.order_by_date.text).to eq(date_string)
 end

--- a/features/step_definitions/fincap_pages_steps.rb
+++ b/features/step_definitions/fincap_pages_steps.rb
@@ -114,6 +114,20 @@ Given(/^I have a lifestage page layout setup with components$/) do
   )
 end
 
+Given(/^I have a news page layout setup with components$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'news',
+    label: 'News',
+    content:  <<-CONTENT
+    {{ cms:page:content:rich_text }}
+    {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+    {{ cms:page:hero_description:simple_component/Description }}
+    {{ cms:field:order_by_date:datetime }}
+    {{ cms:page:cta_links:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+  CONTENT
+  )
+end
+
 Given(/^I am on the homepage$/) do
   home_page.load
 end

--- a/features/support/ui/pages/edit.rb
+++ b/features/support/ui/pages/edit.rb
@@ -101,7 +101,7 @@ module UI::Pages
 
     # news Page
     element :order_by_date, '#blocks_attributes_3_content'
- 
+
     # MAS HOMEPAGE
     element :raw_hero_image, '#blocks_attributes_1_content'
     element :raw_heading, '#blocks_attributes_0_content'

--- a/features/support/ui/pages/edit.rb
+++ b/features/support/ui/pages/edit.rb
@@ -99,6 +99,9 @@ module UI::Pages
     element :steering_group_list_title, '#blocks_attributes_19_content'
     element :steering_group_links, '#blocks_attributes_20_content'
 
+    # news Page
+    element :order_by_date, '#blocks_attributes_3_content'
+ 
     # MAS HOMEPAGE
     element :raw_hero_image, '#blocks_attributes_1_content'
     element :raw_heading, '#blocks_attributes_0_content'

--- a/lib/cms/form_builder.rb
+++ b/lib/cms/form_builder.rb
@@ -73,6 +73,15 @@ class Cms::FormBuilder < ActionView::Helpers::FormBuilder
     default_tag_field(tag, index)
   end
 
+  def field_date_time(tag, index)
+    default_tag_field(
+      tag,
+      index,
+      :date_field_tag,
+      data: { 'cms-datetime' => true }
+    )
+  end
+
   def field_string(tag, index)
     default_tag_field(tag, index)
   end
@@ -88,7 +97,6 @@ class Cms::FormBuilder < ActionView::Helpers::FormBuilder
   # This is because we handle the block attributes independently from the page
   # attributes in forms.
   def default_tag_field(tag, index, method = :text_field_tag, options = {})
-
     label       = tag.blockable.class.human_attribute_name(tag.identifier.to_s)
     content     = ''
     current_value = find_current_value_for_field(tag)

--- a/lib/comfortable_mexican_sofa/extensions/tag.rb
+++ b/lib/comfortable_mexican_sofa/extensions/tag.rb
@@ -3,9 +3,13 @@
 module ComfortableMexicanSofa
   module Extensions
     module Tag
+      MAS_CMS_BLOCKS = %w(page field collection simple image datetime).freeze
+      
       # rubocop:disable Style/PredicateName
       def is_cms_block?
-        %w(page field collection simple image).member?(self.class.to_s.demodulize.underscore.split(/_/).first)
+        MAS_CMS_BLOCKS.member?(
+          self.class.to_s.demodulize.underscore.split(/_/).first
+        )
       end
     end
   end

--- a/lib/tasks/fincap.rake
+++ b/lib/tasks/fincap.rake
@@ -135,5 +135,17 @@ namespace :fincap do
         {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
       CONTENT
     )
+
+    english_site.layouts.find_or_create_by(
+      identifier: 'news',
+      label: 'News',
+      content:  <<-CONTENT
+        {{ cms:page:content:rich_text }}
+        {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+        {{ cms:page:hero_description:simple_component/Description }}
+        {{ cms:field:order_by_date:datetime }}
+        {{ cms:page:cta_links:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+      CONTENT
+    )
   end
 end


### PR DESCRIPTION
[TP 9118](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9118)

There is a fincap requirement for editors to be able to add news pages. These pages are similar to articles but include a date which enables the editors to fine tune the order in which news items are displayed on the Latest News page. [Related TP story, 9117](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9117)