### PR TITLE
[DEV APPROVED] Add `order_by_date` param to documents endpoint

### DIFF
--- a/app/controllers/api/documents_controller.rb
+++ b/app/controllers/api/documents_controller.rb
@@ -12,6 +12,7 @@ module API
     param :keyword, String, required: false
     param :blocks, Array, required: false
     param :tag, [Array, String], required: false
+    param :order_by_date, String, required: false
     def index
       if documents
         render json: paginated_documents, meta: meta_data, root: 'documents'
@@ -26,7 +27,9 @@ module API
       @documents ||= DocumentProvider.new(
         params.permit(
           :keyword,
-          :tag, tag: [],
+          :order_by_date,
+          :tag,
+          tag: [],
           document_type: [],
           blocks: [:identifier, :value, value: []]
         ).merge(current_site: current_site)

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -46,12 +46,10 @@ RSpec.describe API::DocumentsController, type: :request do
         end
 
         it 'returns meta information' do
-          expect(response_body['meta'].symbolize_keys).to eq({
-            results: 2,
-            per_page: 1,
-            page: 1,
-            total_pages: 2
-          })
+          expect(response_body['meta'].symbolize_keys).to eq(results: 2,
+                                                             per_page: 1,
+                                                             page: 1,
+                                                             total_pages: 2)
         end
       end
 
@@ -65,12 +63,10 @@ RSpec.describe API::DocumentsController, type: :request do
         end
 
         it 'returns meta information' do
-          expect(response_body['meta'].symbolize_keys).to eq({
-            results: 2,
-            per_page: 1,
-            page: 2,
-            total_pages: 2
-          })
+          expect(response_body['meta'].symbolize_keys).to eq(results: 2,
+                                                             per_page: 1,
+                                                             page: 2,
+                                                             total_pages: 2)
         end
       end
     end
@@ -110,7 +106,7 @@ RSpec.describe API::DocumentsController, type: :request do
           :page_with_tag,
           label: 'Page with tag',
           site: site,
-          tag_name: 'pensions',
+          tag_name: 'pensions'
         )
       end
       let!(:page_without_tag) do
@@ -141,6 +137,38 @@ RSpec.describe API::DocumentsController, type: :request do
         it 'returns empty documents' do
           expect(documents.size).to be_zero
         end
+      end
+    end
+
+    context 'when ordering documents by "order_by_date"' do
+      let!(:news_page1) do
+        create(
+          :page_with_order_by_date_block,
+          site: site,
+          created_at: Date.today,
+          order_by_date: '2017-03-15'
+        )
+      end
+      let!(:news_page2) do
+        create(
+          :page_with_order_by_date_block,
+          site: site,
+          created_at: Date.yesterday,
+          order_by_date: '2017-03-16'
+        )
+      end
+
+      before do
+        get '/api/en/documents', { order_by_date: 'true' }, headers
+      end
+
+      it 'returns documents ordered by "order_by_date"', :aggregate_failures do
+        expect(documents[0]['blocks']).to include(
+          hash_including('identifier' => 'order_by_date', 'content' => "<p>2017-03-16</p>\n")
+        )
+        expect(documents[1]['blocks']).to include(
+          hash_including('identifier' => 'order_by_date', 'content' => "<p>2017-03-15</p>\n")
+        )
       end
     end
 

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -66,7 +66,7 @@ FactoryGirl.define do
 
     trait :order_by_date do
       identifier { 'order_by_date' }
-      content { '15th March 2017' }
+      content { '2017-03-15' }
     end
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -52,7 +52,7 @@ FactoryGirl.define do
     end
 
     factory :page_abt_debt_and_stress do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'Debt, stress and pay levels'
       after(:create) do |page|
         create :block, :debt_content, blockable: page
@@ -61,7 +61,7 @@ FactoryGirl.define do
     end
 
     factory :uk_study_about_work_and_stress do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'Debt, stress and pay levels in the UK'
       after(:create) do |page|
         create :block, :debt_content, blockable: page
@@ -73,14 +73,14 @@ FactoryGirl.define do
     end
 
     factory :insight_page_about_pensions do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       after(:create) do |page|
         create :block, :pension_content, blockable: page
       end
     end
 
     factory :insight_page_titled_pensions do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'pensions'
       after(:create) do |page|
         create :block, :debt_content, blockable: page
