### PR TITLE
[DEV APPROVED] - Make redirect works for MAS and FINCAP app

### DIFF
--- a/config/initializers/domain.rb
+++ b/config/initializers/domain.rb
@@ -28,7 +28,8 @@ module Domain
                     :dev_db_name,
                     :prod_db_url,
                     :public_website_domain,
-                    :public_website_url
+                    :public_website_url,
+                    :redirect_domain
 
       def initialize
         @algolia_app_id = nil
@@ -43,6 +44,7 @@ module Domain
         @prod_db_url = nil
         @public_website_domain = nil
         @public_website_url = nil
+        @redirect_domain = nil
       end
     end
   end
@@ -64,6 +66,7 @@ Domain.configure do |config|
     config.azure_account_name    ||= ENV['AZURE_ASSETS_STORAGE_FINCAP_CMS_ACCOUNT_NAME']
     config.algolia_app_id        ||= ENV['FINCAP_ALGOLIA_APP_ID']
     config.algolia_api_key       ||= ENV['FINCAP_ALGOLIA_API_KEY']
+    config.redirect_domain       ||= ENV['FINCAP_PUBLIC_WEBSITE_DOMAIN']
   else
     config.app_name              ||= 'MAS'
     config.public_website_domain ||= ENV['MAS_PUBLIC_WEBSITE_DOMAIN']
@@ -78,6 +81,7 @@ Domain.configure do |config|
     config.azure_account_name    ||= ENV['AZURE_ASSETS_STORAGE_CMS_ACCOUNT_NAME']
     config.algolia_app_id        ||= ENV['ALGOLIA_APP_ID']
     config.algolia_api_key       ||= ENV['ALGOLIA_API_KEY']
+    config.redirect_domain       ||= ENV['FARADAY_HOST']
   end
 end
 

--- a/lib/rack/redirect_middleware.rb
+++ b/lib/rack/redirect_middleware.rb
@@ -15,12 +15,16 @@ module Rack
         if redirect
           [
             redirect.status_code,
-            { 'Location' => "#{ENV['FARADAY_X_FORWARDED_PROTO']}://#{ENV['FARADAY_HOST']}#{redirect.destination}" },
+            { 'Location' => "#{redirect_domain}#{redirect.destination}" },
             ['']
           ]
         else
           @app.call(env)
         end
+      end
+
+      def redirect_domain
+        "#{ENV['FARADAY_X_FORWARDED_PROTO']}://#{Domain.config.redirect_domain}"
       end
     end
   end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9225-implement-internal-redirect-feature-on-fincap)

## Problem

Fincap uat was redirecting to the MAS site. One example you can see https://fincap-cms.uat.dev.mas.local/api/en/evaluations/evaluation-of-my-money-now

## What should happen

Mas CMS redirects should redirect to MAS site.
Fincap CMS redirects should redirect to Fincap site.

## Investigation

There was an env var hard coded on redirect middleware which uses as the domain to be redirect to.

Make the domain to look for the right APP_NAME makes the redirect work as expected to.

## Considerations

The env var that's being used  in MAS site is called FARADAY_HOST. I think is a terrible name but I decided to leave as it is to not break functionality under the MAS site.
There is an env var on production already called FINCAP_PUBLIC_WEBSITE_DOMAIN. I asked Oli and he confirmed that this is the env var that should be using.