### PR TITLE
Amend page layout identifiers

### DIFF
--- a/features/step_definitions/fincap_background_steps.rb
+++ b/features/step_definitions/fincap_background_steps.rb
@@ -79,7 +79,7 @@ end
 
 Given(/^I have an thematic reviews landing page layout setup with components$/) do
   cms_site.layouts.find_or_create_by(
-    identifier: 'thematic-reviews-landing-page',
+    identifier: 'thematic_reviews_landing_page',
     label: 'Thematic Reviews Landing Page',
     content:  <<-CONTENT
       {{ cms:page:content:rich_text }}

--- a/lib/tasks/fincap.rake
+++ b/lib/tasks/fincap.rake
@@ -84,7 +84,7 @@ namespace :fincap do
     )
 
     english_site.layouts.find_or_create_by(
-      identifier: 'thematic-review',
+      identifier: 'thematic_review',
       label: 'Thematic Review',
       content:  <<-CONTENT
         {{ cms:page:content:rich_text }}
@@ -98,7 +98,7 @@ namespace :fincap do
     )
 
     english_site.layouts.find_or_create_by(
-      identifier: 'thematic-reviews-landing-page',
+      identifier: 'thematic_reviews_landing_page',
       label: 'Thematic Reviews Landing Page',
       content:  <<-CONTENT
         {{ cms:page:content:rich_text }}


### PR DESCRIPTION
This pr addresses an issue on whereby thematic reviews and the thematic review landing page is not being shown. 

### Problem
The cms is returning a '404 not found' error for these pages because they were set up using hyphens for their page layout identifier. Therefore the cms is looking for documents by page type equal to `thematic-review` and should be looking for `thematic_review`.

### Solution
Amend the page layout identifier to use underscores instead of hyphens.