@@ -88,14 +88,14 @@ FactoryGirl.define do
     end
 
     factory :insight_page do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       after(:create) do |page|
         create :block, :financial_wellbeing_content, blockable: page
       end
     end
 
     factory :insight_page_titled_annuities do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'Annuities'
       after(:create) do |page|
         create :block, identifier: 'content', blockable: page
@@ -103,7 +103,7 @@ FactoryGirl.define do
     end
 
     factory :insight_page_with_overview_block do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'Overview'
       after(:create) do |page|
         create :block, :redundancy_overview, blockable: page
@@ -112,15 +112,23 @@ FactoryGirl.define do
     end
 
     factory :page_with_order_by_date_block do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'Some label'
-      after(:create) do |page|
-        create :block, :order_by_date, blockable: page
+      transient { order_by_date '2017-03-15' }
+      after(:create) do |page, evaluator|
+        page.keywords << Tag.find_or_create_by(value: 'test')
+        create(:block, identifier: 'content', blockable: page)
+        create(
+          :block,
+          :order_by_date,
+          content: evaluator.order_by_date,
+          blockable: page
+        )
       end
     end
 
     factory :insight_page_with_raw_cta_text_block do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'Page with block other than content or identifier'
       after(:create) do |page|
         create :block, :raw_cta_text_content, blockable: page
@@ -128,7 +136,7 @@ FactoryGirl.define do
     end
 
     factory :young_adults_page do
-      site { create :site, identifier: 'test-documents'}
+      site { create :site, identifier: 'test-documents' }
       label 'Debt about young adults and stress'
       after(:create) do |page|
         create :block, :young_adults_client_group, blockable: page

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe DocumentProvider do
       document_type: document_type,
       keyword: keyword,
       blocks: filters,
-      tag: tag
+      tag: tag,
+      order_by_date: order_by_date
     ).retrieve
   end
 
@@ -17,9 +18,10 @@ RSpec.describe DocumentProvider do
   let(:keyword) { nil }
   let(:filters) { nil }
   let(:tag) { nil }
+  let(:order_by_date) { nil }
 
   let(:insight_layout) { create :layout, identifier: 'insight' }
-  let(:review_layout)  { create :layout, identifier: 'review' }
+  let(:news_layout)  { create :layout, identifier: 'news' }
   let(:review_layout)  { create :layout, identifier: 'review' }
 
   describe 'no filtering' do
@@ -106,7 +108,9 @@ RSpec.describe DocumentProvider do
         end
 
         context 'and the keyword is found in an "order_by_date" block' do
-          let!(:page_with_order_by_date_block) { create(:page_with_order_by_date_block, site: site, layout: insight_layout) }
+          let!(:page_with_order_by_date_block) do
+            create(:page_with_order_by_date_block, site: site, layout: insight_layout)
+          end
           let!(:page_without_keyword) { create(:page, site: site, layout: insight_layout) }
           let(:keyword) { '2017' }
 
@@ -165,7 +169,7 @@ RSpec.describe DocumentProvider do
     context 'when there is only one value for the filter type' do
       let!(:page_with_filter_type) { create(:page_abt_debt_and_stress, site: site, layout: insight_layout) }
       let!(:page_without_filter_type) { create(:page, site: site, layout: insight_layout) }
-      let(:filters) { [{identifier: 'client_groups', value: 'Working age (18 - 65)'}] }
+      let(:filters) { [{ identifier: 'client_groups', value: 'Working age (18 - 65)' }] }
 
       it 'returns only documents that meet the filter type' do
         expect(subject.size).to eq(1)
@@ -188,7 +192,7 @@ RSpec.describe DocumentProvider do
             identifier: 'client_groups',
             value: 'Young adults (17 - 24)'
           }
-       ]
+        ]
       end
 
       it 'returns only documents that meet the filter type' do
@@ -205,7 +209,7 @@ RSpec.describe DocumentProvider do
       let!(:page_without_anything) { create(:page, site: site, layout: insight_layout) }
 
       let(:keyword) { 'debt' }
-      let(:filters) { [{identifier: 'client_groups', value: 'Working age (18 - 65)'}] }
+      let(:filters) { [{ identifier: 'client_groups', value: 'Working age (18 - 65)' }] }
 
       it 'returns only documents that have the keyword and meet the filter type' do
         expect(subject.size).to eq(1)
