### PR TITLE
Fincap 9299 deployment strategy

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,23 +2,34 @@
 # N.B. This file is intended as a placeholder. Never put any real values in this file and commit.
 ####################################################################################################
 
-MAS_CMS_API_TOKEN=mytoken
+##GLOBAL
 AZURE_ASSETS_STORAGE_CMS_CONTAINER='container'
 AZURE_ASSETS_STORAGE_CMS_ACCOUNT_KEY='key'
 AZURE_ASSETS_STORAGE_CMS_ACCOUNT_NAME='name'
 FARADAY_HOST='localhost:5000'
 FARADAY_X_FORWARDED_PROTO='http'
-MAS_PUBLIC_WEBSITE_DOMAIN="localhost:5000"
-MAS_PUBLIC_WEBSITE_URL="http://localhost:5000"
-GA_API_EMAIL_ADDRESS="google.service.account@example.com"
-GA_PRIVATE_KEY_PATH="path/to/private.key"
+GA_API_EMAIL_ADDRESS='google.service.account@example.com'
+GA_PRIVATE_KEY_PATH='path/to/private.key'
+INDEXERS_ADAPTER='local'
 MAILJET_DEFAULT_FROM_ADDRESS=notmonitored@notify.moneyadviceservice.org.uk
-MAS_CMS_URL="http://localhost:3000/"
-MAS_BLOG_URL='https://www.moneyadviceservice.org.uk/blog'
 RACKSPACE_API_KEY='key'
 RACKSPACE_API_KEY='key'
 RACKSPACE_BUCKET_NAME='bucket'
 RACKSPACE_USERNAME='username'
-INDEXERS_ADAPTER='local'
-ALGOLIA_APP_ID='test'
+
+# MAS Specific
 ALGOLIA_API_KEY='test'
+ALGOLIA_APP_ID='test'
+MAS_PUBLIC_WEBSITE_DOMAIN='localhost:5000'
+MAS_PUBLIC_WEBSITE_URL='http://localhost:5000'
+MAS_BLOG_URL='https://www.moneyadviceservice.org.uk/blog'
+MAS_CMS_URL='http://localhost:3000/'
+MAS_CMS_API_TOKEN=mytoken
+
+# Fincap Specific
+FINCAP_PUBLIC_WEBSITE_DOMAIN='localhost:5000'
+FINCAP_PUBLIC_WEBSITE_URL='http://localhost:5000'
+FINCAP_CMS_URL='http://localhost:3000/'
+FINCAP_CMS_API_TOKEN=mytoken
+FINCAP_ALGOLIA_APP_ID='test'
+FINCAP_ALGOLIA_API_KEY='test'

--- a/README.md
+++ b/README.md
@@ -20,21 +20,24 @@ So the next section will explain the setup for each application.
 
 ```sh
 $ ./bin/setup
-$ rails s
 ```
 
 The setup script will install required gems, bower modules and create the databases as well as seed some data to setup the CMS.
 
 Note: Make sure you've added all the required API keys for the app to work properly. Make sure you set the HOSTNAME, GA_API_EMAIL_ADDRESS, GA_PRIVATE_KEY_PATH variables in the `.env` file appropriately. The setup script above will set up the `.env` file  structure but you may need to set some keys seperately, particularly the Rackspace ones.
 
-### Fincap CMS setup
+The setup script will create *three* databases: `cms_test`, `cms_mas_development`, `cms_fincap_development`
+The two development databases are for the two different applications we run from this repository: MAS CMS and Fincap CMS
 
+### Running application locally
+
+You can run either application separately by passing the APP_NAME environment variable when running the command
 ```sh
-$ bundle install
-$ npm install
-$ bowndler install
-$ bundle exec rake db:create db:schema:load db:migrate db:seed:fincap
-$ rails s
+$ APP_NAME='FINCAP' rails s
+```
+or
+```sh
+$ APP_NAME='MAS' rails s
 ```
 
 ### Updating Dough
@@ -48,16 +51,20 @@ bowndler update
 
 ## Testing
 
