### PR TITLE
[DEV APPROVED] Feature/8847 fincap migration

### DIFF
--- a/lib/prismic/cms_converter.rb
+++ b/lib/prismic/cms_converter.rb
@@ -1,5 +1,8 @@
 module Prismic
-  class CmsDocument < OpenStruct
+  class ConvertedDocument < OpenStruct
+    def migrate
+      "Prismic::Migrator::#{type.classify}".constantize.new(self).migrate
+    end
   end
 
   class CmsConverter
@@ -21,7 +24,7 @@ module Prismic
         end
       end
 
-      CmsDocument.new(converted_data)
+      ConvertedDocument.new(converted_data)
     end
   end
 end

--- a/lib/prismic/cms_converter.rb
+++ b/lib/prismic/cms_converter.rb
@@ -1,10 +1,4 @@
 module Prismic
-  class ConvertedDocument < OpenStruct
-    def migrate
-      "Prismic::Migrator::#{type.classify}".constantize.new(self).migrate
-    end
-  end
-
   class CmsConverter
     attr_reader :document, :converted_data
 

--- a/lib/prismic/cms_converter.rb
+++ b/lib/prismic/cms_converter.rb
@@ -1,0 +1,25 @@
+module Prismic
+  class CmsDocument < OpenStruct
+  end
+
+  class CmsConverter
+    attr_reader :document, :converted_data
+
+    def initialize(document)
+      @document = document
+      @converted_data = {}
+    end
+
+    def convert
+      document.row.each do |attribute, content|
+        if content.is_a?(Array) && content.first.is_a?(Hash)
+          converted_data[attribute] = HTMLConverter.new(content).to_html
+        else
+          converted_data[attribute] = content
+        end
+      end
+
+      CmsDocument.new(converted_data)
+    end
+  end
+end

--- a/lib/prismic/cms_converter.rb
+++ b/lib/prismic/cms_converter.rb
@@ -13,7 +13,9 @@ module Prismic
     def convert
       document.row.each do |attribute, content|
         if content.is_a?(Array) && content.first.is_a?(Hash)
-          converted_data[attribute] = HTMLConverter.new(content).to_html
+          html = HTMLConverter.new(content).to_html
+          converted_data[attribute] = html
+          converted_data["#{attribute}_markdown"] = ReverseMarkdown.convert(html)
         else
           converted_data[attribute] = content
         end

--- a/lib/prismic/converted_document.rb
+++ b/lib/prismic/converted_document.rb
@@ -15,6 +15,10 @@ module Prismic
       strip_tags(title).to_s
     end
 
