### PR TITLE
Amend searching by keyword

### DIFF
--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -1,7 +1,7 @@
 class DocumentProvider
   attr_reader :current_site, :document_type, :keyword, :filters, :tag
 
-  BLOCKS_TO_SEARCH = %w(content overview)
+  BLOCKS_TO_SEARCH = %w(content overview order_by_date)
   FILTER_LIMIT = 26
 
   def initialize(params = {})

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -63,5 +63,10 @@ FactoryGirl.define do
       identifier { 'countries_of_delivery' }
       content { 'United Kingdom' }
     end
+
+    trait :order_by_date do
+      identifier { 'order_by_date' }
+      content { '15th March 2017' }
+    end
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -111,6 +111,14 @@ FactoryGirl.define do
       end
     end
 
+    factory :page_with_order_by_date_block do
+      site { create :site, identifier: 'test-documents'}
+      label 'Some label'
+      after(:create) do |page|
+        create :block, :order_by_date, blockable: page
+      end
+    end
+
     factory :insight_page_with_raw_cta_text_block do
       site { create :site, identifier: 'test-documents'}
       label 'Page with block other than content or identifier'

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe DocumentProvider do
           end
         end
 
-         context 'and the keyword is found in a "content" block' do
+        context 'and the keyword is found in a "content" block' do
           let!(:page_with_keyword) { create(:insight_page_with_overview_block, site: site, layout: insight_layout) }
           let!(:page_without_keyword) { create(:page, site: site, layout: insight_layout) }
           let(:keyword) { 'redundancy' }
@@ -102,6 +102,17 @@ RSpec.describe DocumentProvider do
           it 'returns only those documents' do
             expect(subject.size).to eq(1)
             expect(subject).to match_array([page_with_keyword])
+          end
+        end
+
+        context 'and the keyword is found in an "order_by_date" block' do
+          let!(:page_with_order_by_date_block) { create(:page_with_order_by_date_block, site: site, layout: insight_layout) }
+          let!(:page_without_keyword) { create(:page, site: site, layout: insight_layout) }
+          let(:keyword) { '2017' }
+
+          it 'returns only those documents' do
+            expect(subject.size).to eq(1)
+            expect(subject).to match_array([page_with_order_by_date_block])
           end
         end
 


### PR DESCRIPTION
[TP 9305](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=task/9305)

### REQUIREMENT
On the fincap latest news page, there needs to be links to allow the user to view news items from a particular year. This pr amends the database querying to ensure pages are only returned for a specific year.

### TECHNICAL
Refer to [fin_cap pr 155](https://github.com/moneyadviceservice/fin_cap/pull/155).

Several solutions were considered to meet the requirement. This solution was considered the simplest.

Fincap news article pages include an `order_by_date` which is considered the 'official publication' date and is specifically used by editors to manipulate the order in which these articles appear on the 'Latest News' page. In order to get the news articles for a specific year, fin_cap passes a keyword parameter for the specific year. The solution adds the 'order_by_date' block to the list of blocks searched for a keyword search.