+The tests(and code) are agnostic to the applications(MAS & Fincap) however the current implementation
+still requires you to pass an APP_NAME when running the tests just so everything can boot up.
+It will not matter which APP_NAME you pass through here.
+
 Run unit specs with:
 
 ```sh
-$ bundle exec rspec
+$ APP_NAME='MAS' bundle exec rspec
 ```
 
 Run feature specs with:
 
 ```sh
-$ bundle exec cucumber
+$ APP_NAME='MAS' bundle exec cucumber
 ```
 
 For JavaScript tests we use:

--- a/app/filters/api/authentication_filter.rb
+++ b/app/filters/api/authentication_filter.rb
@@ -1,6 +1,6 @@
 module API
   class AuthenticationFilter
-    MAS_CMS_API_TOKEN = ENV.fetch('MAS_CMS_API_TOKEN')
+    MAS_CMS_API_TOKEN = Domain.config.cms_api_token
 
     def self.before(controller)
       authenticate?(controller)

--- a/bin/setup
+++ b/bin/setup
@@ -8,7 +8,7 @@ set -e
 
 # Set up Ruby dependencies via Bundler
 gem install bundler --conservative
-bundle check || bundle install
+bundle check || bundle install --with development
 
 #Set up frontend dependencies
 npm install
@@ -20,4 +20,5 @@ if [ ! -f .env ]; then
 fi
 
 # Set up database and add any development seed data
-bundle exec rake db:create db:schema:load db:seed layout:video b2b:create_type
+APP_NAME=MAS bundle exec rake db:create db:schema:load db:migrate db:seed:cms
+APP_NAME=FINCAP bundle exec rake db:create db:schema:load db:migrate db:seed:fincap

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Cms
     require_relative '../lib/cms'
     require_relative '../lib/rack/redirect_middleware'
     require_relative '../config/initializers/features'
+    require_relative '../config/initializers/domain'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 development:
   adapter: mysql2
   username: root
-  database: cms_development
+  database: <%= Domain.config.dev_db_name %>
   pool: 5
   timeout: 5000
   encoding: utf8
@@ -27,7 +27,7 @@ production:
   encoding: utf8
   reconnect: true
   strict: false
-  url: <%= ENV["MAS_CMS_DATABASE_URL"] %>
+  url: <%= Domain.config.prod_db_url %>
 
 
 # We have this database configuration because we use the gem `js-routes` to allow us to access Rails routes from

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,10 +56,10 @@ Rails.application.configure do
   config.cache_store = :memory_store, { size: 8.megabytes }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = if ENV.has_key?('MAS_CMS_PUBLIC_URL')
-                                          ENV['MAS_CMS_PUBLIC_URL']
+  config.action_controller.asset_host = if Domain.config.cms_public_url
+                                          Domain.config.cms_public_url
                                         else
-                                          ENV['MAS_CMS_URL']
+                                          Domain.config.cms_url
                                         end
 
   # Precompile additional assets.

--- a/config/initializers/algolia_setup.rb
+++ b/config/initializers/algolia_setup.rb
@@ -1,2 +1,2 @@
-Algolia.init application_id: ENV['ALGOLIA_APP_ID'],
-             api_key:        ENV['ALGOLIA_API_KEY']
+Algolia.init application_id: Domain.config.algolia_app_id,
+             api_key:        Domain.config.algolia_api_key

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -3,7 +3,7 @@
 ComfortableMexicanSofa.configure do |config|
   # TODO Change this stuff to use config_for gem unless updating Rails to 4.2
 
-  config.preview_domain = ENV['MAS_PUBLIC_WEBSITE_DOMAIN']
+  config.preview_domain = Domain.config.public_website_domain
   # Title of the admin area
   #   config.cms_title = 'ComfortableMexicanSofa CMS Engine'
 