+    def slug
+      formatted_title.parameterize
+    end
+
     def filename
       formatted_title[0..30].gsub(/\//, '').parameterize
     end

--- a/lib/prismic/converted_document.rb
+++ b/lib/prismic/converted_document.rb
@@ -1,0 +1,30 @@
+require 'erb'
+
+module Prismic
+  class ConvertedDocument < OpenStruct
+    include ActionView::Helpers::SanitizeHelper
+    attr_reader :attributes
+
+    def initialize(fields)
+      @attributes = fields.keys
+
+      super(fields)
+    end
+
+    def formatted_title
+      strip_tags(title).to_s
+    end
+
+    def filename
+      formatted_title[0..30].gsub(/\//, '').parameterize
+    end
+
+    def get_binding
+      binding
+    end
+
+    def migrate
+      "Prismic::Migrator::#{type.classify}".constantize.new(self).migrate
+    end
+  end
+end

--- a/lib/prismic/data_store.rb
+++ b/lib/prismic/data_store.rb
@@ -1,0 +1,8 @@
+module Prismic
+  module DataStore
+    def all(dir)
+      files = Dir[File.expand_path("#{dir}/*.json")]
+      files.map { |file| new(JSON.parse(File.read(file))) }.flatten
+    end
+  end
+end

--- a/lib/prismic/document.rb
+++ b/lib/prismic/document.rb
@@ -1,0 +1,21 @@
+require_relative 'data_store'
+require_relative 'cms_converter'
+
+module Prismic
+  class Document < OpenStruct
+    extend DataStore
+    attr_reader :row, :attributes
+
+    def initialize(row)
+      @row = row
+      @attributes = row.keys
+
+      super(row)
+    end
+
+    def to_cms
+      puts "Converting #{self.title}"
+      ::Prismic::CmsConverter.new(self).convert
+    end
+  end
+end

--- a/lib/prismic/document.rb
+++ b/lib/prismic/document.rb
@@ -1,5 +1,8 @@
 require_relative 'data_store'
 require_relative 'cms_converter'
+require_relative 'converted_document'
+require_relative 'html_converter'
+require_relative 'tag_converter'
 
 module Prismic
   class Document < OpenStruct

--- a/lib/prismic/document.rb
+++ b/lib/prismic/document.rb
@@ -14,7 +14,6 @@ module Prismic
     end
 
     def to_cms
-      puts "Converting #{self.title}"
       ::Prismic::CmsConverter.new(self).convert
     end
   end

--- a/lib/prismic/fragment.rb
+++ b/lib/prismic/fragment.rb
@@ -1,8 +1,9 @@
 module Prismic
   class Fragment
-    attr_reader :field_type, :text, :text_format
+    attr_reader :original_fragment, :field_type, :text, :text_format
 
     def initialize(fragment)
+      @original_fragment = fragment
       @field_type = fragment['type']
       @text = fragment['content']['text'] if fragment['content']
       @text_format = fragment['content']['spans'] if fragment['content']

--- a/lib/prismic/fragment.rb
+++ b/lib/prismic/fragment.rb
@@ -1,15 +1,11 @@
 module Prismic
   class Fragment
-    attr_reader :field_type, :text, :format
+    attr_reader :field_type, :text, :text_format
 
     def initialize(fragment)
       @field_type = fragment['type']
       @text = fragment['content']['text'] if fragment['content']
-      @format = fragment['content']['spans'] if fragment['content']
-    end
-
-    def document
-      Nokogiri::HTML::DocumentFragment.parse(text)
+      @text_format = fragment['content']['spans'] if fragment['content']
     end
   end
 end

--- a/lib/prismic/fragment.rb
+++ b/lib/prismic/fragment.rb
@@ -1,0 +1,15 @@
+module Prismic
+  class Fragment
+    attr_reader :field_type, :text, :format
+
+    def initialize(fragment)
+      @field_type = fragment['type']
+      @text = fragment['content']['text'] if fragment['content']
+      @format = fragment['content']['spans'] if fragment['content']
+    end
+
+    def document
+      Nokogiri::HTML::DocumentFragment.parse(text)
+    end
+  end
+end

--- a/lib/prismic/html_converter.rb
+++ b/lib/prismic/html_converter.rb
@@ -1,28 +1,72 @@
 module Prismic
+  class Fragment
+    attr_reader :field_type, :text, :format
+
+    def initialize(fragment)
+      @field_type = fragment['type']
+      @text = fragment['content']['text'] if fragment['content']
+      @format = fragment['content']['spans'] if fragment['content']
+    end
+
+    def document
+      Nokogiri::HTML::DocumentFragment.parse(text)
+    end
+  end
+
   class HTMLConverter
+    LIST_ITENS = ['list-item', 'o-list-item']
     attr_reader :content
 
     def initialize(content)
-      @content = content
+      fragments = content.map do |fragment|
+        prismic_fragment = Prismic::Fragment.new(fragment)
+
+        next if prismic_fragment.field_type.blank?
+
+        prismic_fragment
+      end.compact
+
+      ordered_fragments = []
+
+      fragments.each_with_index do |fragment, index|
+        if fragment.field_type.in?(LIST_ITENS)
+          if index.zero? || !fragments[index - 1].field_type.in?(LIST_ITENS)
+
+            list = []
+            i = index
+
+            while fragments[i] && fragments[i].field_type.in?(LIST_ITENS)
+              list << fragments[i]
+              i += 1
+            end
+            ordered_fragments << list
+          end
+        else
+          ordered_fragments << fragment
+        end
+      end
+
+      @content = ordered_fragments
     end
 
     def to_html
-      content.each_with_index.map do |fragment, index|
-        fragment_type = fragment['type']
-
-        next if fragment_type.blank?
-
-        text = fragment['content']['text']
-        text_format = fragment['content']['spans']
-        document_fragment = Nokogiri::HTML::DocumentFragment.parse(text)
-
-        TagConverter.new(
-          document_fragment: document_fragment,
-          fragment_type: fragment_type,
-          text: text,
-          text_format: text_format
-        ).to_html
+      content.map do |fragment|
+        if fragment.is_a?(Array)
+          html = fragment.map { |f| to_tag(f) }.join
+          "<ul>#{html}</ul>"
+        else
+          to_tag(fragment)
+        end
       end.compact.join
+    end
+
+    def to_tag(fragment)
+      TagConverter.new(
+        document_fragment: fragment.document,
+        fragment_type: fragment.field_type,
+        text: fragment.text,
+        text_format: fragment.format
+      ).to_html
     end
   end
 end

--- a/lib/prismic/html_converter.rb
+++ b/lib/prismic/html_converter.rb
@@ -37,12 +37,7 @@ module Prismic
     end
 
     def to_tag(fragment)
-      TagConverter.new(
-        document_fragment: fragment.document,
-        fragment_type: fragment.field_type,
-        text: fragment.text,
-        text_format: fragment.format
-      ).to_html
+      TagConverter.new(fragment: fragment).to_html
     end
 
     private

--- a/lib/prismic/html_converter.rb
+++ b/lib/prismic/html_converter.rb
@@ -1,6 +1,6 @@
 module Prismic
   class HTMLConverter
-    LIST_ITENS = ['list-item', 'o-list-item']
+    LIST_ITEMS = ['list-item', 'o-list-item']
     HTML_LIST = {
       'list-item' => 'ul',
       'o-list-item' => 'ol'
@@ -12,8 +12,8 @@ module Prismic
       ordered_fragments = []
 
       fragments.each_with_index do |fragment, index|
-        if fragment.field_type.in?(LIST_ITENS)
-          if index.zero? || !fragments[index - 1].field_type.in?(LIST_ITENS)
+        if fragment.field_type.in?(LIST_ITEMS)
+          if index.zero? || !fragments[index - 1].field_type.in?(LIST_ITEMS)
             ordered_fragments << map_html_list(fragments, fragment, index)
           end
         else
@@ -56,7 +56,7 @@ module Prismic
       list = []
       i = index
 
-      while fragments[i] && fragments[i].field_type.in?(LIST_ITENS)
+      while fragments[i] && fragments[i].field_type.in?(LIST_ITEMS)
         list << fragments[i]
         i += 1
       end

--- a/lib/prismic/html_converter.rb
+++ b/lib/prismic/html_converter.rb
@@ -1,0 +1,28 @@
+module Prismic
+  class HTMLConverter
+    attr_reader :content
+
+    def initialize(content)
+      @content = content
+    end
+
+    def to_html
+      content.each_with_index.map do |fragment, index|
+        fragment_type = fragment['type']
+
+        next if fragment_type.blank?
+
+        text = fragment['content']['text']
+        text_format = fragment['content']['spans']
+        document_fragment = Nokogiri::HTML::DocumentFragment.parse(text)
+
+        TagConverter.new(
+          document_fragment: document_fragment,
+          fragment_type: fragment_type,
+          text: text,
+          text_format: text_format
+        ).to_html
+      end.compact.join
+    end
+  end
+end

--- a/lib/prismic/html_converter.rb
+++ b/lib/prismic/html_converter.rb
@@ -1,45 +1,20 @@
 module Prismic
-  class Fragment
-    attr_reader :field_type, :text, :format
-
-    def initialize(fragment)
-      @field_type = fragment['type']
-      @text = fragment['content']['text'] if fragment['content']
-      @format = fragment['content']['spans'] if fragment['content']
-    end
-
-    def document
-      Nokogiri::HTML::DocumentFragment.parse(text)
-    end
-  end
-
   class HTMLConverter
     LIST_ITENS = ['list-item', 'o-list-item']
+    HTML_LIST = {
+      'list-item' => 'ul',
+      'o-list-item' => 'ol'
+    }
     attr_reader :content
 
     def initialize(content)
-      fragments = content.map do |fragment|
-        prismic_fragment = Prismic::Fragment.new(fragment)
-
-        next if prismic_fragment.field_type.blank?
-
-        prismic_fragment
-      end.compact
-
+      fragments = map_fragments(content)
       ordered_fragments = []
 
       fragments.each_with_index do |fragment, index|
         if fragment.field_type.in?(LIST_ITENS)
           if index.zero? || !fragments[index - 1].field_type.in?(LIST_ITENS)
-
-            list = []
-            i = index
-
-            while fragments[i] && fragments[i].field_type.in?(LIST_ITENS)
-              list << fragments[i]
-              i += 1
-            end
-            ordered_fragments << list
+            ordered_fragments << map_html_list(fragments, fragment, index)
           end
         else
           ordered_fragments << fragment
@@ -53,7 +28,8 @@ module Prismic
       content.map do |fragment|
         if fragment.is_a?(Array)
           html = fragment.map { |f| to_tag(f) }.join
-          "<ul>#{html}</ul>"
+          fragment_type = fragment.first.field_type
+          "<#{HTML_LIST[fragment_type]}>#{html}</#{HTML_LIST[fragment_type]}>"
         else
           to_tag(fragment)
         end
@@ -67,6 +43,30 @@ module Prismic
         text: fragment.text,
         text_format: fragment.format
       ).to_html
+    end
+
+    private
+
+    def map_fragments(content)
+      content.map do |fragment|
+        prismic_fragment = Prismic::Fragment.new(fragment)
+
+        next if prismic_fragment.field_type.blank?
+
+        prismic_fragment
+      end.compact
+    end
+
+    def map_html_list(fragments, fragment, index)
+      list = []
+      i = index
+
+      while fragments[i] && fragments[i].field_type.in?(LIST_ITENS)
+        list << fragments[i]
+        i += 1
+      end
+
+      list
     end
   end
 end

--- a/lib/prismic/migrator/article.rb
+++ b/lib/prismic/migrator/article.rb
@@ -1,0 +1,19 @@
+module Prismic
+  module Migrator
+    class Article < Base
+      def layout_identifier
+        'article'
+      end
+
+      def blocks
+        [
+          Comfy::Cms::Block.new(
+            identifier: 'content',
+            content: document.content_markdown,
+            processed_content: document.content
+          )
+        ]
+      end
+    end
+  end
+end

--- a/lib/prismic/migrator/base.rb
+++ b/lib/prismic/migrator/base.rb
@@ -1,0 +1,40 @@
+module Prismic
+  module Migrator
+    class Base
+      PUBLISHED = 'published'.freeze
+      attr_reader :document
+
+      delegate :formatted_title, :slug, to: :document
+
+      def initialize(document)
+        @document = document
+      end
+
+      def migrate
+        site.pages.create!(
+          label: formatted_title,
+          slug: slug,
+          layout: layout,
+          state: PUBLISHED,
+          blocks: blocks
+        )
+      end
+
+      def layout
+        Comfy::Cms::Layout.find_by(identifier: layout_identifier)
+      end
+
+      def layout_identifier
+        raise NotImplementedError
+      end
+
+      def blocks
+        raise NotImplementedError
+      end
+
+      def site
+        Comfy::Cms::Site.find_by(label: 'en')
+      end
+    end
+  end
+end

--- a/lib/prismic/tag_converter.rb
+++ b/lib/prismic/tag_converter.rb
@@ -1,0 +1,77 @@
+module Prismic
+  class TagConverter
+    PRISMIC_FIELD = {
+      paragraph: '<p/>',
+      heading1: '<h1/>',
+      heading2: '<h2/>',
+      heading3: '<h3/>',
+      heading4: '<h4/>',
+      heading5: '<h5/>',
+      heading6: '<h6/>',
+      :'list-item' => '<li/>',
+      embed: '',
+      image: '',
+      :'o-list-item' => '<li/>'
+    }.stringify_keys.freeze
+
+    PRISMIC_FORMAT = {
+      strong: 'strong'
+    }.stringify_keys.freeze
+    attr_accessor :document_fragment, :fragment_type, :text, :text_format
+    include ActiveModel::Model
+
+    # Transform Prismic fields into html tags. The possible values:
+    #  [
+    #   "paragraph",
+    #   "list-item",
+    #   "embed",
+    #   "image",
+    #   "o-list-item",
+    #   "heading2",
+    #   "heading3",
+    #   "heading4",
+    #   "heading1",
+    #   "heading6",
+    #   "heading5"
+    #  ]
+    #
+    def to_html
+      html_tag = PRISMIC_FIELD[fragment_type].to_s
+
+      fragment_text.wrap(html_tag) if html_tag
+
+      convert_special_formats(
+        text: text,
+        text_format: text_format,
+        document_fragment: document_fragment
+      )
+
+      document_fragment.to_html
+    end
+
+    private
+
+    def fragment_text
+      document_fragment.xpath('.//text()')
+    end
+
+    # Prismic formats. The "spans" node has this possible values:
+    #
+    #  ["strong", "hyperlink", "em", "label"]
+    #
+    def convert_special_formats(text:, text_format:, document_fragment:)
+      text_format.each do |format|
+        start_at = format['start']
+        end_at = format['end']
+        html_tag_format = PRISMIC_FORMAT[format['type']]
+        content = text[start_at, end_at]
+
+        if html_tag_format
+          fragment_text.first.replace(
+            text.gsub(content, "<#{html_tag_format}>#{content}</#{html_tag_format}>")
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/prismic/tag_converter.rb
+++ b/lib/prismic/tag_converter.rb
@@ -60,7 +60,7 @@ module Prismic
 
     private
 
-    # Prismic formats. The "spans" node has this possible values:
+    # The "spans" node can have the following possible values:
     #
     #  ["strong", "hyperlink", "em"]
     #

--- a/lib/prismic/tag_converter.rb
+++ b/lib/prismic/tag_converter.rb
@@ -9,7 +9,6 @@ module Prismic
       heading5: 'h5',
       heading6: 'h6',
       :'list-item' => 'li',
-      embed: '',
       image: '',
       :'o-list-item' => 'li'
     }.stringify_keys.freeze
@@ -20,7 +19,7 @@ module Prismic
       hyperlink: '<a href="%{link}">%{text}</a>'
     }.stringify_keys.freeze
     attr_accessor :fragment
-    delegate :field_type, :text, :text_format, to: :fragment
+    delegate :original_fragment, :field_type, :text, :text_format, to: :fragment
     include ActiveModel::Model
 
     # Transform Prismic fields into html tags. The possible values:
@@ -41,7 +40,12 @@ module Prismic
     def to_html
       result = convert_special_formats
 
-      "<#{html_tag}>#{result}</#{html_tag}>"
+      if field_type == 'embed'
+        original_fragment['data']['html']
+      elsif field_type == 'image'
+      else
+        "<#{html_tag}>#{result}</#{html_tag}>"
+      end
     end
 
     def html_tag
@@ -89,8 +93,10 @@ module Prismic
 
     def format_content(content:, tag:, format:)
       if tag.include?("<a")
+        link = format['data']['url']
+
         tag % {
-          link: format['data']['url'],
+          link: link,
           text: content
         }
       else

--- a/lib/prismic/tag_converter.rb
+++ b/lib/prismic/tag_converter.rb
@@ -16,7 +16,8 @@ module Prismic
 
     PRISMIC_FORMAT = {
       strong: 'strong',
-      em: 'em'
+      em: 'em',
+      hyperlink: '<a href="%{link}">%{text}</a>'
     }.stringify_keys.freeze
     attr_accessor :fragment
     delegate :field_type, :text, :text_format, to: :fragment
@@ -65,18 +66,36 @@ module Prismic
         next if html_tag_format.blank?
 
         if html[start_at..end_at] == content
-          html[start_at..end_at] = "<#{html_tag_format}>#{content}</#{html_tag_format}>"
+          html[start_at..end_at] = format_content(
+            content: content,
+            tag: html_tag_format,
+            format: format
+          )
         else
           new_start_at = html.index(content)
           new_end_at = new_start_at + (end_at - start_at) - 1
           new_content = html[new_start_at..new_end_at]
 
-          html[new_start_at..new_end_at] =
-            "<#{html_tag_format}>#{new_content}</#{html_tag_format}>"
+          html[new_start_at..new_end_at] = format_content(
+            content: new_content,
+            tag: html_tag_format,
+            format: format
+          )
         end
       end
 
       html
+    end
+
+    def format_content(content:, tag:, format:)
+      if tag.include?("<a")
+        tag % {
+          link: format['data']['url'],
+          text: content
+        }
+      else
+        "<#{tag}>#{content}</#{tag}>"
+      end
     end
   end
 end

--- a/lib/prismic/tag_converter.rb
+++ b/lib/prismic/tag_converter.rb
@@ -1,24 +1,25 @@
 module Prismic
   class TagConverter
     PRISMIC_FIELD = {
-      paragraph: '<p/>',
-      heading1: '<h1/>',
-      heading2: '<h2/>',
-      heading3: '<h3/>',
-      heading4: '<h4/>',
-      heading5: '<h5/>',
-      heading6: '<h6/>',
-      :'list-item' => '<li/>',
+      paragraph: 'p',
+      heading1: 'h1',
+      heading2: 'h2',
+      heading3: 'h3',
+      heading4: 'h4',
+      heading5: 'h5',
+      heading6: 'h6',
+      :'list-item' => 'li',
       embed: '',
       image: '',
-      :'o-list-item' => '<li/>'
+      :'o-list-item' => 'li'
     }.stringify_keys.freeze
 
     PRISMIC_FORMAT = {
       strong: 'strong',
       em: 'em'
     }.stringify_keys.freeze
-    attr_accessor :document_fragment, :fragment_type, :text, :text_format
+    attr_accessor :fragment
+    delegate :field_type, :text, :text_format, to: :fragment
     include ActiveModel::Model
 
     # Transform Prismic fields into html tags. The possible values:
@@ -37,47 +38,45 @@ module Prismic
     #  ]
     #
     def to_html
-      html_tag = PRISMIC_FIELD[fragment_type].to_s
+      result = convert_special_formats
 
-      fragment_text.wrap(html_tag) if html_tag
+      "<#{html_tag}>#{result}</#{html_tag}>"
+    end
 
-      convert_special_formats(
-        text: text,
-        text_format: text_format
-      )
-
-      document_fragment.to_html
+    def html_tag
+      PRISMIC_FIELD[field_type].to_s
     end
 
     private
 
-    def fragment_text
-      document_fragment.xpath('.//text()')
-    end
-
     # Prismic formats. The "spans" node has this possible values:
     #
-    #  ["strong", "hyperlink", "em", "label"]
+    #  ["strong", "hyperlink", "em"]
     #
-    def convert_special_formats(text:, text_format:)
+    def convert_special_formats
+      html = text.dup
+
       text_format.each do |format|
         start_at = format['start']
         end_at = format['end']
         html_tag_format = PRISMIC_FORMAT[format['type']]
-        content = text[start_at, end_at]
+        content = text[start_at...end_at]
 
-        if html_tag_format
-          if fragment_text.size > 1
-            fragment_text.find { |f| f.text.include?(content) }.replace(
-              content.gsub(content, "<#{html_tag_format}>#{content}</#{html_tag_format}>")
-            )
-          else
-            fragment_text.find { |f| f.text.include?(content) }.replace(
-              text.gsub(content, "<#{html_tag_format}>#{content}</#{html_tag_format}>")
-            )
-          end
+        next if html_tag_format.blank?
+
+        if html[start_at..end_at] == content
+          html[start_at..end_at] = "<#{html_tag_format}>#{content}</#{html_tag_format}>"
+        else
+          new_start_at = html.index(content)
+          new_end_at = new_start_at + (end_at - start_at) - 1
+          new_content = html[new_start_at..new_end_at]
+
+          html[new_start_at..new_end_at] =
+            "<#{html_tag_format}>#{new_content}</#{html_tag_format}>"
         end
       end
+
+      html
     end
   end
 end

--- a/lib/prismic/tag_converter.rb
+++ b/lib/prismic/tag_converter.rb
@@ -9,7 +9,7 @@ module Prismic
       heading5: 'h5',
       heading6: 'h6',
       :'list-item' => 'li',
-      image: '',
+      image: '<img src="%{src}" width="%{width}" height="%{height}" />',
       :'o-list-item' => 'li'
     }.stringify_keys.freeze
 
