### PR TITLE
Allow block filter values to be strings or arrays

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -28,7 +28,7 @@ module API
           :keyword,
           :tag,
           document_type: [],
-          blocks: [:identifier, :value]
+          blocks: [:identifier, :value, value: []]
         ).merge(current_site: current_site)
       ).retrieve
     end


### PR DESCRIPTION
[TP 9281](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5580782241563718174&appConfig=eyJhY2lkIjoiRTQ4MDEyNENDOUYxRDU4RDg0RTEyRjNCODBEN0VBMUYifQ==&searchPopup=userstory/9281)

This pr addresses the technical debt on fincap where filtering the evidence hub search by Year of Publication was returning incorrect results.

### Solution
The `value` parameter was being permitted as a string which worked for the other filters. Year of Publication values are passed as an array and therefore were being rejected.  Allowing the `value` to be a string OR an array satisfies all filters.

Please see [associated fincap pr 158](https://github.com/moneyadviceservice/fin_cap/pull/158) for testing.