### PR TITLE
[DEV APPROVED] 9283 Latest news component

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -11,7 +11,7 @@ module API
     param :document_type, Array, required: false
     param :keyword, String, required: false
     param :blocks, Array, required: false
-    param :tag, String, required: false
+    param :tag, [Array, String], required: false
     def index
       if documents
         render json: paginated_documents, meta: meta_data, root: 'documents'
@@ -26,7 +26,7 @@ module API
       @documents ||= DocumentProvider.new(
         params.permit(
           :keyword,
-          :tag,
+          :tag, tag: [],
           document_type: [],
           blocks: [:identifier, :value, value: []]
         ).merge(current_site: current_site)

--- a/app/serializers/page_serializer.rb
+++ b/app/serializers/page_serializer.rb
@@ -3,7 +3,8 @@ require 'active_model_serializers'
 class PageSerializer < ActiveModel::Serializer
   attributes :label, :slug, :full_path,
              :meta_description, :meta_title, :category_names,
-             :layout_identifier, :related_content, :published_at, :supports_amp
+             :layout_identifier, :related_content, :published_at, :supports_amp,
+             :tags
 
   has_many :blocks, serializer: BlockSerializer
   has_many :translations, serializer: PageTranslationSerializer
@@ -20,5 +21,9 @@ class PageSerializer < ActiveModel::Serializer
       previous_link: PageLink::PreviousLink.new(object),
       next_link: PageLink::NextLink.new(object)
     }
+  end
+
+  def tags
+    object.keywords.map(&:value)
   end
 end

--- a/db/seeds/fincap.seeds.rb
+++ b/db/seeds/fincap.seeds.rb
@@ -741,7 +741,7 @@ Or, for a wide range of evaluation evidence, insight and market research don't f
   ]
 )
 
-english_site.pages.create!(
+lifestage_page = english_site.pages.create!(
   label: 'Young Adults',
   slug: 'young-adults',
   layout: lifestage_layout,
@@ -899,6 +899,8 @@ Policy Statement published in March 2015.
 [mobile_payments_tag, secure_payments_tag].each do |tag|
   news_page.keywords << tag
 end
+
+lifestage_page.keywords << mobile_payments_tag
 
 Comfy::Cms::Block.all.each do |block|
   block.update(

--- a/spec/serializers/page_serializer_spec.rb
+++ b/spec/serializers/page_serializer_spec.rb
@@ -275,4 +275,22 @@ describe PageSerializer do
     end
 
   end
+
+  describe '#tags' do
+    context 'when article has keywords' do
+      before { allow(article).to receive(:keywords).and_return(tags) }
+
+      let(:tags){ [build(:tag, value: 'mobile_payments')] }
+
+      it 'returns array of keyword values' do
+        expect(subject.tags).to eql(%w[mobile_payments])
+      end
+    end
+
+    context 'when article has no keywords' do
+      it 'returns an empty array' do
+        expect(subject.tags).to eql([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
[TP 9283](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5481321774608038243&appConfig=eyJhY2lkIjoiNjRGM0FCMDY3RUQ5MDREM0RGNDZGOUM0REZENUZBMzIifQ==&searchPopup=userstory/9283)

### REQUIREMENT
A number of FinCap pages need to show related news articles. Related news articles are those that have the same tags as the current page.

### SOLUTION
Ensure keywords are included in the json response that cms returns to fincap:
- Add tags method to the page serializer to return an array of values.
- Ensure api documentation allows tag parameter to be a string or an array.

This solution works with [changes to mas-cms-client](https://github.com/moneyadviceservice/mas-cms-client/pull/31)