@@ -43,6 +43,12 @@ module Prismic
       if field_type == 'embed'
         original_fragment['data']['html']
       elsif field_type == 'image'
+        image = original_fragment['data']['origin']
+        html_tag % {
+          src: original_fragment['data']['url'],
+          width: image['width'],
+          height: image['height']
+        }
       else
         "<#{html_tag}>#{result}</#{html_tag}>"
       end
@@ -76,7 +82,7 @@ module Prismic
             format: format
           )
         else
-          new_start_at = html.index(content)
+          new_start_at = html.index(content) || start_at
           new_end_at = new_start_at + (end_at - start_at) - 1
           new_content = html[new_start_at..new_end_at]
 

--- a/lib/prismic/tag_converter.rb
+++ b/lib/prismic/tag_converter.rb
@@ -15,7 +15,8 @@ module Prismic
     }.stringify_keys.freeze
 
     PRISMIC_FORMAT = {
-      strong: 'strong'
+      strong: 'strong',
+      em: 'em'
     }.stringify_keys.freeze
     attr_accessor :document_fragment, :fragment_type, :text, :text_format
     include ActiveModel::Model
@@ -42,8 +43,7 @@ module Prismic
 
       convert_special_formats(
         text: text,
-        text_format: text_format,
-        document_fragment: document_fragment
+        text_format: text_format
       )
 
       document_fragment.to_html
@@ -59,7 +59,7 @@ module Prismic
     #
     #  ["strong", "hyperlink", "em", "label"]
     #
-    def convert_special_formats(text:, text_format:, document_fragment:)
+    def convert_special_formats(text:, text_format:)
       text_format.each do |format|
         start_at = format['start']
         end_at = format['end']
@@ -67,9 +67,15 @@ module Prismic
         content = text[start_at, end_at]
 
         if html_tag_format
-          fragment_text.first.replace(
-            text.gsub(content, "<#{html_tag_format}>#{content}</#{html_tag_format}>")
-          )
+          if fragment_text.size > 1
+            fragment_text.find { |f| f.text.include?(content) }.replace(
+              content.gsub(content, "<#{html_tag_format}>#{content}</#{html_tag_format}>")
+            )
+          else
+            fragment_text.find { |f| f.text.include?(content) }.replace(
+              text.gsub(content, "<#{html_tag_format}>#{content}</#{html_tag_format}>")
+            )
+          end
         end
       end
     end

--- a/lib/tasks/prismic.rake
+++ b/lib/tasks/prismic.rake
@@ -3,6 +3,19 @@ namespace :prismic do
   task :migrate, [:dir] => :environment do |t, args|
     documents = Prismic::Document.all(args[:dir])
     converted_documents = documents.map(&:to_cms)
+    errors = []
+
+    converted_documents.map do |converted_document|
+      begin
+        converted_document.migrate
+        print '.'
+      rescue NameError
+        print 'F'
+        errors << "Prismic::Migrator::#{converted_document.type.classify} is not defined. Skipping"
+      end
+    end
+
+    puts errors.uniq.sort if errors.present?
   end
 
   desc 'Show statistics for Prismic pages given a directory. Example: rake prismic:statistics[~/prismic_files]'

--- a/lib/tasks/prismic.rake
+++ b/lib/tasks/prismic.rake
@@ -9,12 +9,13 @@ namespace :prismic do
       begin
         converted_document.migrate
         print '.'
-      rescue NameError
+      rescue StandardError, NotImplementedError => exception
         print 'F'
-        errors << "Prismic::Migrator::#{converted_document.type.classify} is not defined. Skipping"
+        errors << exception.message
       end
     end
 
+    puts
     puts errors.uniq.sort if errors.present?
   end
 

--- a/lib/tasks/prismic.rake
+++ b/lib/tasks/prismic.rake
@@ -3,9 +3,6 @@ namespace :prismic do
   task :migrate, [:dir] => :environment do |t, args|
     documents = Prismic::Document.all(args[:dir])
     converted_documents = documents.map(&:to_cms)
-
-    puts "Migrating '#{documents.size}' documents."
-#    puts converted_documents
   end
 
   desc 'Show statistics for Prismic pages given a directory. Example: rake prismic:statistics[~/prismic_files]'

--- a/lib/tasks/prismic.rake
+++ b/lib/tasks/prismic.rake
@@ -1,4 +1,13 @@
 namespace :prismic do
+  desc 'Migrate all prismic documents to fincap. Example rake prismic:migrate[~/prismic_files]'
+  task :migrate, [:dir] => :environment do |t, args|
+    documents = Prismic::Document.all(args[:dir])
+    converted_documents = documents.map(&:to_cms)
+
+    puts "Migrating '#{documents.size}' documents."
+#    puts converted_documents
+  end
+
   desc 'Show statistics for Prismic pages given a directory. Example: rake prismic:statistics[~/prismic_files]'
   task :statistics, [:dir] => :environment do |t, args|
     Prismic::Statistics.new(args[:dir]).call
@@ -7,12 +16,6 @@ namespace :prismic do
   desc 'Show information about each evidence hub field type. Example: rake prismic:fields[~/Downloads/fincap,insight]'
   task :fields, [:dir, :evidence_type] => :environment do |t, args|
     Prismic::Fields.new(args[:dir], args[:evidence_type]).filter.print_table
-  end
-
-  desc 'Import all Evidence Hub prismic pages given a directory. Example: rake prismic:hub_import[~/prismic_files]'
-  task :hub_import, [:dir] => :environment do |t, args|
-    ActiveRecord::Base.logger = Logger.new(STDOUT)
-    Prismic::HubImport.new(args[:dir]).call
   end
 end
 

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -1,0 +1,297 @@
+RSpec.describe Prismic::CmsConverter do
+  subject(:cms_converter) { described_class.new(document) }
+  let(:document) { Prismic::Document.new(row) }
+
+  describe '#convert' do
+    subject(:convert) { cms_converter.convert }
+
+    context 'when attributes does not have content' do
+      let(:row) do
+        {
+          type: 'article',
+          lang: 'en-GB'
+        }
+      end
+
+      it 'returns documents with same attributes' do
+        expect(convert).to eq(
+          Prismic::CmsDocument.new(row)
+        )
+      end
+    end
+
+    context 'when attributes does not have any types mapped by prismic' do
+      let(:row) do
+        {
+          content: [
+            { some_field: 'foo', link: { title: 'foo', media: 'link' } }
+          ]
+        }
+      end
+
+      it 'ignores attributes' do
+        expect(convert).to eq(
+          Prismic::CmsDocument.new(content: '')
+        )
+      end
+    end
+
+    context 'when attributes have content' do
+      context 'when attributes have lists' do
+        let(:row) do
+          {
+            content: [
+						  {
+					    	'type'=>'list-item',
+					    	'content'=> {
+									'text' => "Relate to people's financial capability",
+									'spans'=>[]
+								}
+							},
+					    {
+								'type'=>'list-item',
+					     	'content'=>
+					      {
+									'text' => 'Make a positive contribution to evidence hub, given what is on there already',
+					      'spans' => []
+								}
+							},
+            ]
+          }
+        end
+
+        it 'wrap text with unordered list tag' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+							content: "<ul>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</ul>"
+            )
+          )
+        end
+      end
+
+      context 'when attributes have list with bold' do
+        let(:row) do
+					{
+						content: [
+              {
+							  'type' => 'list-item',
+					  	  'content' => {
+							  	 'text' => 'Programme theory describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;',
+					  	    'spans' => [{'start' => 0, 'end' => 16, 'type' => 'strong'}]
+							  }
+              },
+					 		{
+							  'type' => 'list-item',
+					 		  'content' => {
+                  'text' => "Measured outcomes reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;",
+					 		   'spans' => [{'start'=>0, 'end'=>17, 'type'=>'strong'}]
+                }
+							}
+            ]
+          }
+        end
+
+        it 'wrap text with unordered list tag with bold' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: "<ul><li>\n<strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li>\n<strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>"
+            )
+          )
+        end
+			end
+
+      context 'when attribute has paragraphs and lists' do
+        let(:row) do
+          {
+            content: [
+							{
+								'type'=>'paragraph',
+							  'content'=>
+							   {'text'=>
+							     "Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability",
+							    'spans'=>[]
+			          	}
+              },
+							{
+                'type'=>'list-item',
+							  'content'=> {
+                  'text'=>'Around four out of ten adults are not in control of their finances',
+							    'spans'=>[]
+                }
+              },
+							{
+                'type'=>'list-item',
+							  'content'=>{
+                  'text'=>'One in five cannot read a bank statement', 'spans'=>[]
+                }
+              },
+							{
+                'type'=>'paragraph',
+							  'content'=> {
+                  'text'=>
+							    'Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.',
+                  'spans' => []
+                }
+              }
+            ]
+          }
+        end
+
+        it 'convert paragraphs and unordered lists' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: "<p>Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability</p><ul><li>Around four out of ten adults are not in control of their finances</li><li>One in five cannot read a bank statement</li></ul><p>Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.</p>"
+            )
+          )
+        end
+      end
+
+      context 'when attribute does not contain special format' do
+        let(:row) do
+          {
+            content: [{
+              'type' => 'paragraph',
+              'content' => {
+                'text' => 'Audio clip available for use on radio.',
+                'spans' => []
+              }
+            }]
+          }
+        end
+
+        it 'wrap text with paragraph html tag' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<p>Audio clip available for use on radio.</p>'
+            )
+          )
+        end
+      end
+
+      context 'when attribute contains bold text' do
+        let(:row) do
+          {
+            content: [
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => 'Monday 25th September 2016',
+                  'spans' => [{ 'start' => 0, 'end' => 26, 'type' => 'strong' }]
+                }
+              }
+            ]
+          }
+        end
+
+        it 'wrap text with paragraph tag and format with bold text' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<p><strong>Monday 25th September 2016</strong></p>'
+            )
+          )
+        end
+      end
+
+      context 'when content has multiple paragraphs' do
+        let(:row) do
+          {
+            content: [
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => 'Audio clip available for use on radio.',
+                  'spans' => []
+                }
+              },
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => 'The need to improve financial education.',
+                  'spans' => []
+                }
+              }
+            ]
+          }
+        end
+
+        it 'wrap text with paragraph html tags' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<p>Audio clip available for use on radio.</p><p>The need to improve financial education.</p>'
+            )
+          )
+        end
+      end
+
+      context 'when attribute has heading one' do
+        let(:row) do
+          {
+            title: [
+              {
+                'type' => 'heading1',
+                'content' => {
+                  'text'  => "The Money Charity's Financial Education Report",
+                  'spans' => []
+                }
+              }
+            ]
+          }
+        end
+
+        it 'wrap text with heading one html tag' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              title: "<h1>The Money Charity's Financial Education Report</h1>"
+            )
+         )
+        end
+      end
+
+      context 'when attribute has lot of content' do
+        let(:row) do
+          {
+            content: [
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => "Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries & Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\nTotal \t \t£192,000 ",
+                  'spans'=>[{'start'=>684, 'end'=>702, 'type'=>'strong'}]
+                }
+              }
+            ]
+          }
+        end
+
+        it 'transform into html' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(content: "<p>Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries &amp; Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\n<strong>Total \t \t£192,000 </strong></p>")
+          )
+        end
+      end
+
+      context 'when attribute has heading 5' do
+        let(:row) do
+          {
+            title: [
+              {
+                'type' => 'heading5',
+                'content' => {
+                  'text'  => "The Money Charity's Financial Education Report",
+                  'spans' => []
+                }
+              }
+            ]
+          }
+        end
+
+        it 'wrap text with heading one html tag' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              title: "<h5>The Money Charity's Financial Education Report</h5>"
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe Prismic::CmsConverter do
                   'text' => "Wednesday 11 January 2017\n\nWith rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns",
                   'spans' => [
                     {
-                      "start"=>0, "end"=>27, "type"=>"strong"
+                      'start' => 0, 'end' => 27, 'type' => 'strong'
                     },
                     {
-                      "start"=>27, "end"=>155, "type"=>"em"
+                      'start' => 27, 'end' => 155, 'type' => 'em'
                     }
                   ]
                 }