@@ -215,15 +219,17 @@ RSpec.describe DocumentProvider do
 
     context 'when there are multiple filters of different types' do
       let!(:page_with_filter_type_and_keyword) { create(:page_abt_debt_and_stress, site: site, layout: insight_layout) }
-      let!(:page_with_3_filter_types_and_keyword) { create(:uk_study_about_work_and_stress, site: site, layout: insight_layout) }
+      let!(:page_with_3_filter_types_and_keyword) do
+        create(:uk_study_about_work_and_stress, site: site, layout: insight_layout)
+      end
       let!(:page_with_keyword) { create(:young_adults_page, site: site, layout: insight_layout) }
       let!(:page_without_anything) { create(:page, site: site, layout: insight_layout) }
 
       let(:keyword) { 'stress' }
       let(:filters) { [filter1, filter2, filter3] }
-      let(:filter1) { {identifier: 'client_groups', value: 'Working age (18 - 65)'} }
-      let(:filter2) { {identifier: 'topic', value: 'Saving'} }
-      let(:filter3) { {identifier: 'countries_of_delivery', value: 'United Kingdom'} }
+      let(:filter1) { { identifier: 'client_groups', value: 'Working age (18 - 65)' } }
+      let(:filter2) { { identifier: 'topic', value: 'Saving' } }
+      let(:filter3) { { identifier: 'countries_of_delivery', value: 'United Kingdom' } }
 
       it 'returns documents that have the keyword and all the given filter types' do
         expect(subject.size).to eq(1)
@@ -232,14 +238,16 @@ RSpec.describe DocumentProvider do
     end
 
     context 'when there are multiple filters of the same type' do
-      let!(:page_with_3_filter_types_and_keyword) { create(:page_abt_debt_and_stress, site: site, layout: insight_layout) }
+      let!(:page_with_3_filter_types_and_keyword) do
+        create(:page_abt_debt_and_stress, site: site, layout: insight_layout)
+      end
       let!(:page_with_a_diff_filter_and_keyword) { create(:young_adults_page, site: site, layout: insight_layout) }
       let!(:page_without_anything) { create(:page, site: site, layout: insight_layout) }
 
       let(:keyword) { 'stress' }
       let(:filters) { [filter1, filter2] }
-      let(:filter1) { {identifier: 'client_groups', value: 'Working age (18 - 65)'} }
-      let(:filter2) { {identifier: 'client_groups', value: 'Young adults (17 - 24)'} }
+      let(:filter1) { { identifier: 'client_groups', value: 'Working age (18 - 65)' } }
+      let(:filter2) { { identifier: 'client_groups', value: 'Young adults (17 - 24)' } }
 
       it 'returns documents that have the keyword and all the given filter types' do
         expect(subject.size).to eq(2)
@@ -251,12 +259,40 @@ RSpec.describe DocumentProvider do
   end
 
   describe 'ordering search results' do
-    let!(:insight_page) { create(:insight_page, site: site, layout: insight_layout, created_at: Date.today) }
-    let!(:review_page) { create(:page, site: site, layout: review_layout, created_at: Date.yesterday) }
+    let!(:news_page1) do
+      create(
+        :page_with_order_by_date_block,
+        site: site,
+        layout: news_layout,
+        created_at: Date.today,
+        order_by_date: '2017-03-15'
+      )
+    end
+    let!(:news_page2) do
+      create(
+        :page_with_order_by_date_block,
+        site: site,
+        layout: news_layout,
+        created_at: Date.yesterday,
+        order_by_date: '2017-03-16'
+      )
+    end
+    let(:tag) { ['test'] }
 
-    it 'pages in descending order of creation date' do
-      expect(subject.size).to eq(2)
-      expect(subject.first).to eq(insight_page)
+    context 'when ordering by "order_by_date"' do
+      let(:order_by_date) { 'true' }
+
+      it 'returns pages in descending order of "order_by_date"' do
+        expect(subject).to eq([news_page2, news_page1])
+      end
+    end
+
+    context 'when not ordering by "order_by_date"' do
+      let(:order_by_date) { 'false' }
+
+      it 'returns pages in descending order of creation date' do
+        expect(subject).to eq([news_page1, news_page2])
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds an optional param to the documents  in order to override the default order (by `position` ASC, followed by `created_at` DESC for the average case).

Please note that this PR contains a lot of rubocop fixes because of the fact that these files have been touched.