### PR TITLE
[DEV APPROVED] [9508] Add seeds to allow feature testing on paginated search

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ So the next section will explain the setup for each application.
 
 ### Environment setup (Mac OsX)
 
-MySql needs to be installed and linked. 
+MySql needs to be installed and linked.
 Make sure Homebrew is installed.
 
 ```
@@ -48,6 +48,17 @@ $ APP_NAME='FINCAP' rails s
 or
 ```sh
 $ APP_NAME='MAS' rails s
+```
+
+####
+
+To reseed the database to the initial state:
+```sh
+$ APP_NAME='FINCAP' bundle exec rake db:drop db:create db:schema:load db:migrate db:seed:fincap
+```
+
+```sh
+$ APP_NAME='MAS' bundle exec rake db:drop db:create db:schema:load db:migrate db:seed:cms
 ```
 
 ### Updating Dough

--- a/db/seeds/fincap_data/lifestage.seeds.rb
+++ b/db/seeds/fincap_data/lifestage.seeds.rb
@@ -36,116 +36,131 @@ lifestage_layout = english_site.layouts.find_or_create_by(
   CONTENT
 )
 
-lifestage_page = english_site.pages.create!(
-  label: 'Young Adults',
-  slug: 'young-adults',
-  layout: lifestage_layout,
+lifestage_pages = []
 
-  state: 'published',
-  blocks: [
-    Comfy::Cms::Block.new(
-      identifier: 'content',
-      content: <<-CONTENT
-Young adults are those who have left compulsory education or other statutory settings, 
-such as care. They are transitioning towards independent living and financial 
-independence, beginning between the ages of 16 to 18 and continuing to their mid-20s.
-      CONTENT
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'component_hero_image',
-      content: '/assets/styleguide/hero-sample.jpg'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'component_hero_description',
-      content: 'Research suggests that young adults typically display lower levels of financial capability than older age groups.'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser_section_title',
-      content: 'Financial capability in action'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser1_title',
-      content: 'Some title to tease you'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser1_image',
-      content: '/assets/styleguide/hero-sample.jpg'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser1_text',
-      content: 'Loads of content to make you read more'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser1_link',
-      content: '[teaser1 link text](/financial+capability+strategy.pdf)'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser2_title',
-      content: 'Another title to entice you'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser2_image',
-      content: '/assets/styleguide/hero-sample.jpg'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser2_text',
-      content: 'A bunch of well written content to make you click'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser2_link',
-      content: '[Read more](/financial+capability+strategy.pdf)'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser3_title',
-      content: 'Teasing title'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser3_image',
-      content: '/assets/styleguide/hero-sample.jpg'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser3_text',
-      content: 'You want to read this, you need to read this'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'teaser3_link',
-      content: '[Click here](/financial+capability+strategy.pdf)'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'strategy_title',
-      content: 'Strategy Title'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'strategy_overview',
-      content: 'Adult financial capability is a direct resul'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'strategy_link',
-      content: '[Link to strategy](/financial+capability+strategy.pdf)'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'steering_group_title',
-      content: 'Steering group'
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'steering_group_links',
-      content: <<-CONTENT
-        [Steering group members](/financial+capability+strategy.pdf)
-        [Steering group updates](/financial+capability+strategy.pdf)
-        [Action plans](/financial+capability+strategy.pdf)
-      CONTENT
-    ),
-    Comfy::Cms::Block.new(
-      identifier: 'component_download',
-      content: <<-CONTENT
-      [Young Adults download](/financial+capability+strategy.pdf)
-      CONTENT
-    ),
-  ]
-)
+[
+  'Young Adults',
+  'Children and Young People',
+  'Working Age Adults',
+  'Older People in Retirement',
+  'People planning to retire',
+  'People in Financial difficulties',
+  'People trying to save',
+  'Dummy category 1',
+  'Dummy category 2',
+  'Dummy category 3',
+  'Dummy category 4',
+  'Dummy category 5',
+].each do |stage|
+  english_site.pages.create!(
+    label: stage,
+    slug: stage.gsub(' ', '_').downcase,
+    layout: lifestage_layout,
+
+    state: 'published',
+    blocks: [
+      Comfy::Cms::Block.new(
+        identifier: 'content',
+        content: <<-CONTENT
+          This is an example paragraph containing information about a specific lifestage.
+        CONTENT
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'component_hero_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'component_hero_description',
+        content: "Research suggests that #{stage} typically display lower levels of financial capability than other age groups."
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser_section_title',
+        content: 'Financial capability in action'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_title',
+        content: 'Some title to tease you'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_text',
+        content: 'Loads of content to make you read more'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_link',
+        content: '[teaser1 link text](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_title',
+        content: 'Another title to entice you'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_text',
+        content: 'A bunch of well written content to make you click'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_link',
+        content: '[Read more](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_title',
+        content: 'Teasing title'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_text',
+        content: 'You want to read this, you need to read this'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_link',
+        content: '[Click here](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'strategy_title',
+        content: 'Strategy Title'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'strategy_overview',
+        content: 'Adult financial capability is a direct resul'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'strategy_link',
+        content: '[Link to strategy](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'steering_group_title',
+        content: 'Steering group'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'steering_group_links',
+        content: <<-CONTENT
+          [Steering group members](/financial+capability+strategy.pdf)
+          [Steering group updates](/financial+capability+strategy.pdf)
+          [Action plans](/financial+capability+strategy.pdf)
+        CONTENT
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'component_download',
+        content: <<-CONTENT
+        [Lifestage category download](/financial+capability+strategy.pdf)
+        CONTENT
+      ),
+    ]
+  )
+end
 
 mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
-lifestage_page.keywords << mobile_payments_tag
+lifestage_pages.each { |page| page.keywords << mobile_payments_tag }
 
 Comfy::Cms::Block.all.each do |block|
   block.update(


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/9508)

## Context

In order to enable feature tests for the Fincap Search feature, a new app has been created in Algolia:
`FINCAP_LOCAL_TESTING`

This allows to have a shared and common index based on the FINCAP Cms DB seed. 

In order to test pagination more records were needed. I have tried to keep it as simple as possible as this will be used mainly for testing

## To re-seed

Instructions to reset the seed have been added to the readme. 

## Considerations

Dropping the DB can be dangerous as you might have to re-create users, etc. The ideal solution, in the future, would be to use a `find_or_create` seeding mechanism