@@ -68,7 +68,80 @@ RSpec.describe Prismic::CmsConverter do
         end
       end
 
-      context 'when attributes have links' do
+      context 'when attributes have embed videos' do
+        let(:row) do
+          {
+            content: [
+              {
+                'content' => { 'spans' => [], 'text' => '' },
+                'type' => 'embed',
+                'data' =>                  { 'height' => 344,
+                                             'width' => 459,
+                                             'embed_url' => 'https://www.youtube.com/watch?v=ThmnAhEJ1Lk',
+                                             'type' => 'video',
+                                             'version' => '1.0',
+                                             'title' => 'What Works Funding - Webinar',
+                                             'author_name' => 'MoneyAdviceService',
+                                             'author_url' => 'https://www.youtube.com/user/MoneyAdviceService',
+                                             'provider_name' => 'YouTube',
+                                             'provider_url' => 'https://www.youtube.com/',
+                                             'cache_age' => nil,
+                                             'thumbnail_url' => 'https://i.ytimg.com/vi/ThmnAhEJ1Lk/hqdefault.jpg',
+                                             'thumbnail_width' => 480,
+                                             'thumbnail_height' => 360,
+                                             'html' =>                     "<iframe width=\'459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>"
+                },
+                'label' => nil,
+                'direction' => nil
+              }
+            ]
+          }
+        end
+
+        it 'converts to html tags' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: "<iframe width=\'459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>"
+            )
+          )
+        end
+      end
+
+      context 'when attributes have images' do
+        let(:row) do
+          {
+            content: [
+              {
+                'content' => { 'spans' => [], 'text' => '' },
+                'type' => 'image',
+                'data' => {
+                  'origin' => {
+                    'id' => 'V0W9PyUAAKwMBoZk',
+                    'url' => 'https://prismic-io.s3.amazonaws.com/fincap-two%2F192ce333-1802-45e3-9a45-57c792c21e50_the+pensions+dashboard.png',
+                    'width' => 2624,
+                    'height' => 2624
+                  },
+                  'width' => 2624,
+                  'height' => 2624,
+                  'url' => 'https://prismic-io.s3.amazonaws.com/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png',
+                  'edit' => {
+                    'background' => 'transparent',
+                    'zoom' => 1.0,
+                    'crop' => { 'x' => 0, 'y' => 0 }
+                  },
+                  'credits' => nil,
+                  'alt' => nil,
+                  'linkTo' => nil
+                },
+                'label' => nil,
+                'direction' => nil
+              }
+            ]
+          }
+        end
+      end
+
+      context 'when attributes have external links' do
         let(:row) do
           {
             content: [
@@ -77,21 +150,19 @@ RSpec.describe Prismic::CmsConverter do
                 'content' => {
                   'text' => "•\tTo view the Money Advice Service Financial Capability UK Survey report, please click here",
                   'spans' => [
-										{'start'=>0, 'end'=>87, 'type'=>'strong'},
-                    {'start'=>87,
-                     'end'=>91,
-                     'type'=>'hyperlink',
-                     'data'=>
-                      {'wioUrl'=>'wio://medias/WFEJPioAAL4bnH2x',
-                       'url'=>
-                        'https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf',
-                       'kind'=>'document',
-                       'id'=>'WFEJPioAAL4bnH2x',
-                       'size'=>'2902326',
-                       'date'=>'12/14/16 08:53',
-                       'name'=>'MAS_FinCap_UK_Survey_2015_AW.PDF',
-                       'preview'=>{'title'=>'MAS_FinCap_UK_Survey_2015_AW.PDF', 'image'=>nil}}},
-                    {'start'=>87, 'end'=>91, 'type'=>'strong'}
+                    { 'start' => 0, 'end' => 87, 'type' => 'strong' },
+                    { 'start' => 87,
+                      'end' => 91,
+                      'type' => 'hyperlink',
+                      'data' =>                       { 'wioUrl' => 'wio://medias/WFEJPioAAL4bnH2x',
+                                                        'url' =>                         'https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf',
+                                                        'kind' => 'document',
+                                                        'id' => 'WFEJPioAAL4bnH2x',
+                                                        'size' => '2902326',
+                                                        'date' => '12/14/16 08:53',
+                                                        'name' => 'MAS_FinCap_UK_Survey_2015_AW.PDF',
+                                                        'preview' => { 'title' => 'MAS_FinCap_UK_Survey_2015_AW.PDF', 'image' => nil } } },
+                    { 'start' => 87, 'end' => 91, 'type' => 'strong' }
                   ]
                 }
               }
@@ -99,7 +170,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-				it '' do
+        it 'converts the links' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
               content: "<p><strong>•\tTo view the Money Advice Service Financial Capability UK Survey report, please click </strong><a href=\"https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf\"><strong>here</strong></a></p>"
@@ -113,19 +184,19 @@ RSpec.describe Prismic::CmsConverter do
           {
             content: [
               {
-                "type"=>"paragraph",
-                "content"=> {
-                  "text"=> "Caroline Rookes, Chief Executive of the Money Advice Service, said: “Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. ",
-                  "spans"=> [
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => 'Caroline Rookes, Chief Executive of the Money Advice Service, said: “Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. ',
+                  'spans' => [
                     {
-                      "start"=>0,
-                      "end"=>67,
-                      "type"=>"strong"
+                      'start' => 0,
+                      'end' => 67,
+                      'type' => 'strong'
                     },
                     {
-                      "start"=>68,
-                      "end"=>557,
-                      "type"=>"em"
+                      'start' => 68,
+                      'end' => 557,
+                      'type' => 'em'
                     }
                   ]
                 }
@@ -147,32 +218,32 @@ RSpec.describe Prismic::CmsConverter do
         let(:row) do
           {
             content: [
- 							{
-              	'type'=>'paragraph',
-                'content'=>{
-                  'text'=>'The Strategy is built around two key concepts:',
-                  'spans'=>[{'start'=>0, 'end'=>46, 'type'=>'strong'}]
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => 'The Strategy is built around two key concepts:',
+                  'spans' => [{ 'start' => 0, 'end' => 46, 'type' => 'strong' }]
                 }
               },
- 							{
-                'type'=>'o-list-item',
-                'content'=> {
-                  'text'=>'Collective impact and cross-sector co-ordination rather than isolated interventions.',
-                  'spans'=>[]
+              {
+                'type' => 'o-list-item',
+                'content' => {
+                  'text' => 'Collective impact and cross-sector co-ordination rather than isolated interventions.',
+                  'spans' => []
                 }
               },
- 							{
-                'type'=>'o-list-item',
- 							  'content'=> {
-                  'text'=> 'Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.',
- 							   'spans'=>[]
+              {
+                'type' => 'o-list-item',
+                'content' => {
+                  'text' => 'Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.',
+                  'spans' => []
                 }
               },
- 							{
-                'type'=>'paragraph',
- 							 'content'=> {
-                  'text'=>'Overall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.',
-                  'spans'=>[]
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => 'Overall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.',
+                  'spans' => []
                 }
               }
             ]
@@ -192,21 +263,20 @@ RSpec.describe Prismic::CmsConverter do
         let(:row) do
           {
             content: [
-						  {
-					    	'type'=>'list-item',
-					    	'content'=> {
-									'text' => "Relate to people's financial capability",
-									'spans'=>[]
-								}
-							},
-					    {
-								'type'=>'list-item',
-					     	'content'=>
-					      {
-									'text' => 'Make a positive contribution to evidence hub, given what is on there already',
-					      'spans' => []
-								}
-							},
+              {
+                'type' => 'list-item',
+                'content' => {
+                  'text' => "Relate to people's financial capability",
+                  'spans' => []
+                }
+              },
+              {
+                'type' => 'list-item',
+                'content' =>                       {
+                  'text' => 'Make a positive contribution to evidence hub, given what is on there already',
+                  'spans' => []
+                }
+              }
             ]
           }
         end
@@ -214,7 +284,7 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with unordered list tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-							content: "<ul><li>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</li></ul>"
+              content: "<ul><li>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</li></ul>"
             )
           )
         end
@@ -222,22 +292,22 @@ RSpec.describe Prismic::CmsConverter do
 
       context 'when attributes have list with bold' do
         let(:row) do
-					{
-						content: [
+          {
+            content: [
               {
-							  'type' => 'list-item',
-					  	  'content' => {
-							  	 'text' => 'Programme theory describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;',
-					  	    'spans' => [{'start' => 0, 'end' => 16, 'type' => 'strong'}]
-							  }
-              },
-					 		{
-							  'type' => 'list-item',
-					 		  'content' => {
-                  'text' => "Measured outcomes reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;",
-					 		   'spans' => [{'start'=>0, 'end'=>17, 'type'=>'strong'}]
+                'type' => 'list-item',
+                'content' => {
+                  'text' => 'Programme theory describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;',
+                  'spans' => [{ 'start' => 0, 'end' => 16, 'type' => 'strong' }]
                 }
-							}
+              },
+              {
+                'type' => 'list-item',
+                'content' => {
+                  'text' => 'Measured outcomes reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;',
+                  'spans' => [{ 'start' => 0, 'end' => 17, 'type' => 'strong' }]
+                }
+              }
             ]
           }
         end
@@ -245,11 +315,11 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with unordered list tag with bold' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<ul><li><strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li><strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>"
+              content: '<ul><li><strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li><strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>'
             )
           )
         end
-			end
+      end
 
       context 'when attributes has bold and emphasis on the same index' do
         let(:row) do
@@ -260,9 +330,9 @@ RSpec.describe Prismic::CmsConverter do
                 'content' => {
                   'text' => '12 million people in the UK are not saving enough for their retirement (DWP, 2014). ',
                   'spans' => [
-										{"start"=>0, "end"=>71, "type"=>"label", "data"=>"very-emphatic"},
-										{"start"=>71, "end"=>84, "type"=>"strong"},
-										{"start"=>71, "end"=>84, "type"=>"em"}
+                    { 'start' => 0, 'end' => 71, 'type' => 'label', 'data' => 'very-emphatic' },
+                    { 'start' => 71, 'end' => 84, 'type' => 'strong' },
+                    { 'start' => 71, 'end' => 84, 'type' => 'em' }
                   ]
                 }
               }
@@ -270,7 +340,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-				it 'converts to strong and emphasis' do
+        it 'converts to strong and emphasis' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
               content: '<p>12 million people in the UK are not saving enough for their retirement <strong><em>(DWP, 2014). </em></strong></p>'
@@ -283,32 +353,29 @@ RSpec.describe Prismic::CmsConverter do
         let(:row) do
           {
             content: [
-							{
-								'type'=>'paragraph',
-							  'content'=>
-							   {'text'=>
-							     "Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability",
-							    'spans'=>[]
-			          	}
+              {
+                'type' => 'paragraph',
+                'content' =>                         { 'text' =>                           'Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability',
+                                                       'spans' => []
+                  }
               },
-							{
-                'type'=>'list-item',
-							  'content'=> {
-                  'text'=>'Around four out of ten adults are not in control of their finances',
-							    'spans'=>[]
+              {
+                'type' => 'list-item',
+                'content' => {
+                  'text' => 'Around four out of ten adults are not in control of their finances',
+                  'spans' => []
                 }
               },
-							{
-                'type'=>'list-item',
-							  'content'=>{
-                  'text'=>'One in five cannot read a bank statement', 'spans'=>[]
+              {
+                'type' => 'list-item',
+                'content' => {
+                  'text' => 'One in five cannot read a bank statement', 'spans' => []
                 }
               },
-							{
-                'type'=>'paragraph',
-							  'content'=> {
-                  'text'=>
-							    'Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.',
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' =>                          'Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.',
                   'spans' => []
                 }
               }
@@ -319,7 +386,7 @@ RSpec.describe Prismic::CmsConverter do
         it 'convert paragraphs and unordered lists' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<p>Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability</p><ul><li>Around four out of ten adults are not in control of their finances</li><li>One in five cannot read a bank statement</li></ul><p>Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.</p>"
+              content: '<p>Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability</p><ul><li>Around four out of ten adults are not in control of their finances</li><li>One in five cannot read a bank statement</li></ul><p>Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.</p>'
             )
           )
         end
@@ -404,22 +471,22 @@ RSpec.describe Prismic::CmsConverter do
 
       context 'when attributes have multiple bold text' do
         let(:row) do
-					{
+          {
             content: [
               {
                 'type' => 'paragraph',
                 'content' => {
                   'text' => "* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. \n\nEnds \\\\\n\nNotes to editors\nFor more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk \n\nAbout Quaker Social Action\nQuaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.\n\nAbout the Fair Funerals campaign\nQuaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by:\n•\tEducating people about their choices so they can avoid funeral poverty\n•\tInfluencing government to do more for people in funeral poverty\n•\tWorking with the funeral industry to do moror people in funeral poverty\nVisit us here: http://fairfuneralscampaign.org.uk/",
                   'spans' => [
-	 									{"start"=>353, "end"=>360, "type"=>"strong"},
-   									{"start"=>361, "end"=>378, "type"=>"strong"},
-   									{"start"=>535, "end"=>561, "type"=>"strong"},
-   									{"start"=>1048, "end"=>1081, "type"=>"strong"}
+                    { 'start' => 353, 'end' => 360, 'type' => 'strong' },
+                    { 'start' => 361, 'end' => 378, 'type' => 'strong' },
+                    { 'start' => 535, 'end' => 561, 'type' => 'strong' },
+                    { 'start' => 1048, 'end' => 1081, 'type' => 'strong' }
                   ]
                 }
               }
             ]
-					}
+          }
         end
 
         it 'convert to strong tags' do
@@ -463,7 +530,7 @@ RSpec.describe Prismic::CmsConverter do
                 'type' => 'paragraph',
                 'content' => {
                   'text' => "Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries & Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\nTotal \t \t£192,000 ",
-                  'spans'=>[{'start'=>684, 'end'=>702, 'type'=>'strong'}]
+                  'spans' => [{ 'start' => 684, 'end' => 702, 'type' => 'strong' }]
                 }
               }
             ]

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Prismic::CmsConverter do
   describe '#convert' do
     subject(:convert) { cms_converter.convert }
 
-    context 'when attributes does not have content' do
+    context 'when attributes do not have content' do
       let(:row) do
         {
           type: 'article',
@@ -20,7 +20,7 @@ RSpec.describe Prismic::CmsConverter do
       end
     end
 
-    context 'when attributes does not have any types mapped by prismic' do
+    context 'when attributes do not have any types mapped by prismic' do
       let(:row) do
         {
           content: [
@@ -69,7 +69,7 @@ RSpec.describe Prismic::CmsConverter do
         end
       end
 
-      context 'when attributes have embed videos' do
+      context 'when attributes have embedded videos' do
         let(:row) do
           {
             content: [
@@ -379,8 +379,9 @@ RSpec.describe Prismic::CmsConverter do
             content: [
               {
                 'type' => 'paragraph',
-                'content' =>                         { 'text' =>                           'Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability',
-                                                       'spans' => []
+                'content' => {
+                  'text' =>'Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability',
+                   'spans' => []
                   }
               },
               {
@@ -455,7 +456,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-        it 'wrap text with paragraph tag and format with bold text' do
+        it 'wraps text with paragraph tag and format with bold text' do
           expect(convert).to eq(
             Prismic::ConvertedDocument.new(
               content: '<p><strong>Monday 25th September 2016</strong></p>',
@@ -487,7 +488,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-        it 'wrap text with paragraph html tags' do
+        it 'wraps text with paragraph html tags' do
           expect(convert).to eq(
             Prismic::ConvertedDocument.new(
               content: '<p>Audio clip available for use on radio.</p><p>The need to improve financial education.</p>',
@@ -517,7 +518,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-        it 'convert to strong tags' do
+        it 'converts to strong tags' do
           expect(convert).to eq(
             Prismic::ConvertedDocument.new(
               content: "<p>* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. \n\n<strong>Ends \\\\</strong>\n<strong>\nNotes to editors</strong>\nFor more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk \n\n<strong>About Quaker Social Action</strong>\nQuaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.\n<strong>\nAbout the Fair Funerals campaign</strong>\nQuaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by:\n•\tEducating people about their choices so they can avoid funeral poverty\n•\tInfluencing government to do more for people in funeral poverty\n•\tWorking with the funeral industry to do moror people in funeral poverty\nVisit us here: http://fairfuneralscampaign.org.uk/</p>",
@@ -542,7 +543,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-        it 'wrap text with heading one html tag' do
+        it 'wraps text with heading one html tag' do
           expect(convert).to eq(
             Prismic::ConvertedDocument.new(
               title: "<h1>The Money Charity's Financial Education Report</h1>",
@@ -552,7 +553,7 @@ RSpec.describe Prismic::CmsConverter do
         end
       end
 
-      context 'when attribute has lot of content' do
+      context 'when attribute has a lot of content' do
         let(:row) do
           {
             content: [
@@ -567,7 +568,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-        it 'transform into html' do
+        it 'transforms into html' do
           expect(convert).to eq(
             Prismic::ConvertedDocument.new(
               content: "<p>Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries & Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\n<strong>Total \t \t£192,000 </strong></p>",
@@ -592,7 +593,7 @@ RSpec.describe Prismic::CmsConverter do
           }
         end
 
-        it 'wrap text with heading one html tag' do
+        it 'wraps text with heading one html tag' do
           expect(convert).to eq(
             Prismic::ConvertedDocument.new(
               title: "<h5>The Money Charity's Financial Education Report</h5>",

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Prismic::CmsConverter do
 				it '' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p><strong>• To view the Money Advice Service Financial Capability Technical report*, please click </strong><a href="https://fincap-two.cdn.prismic.io/fincap-two%2F5bdea584-c07c-4173-95ab-af8e6dcdafe9_mas_fincap_technical_report.pdf" target="_blank">here</a>'
+              content: "<p><strong>•\tTo view the Money Advice Service Financial Capability UK Survey report, please click </strong><a href=\"https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf\"><strong>here</strong></a></p>"
             )
           )
         end

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Prismic::CmsConverter do
                   },
                   'width' => 2624,
                   'height' => 2624,
-                  'url' => 'https://prismic-io.s3.amazonaws.com/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png',
+                  'url' => 'https://fincap-two.cdn.prismic.io/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png',
                   'edit' => {
                     'background' => 'transparent',
                     'zoom' => 1.0,
@@ -138,6 +138,14 @@ RSpec.describe Prismic::CmsConverter do
               }
             ]
           }
+        end
+
+        it 'converts to image html tag' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<img src="https://fincap-two.cdn.prismic.io/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png" width="2624" height="2624" />'
+            )
+          )
         end
       end
 

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -37,6 +37,86 @@ RSpec.describe Prismic::CmsConverter do
     end
 
     context 'when attributes have content' do
+      context 'when attributes have emphasis text' do
+        let(:row) do
+          {
+            content: [
+              {
+                "type"=>"paragraph",
+                "content"=> {
+                  "text"=> "Caroline Rookes, Chief Executive of the Money Advice Service, said: “Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. ",
+                  "spans"=> [
+                    {
+                      "start"=>0,
+                      "end"=>67,
+                      "type"=>"strong"
+                    },
+                    {
+                      "start"=>68,
+                      "end"=>557,
+                      "type"=>"em"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+
+        it 'converts to emphasied html tag' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<p><strong>Caroline Rookes, Chief Executive of the Money Advice Service, said:</strong><em>“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. </em></p>'
+            )
+          )
+        end
+      end
+
+      context 'when attributes have ordered lists' do
+        let(:row) do
+          {
+            content: [
+ 							{
+              	'type'=>'paragraph',
+                'content'=>{
+                  'text'=>'The Strategy is built around two key concepts:',
+                  'spans'=>[{'start'=>0, 'end'=>46, 'type'=>'strong'}]
+                }
+              },
+ 							{
+                'type'=>'o-list-item',
+                'content'=> {
+                  'text'=>'Collective impact and cross-sector co-ordination rather than isolated interventions.',
+                  'spans'=>[]
+                }
+              },
+ 							{
+                'type'=>'o-list-item',
+ 							  'content'=> {
+                  'text'=> 'Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.',
+ 							   'spans'=>[]
+                }
+              },
+ 							{
+                'type'=>'paragraph',
+ 							 'content'=> {
+                  'text'=>'Overall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.',
+                  'spans'=>[]
+                }
+              }
+            ]
+          }
+        end
+
+        it 'wrap text with ordered list tag' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<p><strong>The Strategy is built around two key concepts:</strong></p><ol><li>Collective impact and cross-sector co-ordination rather than isolated interventions.</li><li>Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.</li></ol><p>Overall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.</p>'
+            )
+          )
+        end
+      end
+
       context 'when attributes have lists' do
         let(:row) do
           {

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Prismic::CmsConverter do
 
       it 'returns documents with same attributes' do
         expect(convert).to eq(
-          Prismic::CmsDocument.new(row)
+          Prismic::ConvertedDocument.new(row)
         )
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe Prismic::CmsConverter do
 
       it 'ignores attributes' do
         expect(convert).to eq(
-          Prismic::CmsDocument.new(content: '', content_markdown: '')
+          Prismic::ConvertedDocument.new(content: '', content_markdown: '')
         )
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'converts both tags' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: "<p><strong>Wednesday 11 January 2017\n\n</strong><em>With rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns</em></p>",
               content_markdown: " **Wednesday 11 January 2017** _With rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns_\n\n"
             )
@@ -102,7 +102,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'converts to html tags' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: "<iframe width=\'459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>",
               content_markdown: "<iframe width='459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen&gt;&lt;/iframe&gt;'></iframe>"
             )
@@ -145,7 +145,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'converts to image html tag' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<img src="https://fincap-two.cdn.prismic.io/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png" width="2624" height="2624" />',
               content_markdown: ' ![](https://fincap-two.cdn.prismic.io/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png)'
             )
@@ -190,7 +190,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'converts the links' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: "<p><strong>•\tTo view the Money Advice Service Financial Capability UK Survey report, please click </strong><a href=\"https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf\"><strong>here</strong></a></p>",
               content_markdown: " **• To view the Money Advice Service Financial Capability UK Survey report, please click** [**here**](https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf)\n\n"
             )
@@ -226,7 +226,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'converts to emphasied html tag' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<p><strong>Caroline Rookes, Chief Executive of the Money Advice Service, said:</strong> <em>“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. </em></p>',
               content_markdown: " **Caroline Rookes, Chief Executive of the Money Advice Service, said:** _“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. _\n\n"
             )
@@ -272,7 +272,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with ordered list tag' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<p><strong>The Strategy is built around two key concepts:</strong></p><ol><li>Collective impact and cross-sector co-ordination rather than isolated interventions.</li><li>Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.</li></ol><p>Overall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.</p>',
               content_markdown: " **The Strategy is built around two key concepts:**\n\n1. Collective impact and cross-sector co-ordination rather than isolated interventions.\n2. Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.\n\nOverall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.\n\n"
             )
@@ -304,7 +304,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with unordered list tag' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: "<ul><li>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</li></ul>",
               content_markdown: "- Relate to people's financial capability\n- Make a positive contribution to evidence hub, given what is on there already\n"
             )
@@ -336,7 +336,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with unordered list tag with bold' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<ul><li><strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li><strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>',
               content_markdown: "- **Programme theory** describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;\n- **Measured outcomes** reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;\n"
             )
@@ -365,7 +365,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'converts to strong and emphasis' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<p>12 million people in the UK are not saving enough for their retirement <strong><em>(DWP, 2014). </em></strong></p>',
               content_markdown: "12 million people in the UK are not saving enough for their retirement **_(DWP, 2014). _**\n\n"
             )
@@ -409,7 +409,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'convert paragraphs and unordered lists' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<p>Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability</p><ul><li>Around four out of ten adults are not in control of their finances</li><li>One in five cannot read a bank statement</li></ul><p>Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.</p>',
               content_markdown: "Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability\n\n- Around four out of ten adults are not in control of their finances\n- One in five cannot read a bank statement\n\nLeading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.\n\n"
             )
@@ -432,7 +432,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with paragraph html tag' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<p>Audio clip available for use on radio.</p>',
               content_markdown: "Audio clip available for use on radio.\n\n"
             )
@@ -457,7 +457,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with paragraph tag and format with bold text' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<p><strong>Monday 25th September 2016</strong></p>',
               content_markdown: " **Monday 25th September 2016**\n\n"
             )
@@ -489,7 +489,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with paragraph html tags' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: '<p>Audio clip available for use on radio.</p><p>The need to improve financial education.</p>',
               content_markdown: "Audio clip available for use on radio.\n\nThe need to improve financial education.\n\n"
             )
@@ -519,7 +519,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'convert to strong tags' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: "<p>* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. \n\n<strong>Ends \\\\</strong>\n<strong>\nNotes to editors</strong>\nFor more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk \n\n<strong>About Quaker Social Action</strong>\nQuaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.\n<strong>\nAbout the Fair Funerals campaign</strong>\nQuaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by:\n•\tEducating people about their choices so they can avoid funeral poverty\n•\tInfluencing government to do more for people in funeral poverty\n•\tWorking with the funeral industry to do moror people in funeral poverty\nVisit us here: http://fairfuneralscampaign.org.uk/</p>",
               content_markdown: "\\* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. **Ends \\\\**** Notes to editors **For more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk** About Quaker Social Action **Quaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.** About the Fair Funerals campaign**Quaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by: • Educating people about their choices so they can avoid funeral poverty • Influencing government to do more for people in funeral poverty • Working with the funeral industry to do moror people in funeral poverty Visit us here: http://fairfuneralscampaign.org.uk/\n\n"
             )
@@ -544,7 +544,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with heading one html tag' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               title: "<h1>The Money Charity's Financial Education Report</h1>",
               title_markdown: "# The Money Charity's Financial Education Report\n"
             )
@@ -569,7 +569,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'transform into html' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               content: "<p>Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries & Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\n<strong>Total \t \t£192,000 </strong></p>",
               content_markdown: "Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ The projects receiving funding are: East Renfrewshire Credit Union East Renfrewshire £20,000 Blackburn, Seafield and District Credit Union West Lothian £20,000 Sovereign Credit Union Ayrshire, Arran, Dumfries & Galloway £20,000 Stirling Credit Union Stirling £20,000 West Lothian Credit Union West Lothian £20,000 Falkirk District Credit Union Falkirk £20,000 Yoker Credit Union Glasgow £20,000 Solway Credit Union Dumfries and Galloway £12,000 North East Credit Union Aberdeen £20,000 BCD Credit Union Glasgow £20,000 **Total £192,000**\n\n"
             )
@@ -594,7 +594,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'wrap text with heading one html tag' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(
+            Prismic::ConvertedDocument.new(
               title: "<h5>The Money Charity's Financial Education Report</h5>",
               title_markdown: "##### The Money Charity's Financial Education Report\n"
             )

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -37,6 +37,77 @@ RSpec.describe Prismic::CmsConverter do
     end
 
     context 'when attributes have content' do
+      context 'when attributes have tags following other tags' do
+        let(:row) do
+          {
+            content: [
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => "Wednesday 11 January 2017\n\nWith rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns",
+                  'spans' => [
+                    {
+                      "start"=>0, "end"=>27, "type"=>"strong"
+                    },
+                    {
+                      "start"=>27, "end"=>155, "type"=>"em"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+
+        it 'converts both tags' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: "<p><strong>Wednesday 11 January 2017\n\n</strong><em>With rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns</em></p>"
+            )
+          )
+        end
+      end
+
+      context 'when attributes have links' do
+        let(:row) do
+          {
+            content: [
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => "•\tTo view the Money Advice Service Financial Capability UK Survey report, please click here",
+                  'spans' => [
+										{'start'=>0, 'end'=>87, 'type'=>'strong'},
+                    {'start'=>87,
+                     'end'=>91,
+                     'type'=>'hyperlink',
+                     'data'=>
+                      {'wioUrl'=>'wio://medias/WFEJPioAAL4bnH2x',
+                       'url'=>
+                        'https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf',
+                       'kind'=>'document',
+                       'id'=>'WFEJPioAAL4bnH2x',
+                       'size'=>'2902326',
+                       'date'=>'12/14/16 08:53',
+                       'name'=>'MAS_FinCap_UK_Survey_2015_AW.PDF',
+                       'preview'=>{'title'=>'MAS_FinCap_UK_Survey_2015_AW.PDF', 'image'=>nil}}},
+                    {'start'=>87, 'end'=>91, 'type'=>'strong'}
+                  ]
+                }
+              }
+            ]
+          }
+        end
+
+				it '' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<p><strong>• To view the Money Advice Service Financial Capability Technical report*, please click </strong><a href="https://fincap-two.cdn.prismic.io/fincap-two%2F5bdea584-c07c-4173-95ab-af8e6dcdafe9_mas_fincap_technical_report.pdf" target="_blank">here</a>'
+            )
+          )
+        end
+      end
+
       context 'when attributes have emphasis text' do
         let(:row) do
           {
@@ -66,7 +137,7 @@ RSpec.describe Prismic::CmsConverter do
         it 'converts to emphasied html tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p><strong>Caroline Rookes, Chief Executive of the Money Advice Service, said:</strong><em>“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. </em></p>'
+              content: '<p><strong>Caroline Rookes, Chief Executive of the Money Advice Service, said:</strong> <em>“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. </em></p>'
             )
           )
         end
@@ -174,11 +245,39 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with unordered list tag with bold' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<ul><li>\n<strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li>\n<strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>"
+              content: "<ul><li><strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li><strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>"
             )
           )
         end
 			end
+
+      context 'when attributes has bold and emphasis on the same index' do
+        let(:row) do
+          {
+            content: [
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => '12 million people in the UK are not saving enough for their retirement (DWP, 2014). ',
+                  'spans' => [
+										{"start"=>0, "end"=>71, "type"=>"label", "data"=>"very-emphatic"},
+										{"start"=>71, "end"=>84, "type"=>"strong"},
+										{"start"=>71, "end"=>84, "type"=>"em"}
+                  ]
+                }
+              }
+            ]
+          }
+        end
+
+				it 'converts to strong and emphasis' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: '<p>12 million people in the UK are not saving enough for their retirement <strong><em>(DWP, 2014). </em></strong></p>'
+            )
+          )
+        end
+      end
 
       context 'when attribute has paragraphs and lists' do
         let(:row) do
@@ -303,6 +402,35 @@ RSpec.describe Prismic::CmsConverter do
         end
       end
 
+      context 'when attributes have multiple bold text' do
+        let(:row) do
+					{
+            content: [
+              {
+                'type' => 'paragraph',
+                'content' => {
+                  'text' => "* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. \n\nEnds \\\\\n\nNotes to editors\nFor more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk \n\nAbout Quaker Social Action\nQuaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.\n\nAbout the Fair Funerals campaign\nQuaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by:\n•\tEducating people about their choices so they can avoid funeral poverty\n•\tInfluencing government to do more for people in funeral poverty\n•\tWorking with the funeral industry to do moror people in funeral poverty\nVisit us here: http://fairfuneralscampaign.org.uk/",
+                  'spans' => [
+	 									{"start"=>353, "end"=>360, "type"=>"strong"},
+   									{"start"=>361, "end"=>378, "type"=>"strong"},
+   									{"start"=>535, "end"=>561, "type"=>"strong"},
+   									{"start"=>1048, "end"=>1081, "type"=>"strong"}
+                  ]
+                }
+              }
+            ]
+					}
+        end
+
+        it 'convert to strong tags' do
+          expect(convert).to eq(
+            Prismic::CmsDocument.new(
+              content: "<p>* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. \n\n<strong>Ends \\\\</strong>\n<strong>\nNotes to editors</strong>\nFor more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk \n\n<strong>About Quaker Social Action</strong>\nQuaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.\n<strong>\nAbout the Fair Funerals campaign</strong>\nQuaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by:\n•\tEducating people about their choices so they can avoid funeral poverty\n•\tInfluencing government to do more for people in funeral poverty\n•\tWorking with the funeral industry to do moror people in funeral poverty\nVisit us here: http://fairfuneralscampaign.org.uk/</p>"
+            )
+          )
+        end
+      end
+
       context 'when attribute has heading one' do
         let(:row) do
           {
@@ -344,7 +472,7 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'transform into html' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(content: "<p>Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries &amp; Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\n<strong>Total \t \t£192,000 </strong></p>")
+            Prismic::CmsDocument.new(content: "<p>Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries & Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\n<strong>Total \t \t£192,000 </strong></p>")
           )
         end
       end

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with unordered list tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-							content: "<ul>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</ul>"
+							content: "<ul><li>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</li></ul>"
             )
           )
         end

--- a/spec/lib/prismic/cms_converter_spec.rb
+++ b/spec/lib/prismic/cms_converter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Prismic::CmsConverter do
 
       it 'ignores attributes' do
         expect(convert).to eq(
-          Prismic::CmsDocument.new(content: '')
+          Prismic::CmsDocument.new(content: '', content_markdown: '')
         )
       end
     end
@@ -62,7 +62,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'converts both tags' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<p><strong>Wednesday 11 January 2017\n\n</strong><em>With rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns</em></p>"
+              content: "<p><strong>Wednesday 11 January 2017\n\n</strong><em>With rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns</em></p>",
+              content_markdown: " **Wednesday 11 January 2017** _With rising inflation likely to lead to pay squeezes, firms need to do more to help their employees cope with financial concerns_\n\n"
             )
           )
         end
