### PR TITLE
[DEV APPROVED] Fix for  teaser_section_title not displaying on Fincap

### DIFF
--- a/db/seeds/fincap_data/homepage_seeds.rb
+++ b/db/seeds/fincap_data/homepage_seeds.rb
@@ -14,7 +14,7 @@ homepage_layout = english_site.layouts.find_or_create_by(
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
     {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+    {{ cms:page:teaser_section_title }}
     {{ cms:page:teaser1_title }}
     {{ cms:page:teaser1_image }}
     {{ cms:page:teaser1_text }}
@@ -37,7 +37,7 @@ homepage_layout = english_site.layouts.find_or_create_by(
 
 homepage_page = english_site.pages.create!(
   label: 'Financial Capability',
-  slug: 'homepage',
+  slug: 'root',
   layout: homepage_layout,
 
   state: 'published',

--- a/db/seeds/fincap_data/lifestage.seeds.rb
+++ b/db/seeds/fincap_data/lifestage.seeds.rb
@@ -14,7 +14,7 @@ lifestage_layout = english_site.layouts.find_or_create_by(
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
     {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+    {{ cms:page:teaser_section_title }}
     {{ cms:page:teaser1_title }}
     {{ cms:page:teaser1_image }}
     {{ cms:page:teaser1_text }}

--- a/db/seeds/fincap_data/regional_strategy_seeds.rb
+++ b/db/seeds/fincap_data/regional_strategy_seeds.rb
@@ -14,7 +14,7 @@ regional_strategy_layout = english_site.layouts.find_or_create_by(
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
     {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+    {{ cms:page:teaser_section_title }}
     {{ cms:page:teaser1_title }}
     {{ cms:page:teaser1_image }}
     {{ cms:page:teaser1_text }}

--- a/features/step_definitions/fincap_background_steps.rb
+++ b/features/step_definitions/fincap_background_steps.rb
@@ -95,7 +95,7 @@ Given(/^I have a lifestage page layout setup with components$/) do
       {{ cms:page:content:rich_text }}
       {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
       {{ cms:page:hero_description:simple_component/Description }}
-      {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+      {{ cms:page:teaser_section_title }}
       {{ cms:page:teaser1_title }}
       {{ cms:page:teaser1_image }}
       {{ cms:page:teaser1_text }}
@@ -153,7 +153,7 @@ Given(/^I have a regional strategy page layout setup with components$/) do
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
     {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+    {{ cms:page:teaser_section_title }}
     {{ cms:page:teaser1_title }}
     {{ cms:page:teaser1_image }}
     {{ cms:page:teaser1_text }}
@@ -184,7 +184,7 @@ Given(/^I have a homepage page layout setup with components$/) do
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
     {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+    {{ cms:page:teaser_section_title }}
     {{ cms:page:teaser1_title }}
     {{ cms:page:teaser1_image }}
     {{ cms:page:teaser1_text }}

--- a/lib/tasks/fincap.rake
+++ b/lib/tasks/fincap.rake
@@ -114,7 +114,7 @@ namespace :fincap do
         {{ cms:page:content:rich_text }}
         {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
         {{ cms:page:hero_description:simple_component/Description }}
-        {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+        {{ cms:page:teaser_section_title }}
         {{ cms:page:teaser1_title }}
         {{ cms:page:teaser1_image }}
         {{ cms:page:teaser1_text }}
@@ -166,7 +166,7 @@ namespace :fincap do
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
     {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+    {{ cms:page:teaser_section_title }}
     {{ cms:page:teaser1_title }}
     {{ cms:page:teaser1_image }}
     {{ cms:page:teaser1_text }}
@@ -195,7 +195,7 @@ namespace :fincap do
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
     {{ cms:page:hero_description:simple_component/Description }}
-    {{ cms:page:teaser_section_title:simple_component/Financial capability in action }}
+    {{ cms:page:teaser_section_title }}
     {{ cms:page:teaser1_title }}
     {{ cms:page:teaser1_image }}
     {{ cms:page:teaser1_text }}


### PR DESCRIPTION
The title for the teaser section with the 3 teaser boxes is not displaying. 

### TECHNICAL
There are 2 solutions to fixing the issue of the teaser_section_title
not displaying:

1. change the field to be a simple text field and not a component
2. update the identifier that the article_template is looking for in fincap

I chose the first approach because it made more sense that this field be a simple text field since the content will only ever be a few words of text.