@@ -31,9 +31,9 @@ ComfortableMexicanSofa.configure do |config|
   if Rails.env.production?
     config.upload_file_options = {
       azure_credentials: {
-        access_key: ENV['AZURE_ASSETS_STORAGE_CMS_ACCOUNT_KEY'],
-        container: ENV['AZURE_ASSETS_STORAGE_CMS_CONTAINER'],
-        storage_account_name: ENV['AZURE_ASSETS_STORAGE_CMS_ACCOUNT_NAME']
+        access_key: Domain.config.azure_access_key,
+        container: Domain.config.azure_container,
+        storage_account_name: Domain.config.azure_account_name
       },
       path: ':attachment/:id_partition/:style/:filename',
       storage: 'azure',

--- a/config/initializers/domain.rb
+++ b/config/initializers/domain.rb
@@ -1,0 +1,79 @@
+module Domain
+  class << self
+      # Modify Domain configuration
+      # Example:
+      #   Domain.configure do |config|
+      #     config.cms_url = 'localhost:3000'
+      #   end
+      def configure
+        yield configuration
+      end
+
+      # Accessor for Domain::Configuration
+      def configuration
+        @configuration ||= Configuration.new
+      end
+      alias :config :configuration
+
+    class Configuration
+      attr_accessor :algolia_app_id,
+                    :algolia_api_key,
+                    :azure_access_key,
+                    :azure_account_name,
+                    :azure_container,
+                    :cms_api_token,
+                    :cms_public_url,
+                    :cms_url,
+                    :dev_db_name,
+                    :prod_db_url,
+                    :public_website_domain,
+                    :public_website_url
+
+      def initialize
+        @algolia_app_id = nil
+        @algolia_api_key = nil
+        @azure_access_key = nil
+        @azure_account_name = nil
+        @azure_container = nil
+        @cms_api_token = nil
+        @cms_public_url = nil
+        @cms_url = nil
+        @dev_db_name = nil
+        @prod_db_url = nil
+        @public_website_domain = nil
+        @public_website_url = nil
+      end
+    end
+  end
+end
+
+Domain.configure do |config|
+  fail "Please set ENV['APP_NAME']" unless Rails.env.production? || ENV['APP_NAME']
+  if ENV['APP_NAME'] == 'FINCAP' || ENV['PWD'] == '/srv/fincap-cms'
+    config.public_website_domain ||= ENV['FINCAP_PUBLIC_WEBSITE_DOMAIN']
+    config.public_website_url    ||= ENV['FINCAP_PUBLIC_WEBSITE_URL']
+    config.cms_public_url        ||= ENV['FINCAP_CMS_PUBLIC_URL']
+    config.cms_url               ||= ENV['FINCAP_CMS_URL']
+    config.cms_api_token         ||= ENV['FINCAP_CMS_API_TOKEN']
+    config.prod_db_url           ||= ENV['MAS_FINCAP_CMS_DATABASE_URL']
+    config.dev_db_name           ||= 'cms_fincap_development'
+    config.azure_access_key      ||= ENV['AZURE_ASSETS_STORAGE_FINCAP_CMS_ACCOUNT_KEY']
+    config.azure_container       ||= ENV['AZURE_ASSETS_STORAGE_FINCAP_CMS_CONTAINER']
+    config.azure_account_name    ||= ENV['AZURE_ASSETS_STORAGE_FINCAP_CMS_ACCOUNT_NAME']
+    config.algolia_app_id        ||= ENV['FINCAP_ALGOLIA_APP_ID']
+    config.algolia_api_key       ||= ENV['FINCAP_ALGOLIA_API_KEY']
+  else
+    config.public_website_domain ||= ENV['MAS_PUBLIC_WEBSITE_DOMAIN']
+    config.public_website_url    ||= ENV['MAS_PUBLIC_WEBSITE_URL']
+    config.cms_public_url        ||= ENV['MAS_CMS_PUBLIC_URL']
+    config.cms_url               ||= ENV['MAS_CMS_URL']
+    config.cms_api_token         ||= ENV['MAS_CMS_API_TOKEN']
+    config.prod_db_url           ||= ENV['MAS_CMS_DATABASE_URL']
+    config.dev_db_name           ||= 'cms_mas_development'
+    config.azure_access_key      ||= ENV['AZURE_ASSETS_STORAGE_CMS_ACCOUNT_KEY']
+    config.azure_container       ||= ENV['AZURE_ASSETS_STORAGE_CMS_CONTAINER']
+    config.azure_account_name    ||= ENV['AZURE_ASSETS_STORAGE_CMS_ACCOUNT_NAME']
+    config.algolia_app_id        ||= ENV['ALGOLIA_APP_ID']
+    config.algolia_api_key       ||= ENV['ALGOLIA_API_KEY']
+  end
+end

--- a/config/initializers/domain.rb
+++ b/config/initializers/domain.rb
@@ -16,7 +16,8 @@ module Domain
       alias :config :configuration
 
     class Configuration
-      attr_accessor :algolia_app_id,
+      attr_accessor :app_name,
+                    :algolia_app_id,
                     :algolia_api_key,
                     :azure_access_key,
                     :azure_account_name,
@@ -50,6 +51,7 @@ end
 Domain.configure do |config|
   fail "Please set ENV['APP_NAME']" unless Rails.env.production? || ENV['APP_NAME']
   if ENV['APP_NAME'] == 'FINCAP' || ENV['PWD'] == '/srv/fincap-cms'
+    config.app_name              ||= 'FINCAP'
     config.public_website_domain ||= ENV['FINCAP_PUBLIC_WEBSITE_DOMAIN']
     config.public_website_url    ||= ENV['FINCAP_PUBLIC_WEBSITE_URL']
     config.cms_public_url        ||= ENV['FINCAP_CMS_PUBLIC_URL']
@@ -63,6 +65,7 @@ Domain.configure do |config|
     config.algolia_app_id        ||= ENV['FINCAP_ALGOLIA_APP_ID']
     config.algolia_api_key       ||= ENV['FINCAP_ALGOLIA_API_KEY']
   else
+    config.app_name              ||= 'MAS'
     config.public_website_domain ||= ENV['MAS_PUBLIC_WEBSITE_DOMAIN']
     config.public_website_url    ||= ENV['MAS_PUBLIC_WEBSITE_URL']
     config.cms_public_url        ||= ENV['MAS_CMS_PUBLIC_URL']
@@ -77,3 +80,7 @@ Domain.configure do |config|
     config.algolia_api_key       ||= ENV['ALGOLIA_API_KEY']
   end
 end
+
+puts("=" * 80)
+puts("Running '#{Domain.config.app_name}' CMS.")
+puts("=" * 80)

--- a/test.sh
+++ b/test.sh
@@ -5,6 +5,9 @@ set -e
 export PATH=./bin:$PATH
 export RAILS_ENV=test
 export BUNDLE_WITHOUT=development
+# the app is irrelevant for testing as the code should be agnostic,
+# this is just to load in some environment variables
+export APP_NAME=FINCAP
 
 CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 BUNDLE_JOBS=$((CORES-1))


### PR DESCRIPTION
[TP9299](https://moneyadviceservice.tpondemand.com/entity/9299-deploy-fincap-cms-to-production-environment)

The main part of this work is to set the correct ENV variables depending on which application domain should be running (MAS or FINCAP)
Most of this work is done within the new `domain.rb`

At the moment `domain.rb` has both the object Domain and the config script at the bottom of it. Probably makes sense to split this out, but I haven't yet decided how best to do this and where to put the files in the tree. It needs to be loaded and run before most of the application so things like the database know's it's name (hence why it's loaded into the Application [here](https://github.com/moneyadviceservice/cms/pull/459/files#diff-b1fe55db50c712fef0673345e5b9c0d9R14))...however the current location of `domain.rb` (within `initializers/`) means that the file will be loaded in again at a later stage... not a huge issue, but doesn't make sense to load it twice.

There is probably further work to be done for this process once we have upgraded to Rails 4.2 as well as updating the seeds scripts so that the correct seeds run just based on the APP_NAME env variable rather than currently having to run like:
`APP_NAME='MAS' bundle exec rake db:create db:schema:load db:migrate db:seed:cms`
`APP_NAME='FINCAP' bundle exec rake db:create db:schema:load db:migrate db:seed:fincap`
`./bin/setup` currently will do the above for you


Once this has been merged in you will then use 3 databases locally
`cms_test`
`cms_fincap_development`
`cms_mas_development`
These will be setup using ./bin/setup or when you pass the APP_NAME through when running seeds.

You can now DROP your old database which was just called `cms_development` - which we were using for either fincap OR mas