@@ -75,21 +76,22 @@ RSpec.describe Prismic::CmsConverter do
               {
                 'content' => { 'spans' => [], 'text' => '' },
                 'type' => 'embed',
-                'data' =>                  { 'height' => 344,
-                                             'width' => 459,
-                                             'embed_url' => 'https://www.youtube.com/watch?v=ThmnAhEJ1Lk',
-                                             'type' => 'video',
-                                             'version' => '1.0',
-                                             'title' => 'What Works Funding - Webinar',
-                                             'author_name' => 'MoneyAdviceService',
-                                             'author_url' => 'https://www.youtube.com/user/MoneyAdviceService',
-                                             'provider_name' => 'YouTube',
-                                             'provider_url' => 'https://www.youtube.com/',
-                                             'cache_age' => nil,
-                                             'thumbnail_url' => 'https://i.ytimg.com/vi/ThmnAhEJ1Lk/hqdefault.jpg',
-                                             'thumbnail_width' => 480,
-                                             'thumbnail_height' => 360,
-                                             'html' =>                     "<iframe width=\'459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>"
+                'data' =>                  {
+                  'height' => 344,
+                  'width' => 459,
+                  'embed_url' => 'https://www.youtube.com/watch?v=ThmnAhEJ1Lk',
+                  'type' => 'video',
+                  'version' => '1.0',
+                  'title' => 'What Works Funding - Webinar',
+                  'author_name' => 'MoneyAdviceService',
+                  'author_url' => 'https://www.youtube.com/user/MoneyAdviceService',
+                  'provider_name' => 'YouTube',
+                  'provider_url' => 'https://www.youtube.com/',
+                  'cache_age' => nil,
+                  'thumbnail_url' => 'https://i.ytimg.com/vi/ThmnAhEJ1Lk/hqdefault.jpg',
+                  'thumbnail_width' => 480,
+                  'thumbnail_height' => 360,
+                  'html' => "<iframe width=\'459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>"
                 },
                 'label' => nil,
                 'direction' => nil
@@ -101,7 +103,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'converts to html tags' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<iframe width=\'459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>"
+              content: "<iframe width=\'459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>",
+              content_markdown: "<iframe width='459\" height=\"344\" src=\"https://www.youtube.com/embed/ThmnAhEJ1Lk?feature=oembed\" frameborder=\"0\" allowfullscreen&gt;&lt;/iframe&gt;'></iframe>"
             )
           )
         end
