### PR TITLE
[DEV APPROVED] 9404 - Add a new What Works page layout

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,4 +13,5 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'API'
   inflect.uncountable 'corporate'
+  inflect.irregular 'what_works', 'what_works'
 end

--- a/db/seeds/fincap_data/evidence_summary_seeds.rb
+++ b/db/seeds/fincap_data/evidence_summary_seeds.rb
@@ -215,11 +215,17 @@ to resolve their difficulties and change their behaviour.
   ]
 )
 
+tag = Tag.find_or_create_by(
+  value: 'how-can-we-improve-the-financial-capability-of-young-adults'
+)
+
 evaluation_page = english_site.pages.create!(
   label: 'Looking after the pennies',
   slug: 'looking-after-the-pennies',
   meta_description: common_dummy_description,
   layout: evaluation_layout,
+  keywords: [tag],
+
   state: 'published',
   blocks: [
     Comfy::Cms::Block.new(
@@ -314,6 +320,8 @@ review_page = english_site.pages.create!(
   slug: 'raising-household-saving',
   meta_description: common_dummy_description,
   layout: review_layout,
+  keywords: [tag],
+
   state: 'published',
   blocks: [
     Comfy::Cms::Block.new(
@@ -388,13 +396,6 @@ Based on an analysis of international evidence, this report examines in detail w
     )
   ]
 )
-
-tag = Tag.find_or_create_by(
-  value: 'how-can-we-improve-the-financial-capability-of-young-adults'
-)
-
-evaluation_page.keywords << tag
-review_page.keywords << tag
 
 Comfy::Cms::Block.all.each do |block|
   block.update(

--- a/db/seeds/fincap_data/lifestage.seeds.rb
+++ b/db/seeds/fincap_data/lifestage.seeds.rb
@@ -9,7 +9,7 @@ english_site = Comfy::Cms::Site.find_or_create_by(
 
 lifestage_layout = english_site.layouts.find_or_create_by(
   identifier: 'lifestage',
-  label: ' Lifestage',
+  label: 'Lifestage',
   content:  <<-CONTENT
     {{ cms:page:content:rich_text }}
     {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
@@ -36,7 +36,7 @@ lifestage_layout = english_site.layouts.find_or_create_by(
   CONTENT
 )
 
-lifestage_pages = []
+mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
 
 [
   'Young Adults',
@@ -57,6 +57,7 @@ lifestage_pages = []
     meta_description: 'This is an example paragraph containing a description about a specific lifestage.',
     slug: stage.gsub(' ', '-').downcase,
     layout: lifestage_layout,
+    keywords: [mobile_payments_tag],
 
     state: 'published',
     blocks: [
@@ -159,9 +160,6 @@ lifestage_pages = []
     ]
   )
 end
-
-mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
-lifestage_pages.each { |page| page.keywords << mobile_payments_tag }
 
 Comfy::Cms::Block.all.each do |block|
   block.update(

--- a/db/seeds/fincap_data/news_seeds.rb
+++ b/db/seeds/fincap_data/news_seeds.rb
@@ -63,11 +63,16 @@ Or, for a wide range of evaluation evidence, insight and market research don't f
   ]
 )
 
+mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
+secure_payments_tag = Tag.find_or_create_by(value: 'secure-payments')
+
 news_page = english_site.pages.create!(
   label: 'Press Release: A new way to pay!',
   slug: 'press-release-a-new-way-to-pay',
   layout: news_layout,
   state: 'published',
+  keywords: [mobile_payments_tag, secure_payments_tag],
+
   blocks: [
     Comfy::Cms::Block.new(
       identifier: 'content',
@@ -184,13 +189,6 @@ news.blocks = [
   )
 ]
 news.save!
-
-mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
-secure_payments_tag = Tag.find_or_create_by(value: 'secure-payments')
-
-[mobile_payments_tag, secure_payments_tag].each do |tag|
-  news_page.keywords << tag
-end
 
 Comfy::Cms::Block.all.each do |block|
   block.update(

--- a/db/seeds/fincap_data/regional_strategy_seeds.rb
+++ b/db/seeds/fincap_data/regional_strategy_seeds.rb
@@ -36,10 +36,13 @@ regional_strategy_layout = english_site.layouts.find_or_create_by(
   CONTENT
 )
 
+mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
+
 regional_strategy_page = english_site.pages.create!(
   label: 'Wales',
   slug: 'wales',
   layout: regional_strategy_layout,
+  keywords: [mobile_payments_tag],
 
   state: 'published',
   blocks: [
@@ -145,9 +148,6 @@ equivalent to 23 per cent of the population.
     )
   ]
 )
-
-mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
-regional_strategy_page.keywords << mobile_payments_tag
 
 Comfy::Cms::Block.all.each do |block|
   block.update(

--- a/db/seeds/fincap_data/what_works_seeds.rb
+++ b/db/seeds/fincap_data/what_works_seeds.rb
@@ -1,0 +1,162 @@
+english_site = Comfy::Cms::Site.find_or_create_by(
+  label: 'en',
+  identifier: 'money-advice-service-en',
+  hostname: ENV['HOSTNAME'] || 'localhost:3000',
+  path: 'en',
+  locale: 'en',
+  is_mirrored: true
+)
+
+what_works_layout = english_site.layouts.find_or_create_by(
+  identifier: 'what_works',
+  label: 'What Works',
+  content:  <<-CONTENT
+    {{ cms:page:content:rich_text }}
+    {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+    {{ cms:page:hero_description:simple_component/Description }}
+    {{ cms:page:teaser_section_title }}
+    {{ cms:page:teaser1_title }}
+    {{ cms:page:teaser1_image }}
+    {{ cms:page:teaser1_text }}
+    {{ cms:page:teaser1_link }}
+    {{ cms:page:teaser2_title }}
+    {{ cms:page:teaser2_image }}
+    {{ cms:page:teaser2_text }}
+    {{ cms:page:teaser2_link }}
+    {{ cms:page:teaser3_title }}
+    {{ cms:page:teaser3_image }}
+    {{ cms:page:teaser3_text }}
+    {{ cms:page:teaser3_link }}
+    {{ cms:page:strategy_title }}
+    {{ cms:page:strategy_overview }}
+    {{ cms:page:strategy_link }}
+    {{ cms:page:steering_group_title }}
+    {{ cms:page:steering_group_links }}
+    {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+  CONTENT
+)
+
+mobile_payments_tag = Tag.find_or_create_by(value: 'mobile-payments')
+
+[
+  'What Works 1',
+  'What Works 2',
+  'What Works 3',
+  'What Works 4',
+  'What Works 5',
+].each do |page|
+  english_site.pages.create!(
+    label: page,
+    meta_description: 'This is an example paragraph containing a description about a specific \'What Works\' page.',
+    slug: page.gsub(' ', '-').downcase,
+    layout: what_works_layout,
+    keywords: [mobile_payments_tag],
+
+    state: 'published',
+    blocks: [
+      Comfy::Cms::Block.new(
+        identifier: 'content',
+        content: <<-CONTENT
+          This is an example paragraph containing information about a specific what works page.
+          It will contain useful information and searchable text.
+        CONTENT
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'component_hero_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'component_hero_description',
+        content: "Research suggests that #{page} typically display useful information that can be extremely useful when used appropriately."
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser_section_title',
+        content: 'What Works'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_title',
+        content: 'Some title to tease you'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_text',
+        content: 'Loads of content to make you read more'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser1_link',
+        content: '[teaser1 link text](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_title',
+        content: 'Another title to entice you'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_text',
+        content: 'A bunch of well written content to make you click'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser2_link',
+        content: '[Read more](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_title',
+        content: 'Teasing title'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_image',
+        content: '/assets/styleguide/hero-sample.jpg'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_text',
+        content: 'You want to read this, you need to read this'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'teaser3_link',
+        content: '[Click here](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'strategy_title',
+        content: 'Strategy Title'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'strategy_overview',
+        content: 'Adult financial capability is a direct resul'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'strategy_link',
+        content: '[Link to strategy](/financial+capability+strategy.pdf)'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'steering_group_title',
+        content: 'Steering group'
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'steering_group_links',
+        content: <<-CONTENT
+          [Steering group members](/financial+capability+strategy.pdf)
+          [Steering group updates](/financial+capability+strategy.pdf)
+          [Action plans](/financial+capability+strategy.pdf)
+        CONTENT
+      ),
+      Comfy::Cms::Block.new(
+        identifier: 'component_download',
+        content: <<-CONTENT
+        [What works category download](/financial+capability+strategy.pdf)
+        CONTENT
+      ),
+    ]
+  )
+end
+
+Comfy::Cms::Block.all.each do |block|
+  block.update(
+    processed_content: Mastalk::Document.new(block.content.strip).to_html
+  )
+end

--- a/features/pages_form/fincap_what_works_page.feature
+++ b/features/pages_form/fincap_what_works_page.feature
@@ -1,0 +1,65 @@
+Feature: Building What Works Page
+  As an Editor
+  In order to the build a What Works Page
+  I want to be able to fill out all the fields on the form
+
+  Background:
+    Given I have a what works page layout setup with components
+    And I am logged in
+
+  Scenario: Creating a What Works Page
+    Given I am on the homepage
+    And I click on "Create new page"
+    And I select "What Works" on the creation page
+    And I create a page "What Works Page"
+    When I edit the page "What Works Page"
+    And I fill in
+      | FIELD                     | VALUE                                         |
+      | content                   | Out of compulsory education or other statutory|
+      | hero_image                | /assets/styleguide/hero-sample.jpg            |
+      | hero_description          | By 2025 we aim to equip all young adults with |
+      | teaser_section_title      | Financial capability in action                |
+      | teaser1_title             | Ipsem lorem                                   |
+      | teaser1_image             | /assets/styleguide/hero-sample.jpg            |
+      | teaser1_text              | Lots of text about something                  |
+      | teaser1_link              | [Test1](/test1)                               |
+      | teaser2_title             | Hic haec hoc                                  |
+      | teaser2_image             | /assets/styleguide/hero-sample.jpg            |
+      | teaser2_text              | Another scintillating teaser box              |
+      | teaser2_link              | [Test2](/test2)                               |
+      | teaser3_title             | To be or not to be                            |
+      | teaser3_image             | /assets/styleguide/hero-sample.jpg            |
+      | teaser3_text              | Officiem im volest pratur, antetum quos laure |
+      | teaser3_link              | [Test3](/test3)                               |
+      | strategy_title            | Strategy extract                              |
+      | strategy_overview         | Adult financial capability is a direct result |
+      | strategy_link             | [Test4](/test4)                               |
+      | steering_group_list_title | Steering group                                |
+      | steering_group_links      | [Test5](/test5)                               |
+      | download                  | [File](a-file)                                |
+    And I save and return to the homepage
+    And when I click the "What Works Page" page
+    Then I should see the fields filled with the content
+      | FIELD                     | VALUE                                         |
+      | content                   | Out of compulsory education or other statutory|
+      | hero_image                | /assets/styleguide/hero-sample.jpg            |
+      | hero_description          | By 2025 we aim to equip all young adults with |
+      | teaser_section_title      | Financial capability in action                |
+      | teaser1_title             | Ipsem lorem                                   |
+      | teaser1_image             | /assets/styleguide/hero-sample.jpg            |
+      | teaser1_text              | Lots of text about something                  |
+      | teaser1_link              | [Test1](/test1)                               |
+      | teaser2_title             | Hic haec hoc                                  |
+      | teaser2_image             | /assets/styleguide/hero-sample.jpg            |
+      | teaser2_text              | Another scintillating teaser box              |
+      | teaser2_link              | [Test2](/test2)                               |
+      | teaser3_title             | To be or not to be                            |
+      | teaser3_image             | /assets/styleguide/hero-sample.jpg            |
+      | teaser3_text              | Officiem im volest pratur, antetum quos laure |
+      | teaser3_link              | [Test3](/test3)                               |
+      | strategy_title            | Strategy extract                              |
+      | strategy_overview         | Adult financial capability is a direct result |
+      | strategy_link             | [Test4](/test4)                               |
+      | steering_group_list_title | Steering group                                |
+      | steering_group_links      | [Test5](/test5)                               |
+      | download                  | [File](a-file)                                |

--- a/features/step_definitions/fincap_background_steps.rb
+++ b/features/step_definitions/fincap_background_steps.rb
@@ -118,6 +118,37 @@ Given(/^I have a lifestage page layout setup with components$/) do
   )
 end
 
+Given(/^I have a what works page layout setup with components$/) do
+  cms_site.layouts.find_or_create_by(
+    identifier: 'what_woks',
+    label: 'What Works',
+    content:  <<-CONTENT
+      {{ cms:page:content:rich_text }}
+      {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+      {{ cms:page:hero_description:simple_component/Description }}
+      {{ cms:page:teaser_section_title }}
+      {{ cms:page:teaser1_title }}
+      {{ cms:page:teaser1_image }}
+      {{ cms:page:teaser1_text }}
+      {{ cms:page:teaser1_link }}
+      {{ cms:page:teaser2_title }}
+      {{ cms:page:teaser2_image }}
+      {{ cms:page:teaser2_text }}
+      {{ cms:page:teaser2_link }}
+      {{ cms:page:teaser3_title }}
+      {{ cms:page:teaser3_image }}
+      {{ cms:page:teaser3_text }}
+      {{ cms:page:teaser3_link }}
+      {{ cms:page:strategy_title }}
+      {{ cms:page:strategy_overview }}
+      {{ cms:page:strategy_link }}
+      {{ cms:page:steering_group_list_title }}
+      {{ cms:page:steering_group_links }}
+      {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+    CONTENT
+  )
+end
+
 Given(/^I have a news page layout setup with components$/) do
   cms_site.layouts.find_or_create_by(
     identifier: 'news',

--- a/lib/tasks/fincap.rake
+++ b/lib/tasks/fincap.rake
@@ -109,7 +109,36 @@ namespace :fincap do
 
     english_site.layouts.find_or_create_by(
       identifier: 'lifestage',
-      label: ' Lifestage',
+      label: 'Lifestage',
+      content:  <<-CONTENT
+        {{ cms:page:content:rich_text }}
+        {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}
+        {{ cms:page:hero_description:simple_component/Description }}
+        {{ cms:page:teaser_section_title }}
+        {{ cms:page:teaser1_title }}
+        {{ cms:page:teaser1_image }}
+        {{ cms:page:teaser1_text }}
+        {{ cms:page:teaser1_link }}
+        {{ cms:page:teaser2_title }}
+        {{ cms:page:teaser2_image }}
+        {{ cms:page:teaser2_text }}
+        {{ cms:page:teaser2_link }}
+        {{ cms:page:teaser3_title }}
+        {{ cms:page:teaser3_image }}
+        {{ cms:page:teaser3_text }}
+        {{ cms:page:teaser3_link }}
+        {{ cms:page:strategy_title }}
+        {{ cms:page:strategy_overview }}
+        {{ cms:page:strategy_link }}
+        {{ cms:page:steering_group_title }}
+        {{ cms:page:steering_group_links }}
+        {{ cms:page:download:simple_component/[Text Link](https://moneyadviceservice.org.uk/link) }}
+      CONTENT
+    )
+
+    english_site.layouts.find_or_create_by(
+      identifier: 'what_works',
+      label: 'What Works',
       content:  <<-CONTENT
         {{ cms:page:content:rich_text }}
         {{ cms:page:hero_image:simple_component/https://moneyadviceservice.org.uk/image.jpg }}


### PR DESCRIPTION
[TP Card](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&boardPopup=userstory/9404/silent)

### Changes
- Add a new layout (`What Works`). This is a copy of the `Lifestages` layout
  This will provide a new URL scope. i.e /en/what_works/my-custom-page
- Amend fincap:setup rake task
- Add `what_works` seed data 

### Fix/Refactor

- We have discovered that tags were not properly added in the seeds. We have also simplified the logic, avoiding a second iteration over the newly created pages. 