@@ -143,7 +146,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'converts to image html tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<img src="https://fincap-two.cdn.prismic.io/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png" width="2624" height="2624" />'
+              content: '<img src="https://fincap-two.cdn.prismic.io/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png" width="2624" height="2624" />',
+              content_markdown: ' ![](https://fincap-two.cdn.prismic.io/fincap-two/981f9fff7abfca68edf52ba7915e1d90cb70dc27_the-pensions-dashboard.png)'
             )
           )
         end
@@ -162,14 +166,20 @@ RSpec.describe Prismic::CmsConverter do
                     { 'start' => 87,
                       'end' => 91,
                       'type' => 'hyperlink',
-                      'data' =>                       { 'wioUrl' => 'wio://medias/WFEJPioAAL4bnH2x',
-                                                        'url' =>                         'https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf',
-                                                        'kind' => 'document',
-                                                        'id' => 'WFEJPioAAL4bnH2x',
-                                                        'size' => '2902326',
-                                                        'date' => '12/14/16 08:53',
-                                                        'name' => 'MAS_FinCap_UK_Survey_2015_AW.PDF',
-                                                        'preview' => { 'title' => 'MAS_FinCap_UK_Survey_2015_AW.PDF', 'image' => nil } } },
+                      'data' => {
+                        'wioUrl' => 'wio://medias/WFEJPioAAL4bnH2x',
+                        'url' => 'https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf',
+                        'kind' => 'document',
+                        'id' => 'WFEJPioAAL4bnH2x',
+                        'size' => '2902326',
+                        'date' => '12/14/16 08:53',
+                        'name' => 'MAS_FinCap_UK_Survey_2015_AW.PDF',
+                        'preview' => {
+                          'title' => 'MAS_FinCap_UK_Survey_2015_AW.PDF',
+                          'image' => nil
+                        }
+                      }
+                    },
                     { 'start' => 87, 'end' => 91, 'type' => 'strong' }
                   ]
                 }
@@ -181,7 +191,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'converts the links' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<p><strong>•\tTo view the Money Advice Service Financial Capability UK Survey report, please click </strong><a href=\"https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf\"><strong>here</strong></a></p>"
+              content: "<p><strong>•\tTo view the Money Advice Service Financial Capability UK Survey report, please click </strong><a href=\"https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf\"><strong>here</strong></a></p>",
+              content_markdown: " **• To view the Money Advice Service Financial Capability UK Survey report, please click** [**here**](https://prismic-io.s3.amazonaws.com/fincap-two%2Fd08746d1-e667-4c9e-84ad-8539ce5c62e0_mas_fincap_uk_survey_2015_aw.pdf)\n\n"
             )
           )
         end
@@ -216,7 +227,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'converts to emphasied html tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p><strong>Caroline Rookes, Chief Executive of the Money Advice Service, said:</strong> <em>“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. </em></p>'
+              content: '<p><strong>Caroline Rookes, Chief Executive of the Money Advice Service, said:</strong> <em>“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. </em></p>',
+              content_markdown: " **Caroline Rookes, Chief Executive of the Money Advice Service, said:** _“Pension provision has changed significantly over recent years and it is more important than ever that individuals make good decisions so their money lasts for the full length of their retirement. We know that online banking has empowered people to engage with their money more regularly. We hope that being able to keep track of their pension savings in a single digital place will ensure that people are fully informed and can make decisions about their future savings in a similar way. _\n\n"
             )
           )
         end
@@ -261,7 +273,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with ordered list tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p><strong>The Strategy is built around two key concepts:</strong></p><ol><li>Collective impact and cross-sector co-ordination rather than isolated interventions.</li><li>Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.</li></ol><p>Overall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.</p>'
+              content: '<p><strong>The Strategy is built around two key concepts:</strong></p><ol><li>Collective impact and cross-sector co-ordination rather than isolated interventions.</li><li>Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.</li></ol><p>Overall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.</p>',
+              content_markdown: " **The Strategy is built around two key concepts:**\n\n1. Collective impact and cross-sector co-ordination rather than isolated interventions.\n2. Testing and learning to determine what works in order to deliver evidence-based interventions: resources will be steered towards activities on the basis of what is proven to work.\n\nOverall progress will be monitored by a Financial Capability Survey and ongoing evaluation of specific interventions.\n\n"
             )
           )
         end
@@ -292,7 +305,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with unordered list tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<ul><li>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</li></ul>"
+              content: "<ul><li>Relate to people's financial capability</li><li>Make a positive contribution to evidence hub, given what is on there already</li></ul>",
+              content_markdown: "- Relate to people's financial capability\n- Make a positive contribution to evidence hub, given what is on there already\n"
             )
           )
         end
@@ -323,7 +337,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with unordered list tag with bold' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<ul><li><strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li><strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>'
+              content: '<ul><li><strong>Programme theory</strong> describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;</li><li><strong>Measured outcomes</strong> reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;</li></ul>',
+              content_markdown: "- **Programme theory** describes how a programme is intended to work and provides some rationale for the design with reference to existing evidence. It describes the intended sequence from activities through to longer term outcomes, acknowledging any important assumptions along the way. This could include a logic model or theory of change diagram;\n- **Measured outcomes** reports evidence of changes that occurred over the course of a programme with reference to the programme’s intended effects. It demonstrates efforts to minimize biasand to accurately represent the experiences of programme participants;\n"
             )
           )
         end
@@ -351,7 +366,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'converts to strong and emphasis' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p>12 million people in the UK are not saving enough for their retirement <strong><em>(DWP, 2014). </em></strong></p>'
+              content: '<p>12 million people in the UK are not saving enough for their retirement <strong><em>(DWP, 2014). </em></strong></p>',
+              content_markdown: "12 million people in the UK are not saving enough for their retirement **_(DWP, 2014). _**\n\n"
             )
           )
         end
@@ -394,7 +410,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'convert paragraphs and unordered lists' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p>Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability</p><ul><li>Around four out of ten adults are not in control of their finances</li><li>One in five cannot read a bank statement</li></ul><p>Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.</p>'
+              content: '<p>Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability</p><ul><li>Around four out of ten adults are not in control of their finances</li><li>One in five cannot read a bank statement</li></ul><p>Leading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.</p>',
+              content_markdown: "Four out of 10 adults are not in control of their finances – new strategy launched to improve UK’s financial capability\n\n- Around four out of ten adults are not in control of their finances\n- One in five cannot read a bank statement\n\nLeading figures from across the financial services industry, government, third sector organisations and charities have come together to launch a major initiative to address the stubbornly low levels of financial capability in the UK.\n\n"
             )
           )
         end
@@ -416,7 +433,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with paragraph html tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p>Audio clip available for use on radio.</p>'
+              content: '<p>Audio clip available for use on radio.</p>',
+              content_markdown: "Audio clip available for use on radio.\n\n"
             )
           )
         end
@@ -440,7 +458,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with paragraph tag and format with bold text' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p><strong>Monday 25th September 2016</strong></p>'
+              content: '<p><strong>Monday 25th September 2016</strong></p>',
+              content_markdown: " **Monday 25th September 2016**\n\n"
             )
           )
         end
@@ -471,7 +490,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with paragraph html tags' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: '<p>Audio clip available for use on radio.</p><p>The need to improve financial education.</p>'
+              content: '<p>Audio clip available for use on radio.</p><p>The need to improve financial education.</p>',
+              content_markdown: "Audio clip available for use on radio.\n\nThe need to improve financial education.\n\n"
             )
           )
         end
@@ -500,7 +520,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'convert to strong tags' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              content: "<p>* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. \n\n<strong>Ends \\\\</strong>\n<strong>\nNotes to editors</strong>\nFor more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk \n\n<strong>About Quaker Social Action</strong>\nQuaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.\n<strong>\nAbout the Fair Funerals campaign</strong>\nQuaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by:\n•\tEducating people about their choices so they can avoid funeral poverty\n•\tInfluencing government to do more for people in funeral poverty\n•\tWorking with the funeral industry to do moror people in funeral poverty\nVisit us here: http://fairfuneralscampaign.org.uk/</p>"
+              content: "<p>* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. \n\n<strong>Ends \\\\</strong>\n<strong>\nNotes to editors</strong>\nFor more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk \n\n<strong>About Quaker Social Action</strong>\nQuaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.\n<strong>\nAbout the Fair Funerals campaign</strong>\nQuaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by:\n•\tEducating people about their choices so they can avoid funeral poverty\n•\tInfluencing government to do more for people in funeral poverty\n•\tWorking with the funeral industry to do moror people in funeral poverty\nVisit us here: http://fairfuneralscampaign.org.uk/</p>",
+              content_markdown: "\\* Fair Funerals looked at 100 independent companies and 100 branches of Co-op Funeralcare and Dignity Funerals (the two largest UK funeral providers) in mystery shopping which checked for affordability and transparency. At the time of conducting the mystery shopping, neither Dignity not Co-op Funeralcare had online prices for any of their branches. **Ends \\\\**** Notes to editors **For more information and to arrange interviews with case studies and the Fair Funerals team, please call 020 8983 5059 or email heatherkennedy@qsa.org.uk** About Quaker Social Action **Quaker Social Action exists to resource, enable and equip people living on a low income in east London. Our projects work towards our vision of 'a just world where people put people first', recognising the people we work with as agents of change not objects of charity. We work to tackle social exclusion, seeing poverty as not just material but also social. Our work is practical, relating to the everyday needs of the people we work with to make a tangible difference to their lives.** About the Fair Funerals campaign**Quaker Social Action launched the Fair Funerals campaign in 2014 to tackle the underlying causes of funeral poverty. It does this by: • Educating people about their choices so they can avoid funeral poverty • Influencing government to do more for people in funeral poverty • Working with the funeral industry to do moror people in funeral poverty Visit us here: http://fairfuneralscampaign.org.uk/\n\n"
             )
           )
         end
@@ -524,7 +545,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with heading one html tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              title: "<h1>The Money Charity's Financial Education Report</h1>"
+              title: "<h1>The Money Charity's Financial Education Report</h1>",
+              title_markdown: "# The Money Charity's Financial Education Report\n"
             )
          )
         end
@@ -547,7 +569,10 @@ RSpec.describe Prismic::CmsConverter do
 
         it 'transform into html' do
           expect(convert).to eq(
-            Prismic::CmsDocument.new(content: "<p>Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries & Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\n<strong>Total \t \t£192,000 </strong></p>")
+            Prismic::CmsDocument.new(
+              content: "<p>Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ \n\nThe projects receiving funding are:\nEast Renfrewshire Credit Union\t\nEast Renfrewshire\t\n£20,000\n\nBlackburn, Seafield and District Credit Union\t\nWest Lothian\t\n£20,000\n\nSovereign Credit Union\t\nAyrshire, Arran, Dumfries & Galloway\t\n£20,000\n\nStirling Credit Union\t\nStirling\t\n£20,000\n\nWest Lothian Credit Union\t\nWest Lothian\t\n£20,000\n\nFalkirk District Credit Union\t\nFalkirk\t\n£20,000\n\nYoker Credit Union\t\nGlasgow\t\n£20,000\n\nSolway Credit Union\t\nDumfries and Galloway\t\n£12,000\n\nNorth East Credit Union\t\nAberdeen\t\n£20,000\n\nBCD Credit Union\t\nGlasgow\t\n£20,000\n\n<strong>Total \t \t£192,000 </strong></p>",
+              content_markdown: "Photographs from the West Lothian Credit Union visit are available to download at: https://www.flickr.com/photos/scottishgovernment/ The projects receiving funding are: East Renfrewshire Credit Union East Renfrewshire £20,000 Blackburn, Seafield and District Credit Union West Lothian £20,000 Sovereign Credit Union Ayrshire, Arran, Dumfries & Galloway £20,000 Stirling Credit Union Stirling £20,000 West Lothian Credit Union West Lothian £20,000 Falkirk District Credit Union Falkirk £20,000 Yoker Credit Union Glasgow £20,000 Solway Credit Union Dumfries and Galloway £12,000 North East Credit Union Aberdeen £20,000 BCD Credit Union Glasgow £20,000 **Total £192,000**\n\n"
+            )
           )
         end
       end
@@ -570,7 +595,8 @@ RSpec.describe Prismic::CmsConverter do
         it 'wrap text with heading one html tag' do
           expect(convert).to eq(
             Prismic::CmsDocument.new(
-              title: "<h5>The Money Charity's Financial Education Report</h5>"
+              title: "<h5>The Money Charity's Financial Education Report</h5>",
+              title_markdown: "##### The Money Charity's Financial Education Report\n"
             )
           )
         end

--- a/spec/lib/prismic/converted_document_spec.rb
+++ b/spec/lib/prismic/converted_document_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Prismic::ConvertedDocument do
+  subject(:converted_document) do
+    described_class.new(attributes)
+  end
+
+  describe '#formatted_title' do
+    let(:attributes) do
+      { title: '<h1>Some title</h1>' }
+    end
+
+    it 'strip tags' do
+      expect(converted_document.formatted_title).to eq('Some title')
+    end
+  end
+
+  describe '#filename' do
+    context 'when title is present' do
+      let(:attributes) do
+        { title: '<h1>Some title</h1>' }
+      end
+
+      it 'returns title paramterized' do
+        expect(converted_document.filename).to eq('some-title')
+      end
+    end
+
+    context 'when document does not have title' do
+      let(:attributes) { {} }
+
+      it 'returns empty string' do
+        expect(converted_document.filename).to eq('')
+      end
+    end
+  end
+end

--- a/spec/lib/prismic/converted_document_spec.rb
+++ b/spec/lib/prismic/converted_document_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Prismic::ConvertedDocument do
       { title: '<h1>Some title</h1>' }
     end
 
-    it 'strip tags' do
+    it 'strips tags' do
       expect(converted_document.formatted_title).to eq('Some title')
     end
   end

--- a/spec/lib/prismic/document_spec.rb
+++ b/spec/lib/prismic/document_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Prismic::Document do
+  subject(:document) do
+    described_class.new(
+      title: 'title',
+      content: 'some content'
+    )
+  end
+
+  describe '#row' do
+    it 'returns data from args' do
+      expect(document.row).to eq(
+        title: 'title',
+        content: 'some content'
+      )
+    end
+  end
+
+  describe '#attributes' do
+    subject(:attributes) do
+      document.attributes
+    end
+
+    it 'returns attribute names from args' do
+      expect(attributes).to match_array([:title, :content])
+    end
+  end
+end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/8847-convert-prismic-json-data-into-markdown)

## Context

So this PR address the **ground work** to migrate all Prismic documents into CMS.

The basic strategy for the implementation:

1) Convert Prismic format into **html** and **markdown**
2) Migrate over to the CMS database (using html and markdown version)

Note: There are some aspects of the code which should be better but since this code will be used only once, I decided to keep as is and skip some refactor steps.

## Future work on other cards to migrate other page types

To create the migration for each page type on prismic you need to:

1) Create a class under Prismic::Migrator namespace with the same class name as the type name of prismic.
2) Implement #layout_identifier which is the same layout identifier on the database to link the page with the layout row on DB.
3) Implement #blocks which will be the blocks created for the page.

Off course, there are more details to consider when implementing the steps above:

1) The migrator has a [Base class](https://github.com/moneyadviceservice/cms/pull/464/files#diff-4ab85a461bfc626d09b24dd79e903a30R3) that already assumes a lot of responsibilites and the only thing that you need to implement for the other page types is **the blocks definition and the layout identifier on CMS**.
2) Each document from Prismic has different attributes. E.g Insight has "description of the programme" while Evaluation has "Points to consider". But the good news is that they are all converted into markdown and html. So on the migrator you can choose the fields that you need.

Example:

```ruby
module Prismic
  module Migrator
    class Article < Base
      def layout_identifier
        'article'
      end

      def blocks
        [
          Comfy::Cms::Block.new(
            identifier: 'content',
            content: document.content_markdown,
            processed_content: document.content
          )
        ]
      end
    end
  end
end
```

Note the "document" instance variable of the migrators will have all attributes converted into html and markdown (you can see that I used the "content" attribute from prismic above in html and markdown).

Done! When you run the migration via he rake task (see how to run below), the articles from prismic will be migrated to the CMS database.

## Commits

I think the commits reflects the thinking process and the right history to search any part of the code with the commit message.

## Running the migration script

In order to run the script to migrate from prismic into cms DB is:

`rake db:drop db:create db:schema:load db:seed:fincap prismic:migrate[~/Downloads/fincap]`

Notes of the script: 

1) the argument "~/Downloads/fincap" is the all prismic files directory which you can export in [http://prismic.io/](http://prismic.io/) - the credentials are on password manager
2) The migration script prints the errors to expose what went wrong. You will see some errors for the page types that we are not migrating at the moment.

## Needs to finish

- [x] Convert paragraph tags

- [x] Convert heading tags

- [x] Convert bold tags

- [x] Convert emphasis tags

- [x] Convert link tags

- [x] Convert embed tags

- [x] Convert image tags

- [x] Having attributes with markdown also

- [x] Create the strategy to for each page type you chose the fields to migrate to the database