### PR TITLE
[DEV APPROVED] - [9580] Fix multiple tags error and duplicated news

### DIFF
--- a/app/filters/document_provider.rb
+++ b/app/filters/document_provider.rb
@@ -50,7 +50,8 @@ class DocumentProvider
     return @documents if tag.blank?
 
     @documents = @documents
-      .joins(:keywords).where('tags.value = ?', tag)
+      .joins(:keywords).where('tags.value IN (?)', tag)
+      .uniq
   end
 
   def filter_documents
@@ -85,6 +86,7 @@ class DocumentProvider
                 .where("comfy_cms_blocks.identifier = 'order_by_date'")
                 .select("comfy_cms_pages.*, STR_TO_DATE(comfy_cms_blocks.content, '%Y-%m-%d') AS order_by_date")
                 .reorder('order_by_date DESC')
+                .uniq
     else
       @documents = @documents.order('created_at DESC')
     end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -113,7 +113,12 @@ RSpec.describe API::DocumentsController, type: :request do
         create(:page, site: site)
       end
       let!(:page_with_a_different_tag) do
-        create(:page_with_tag, site: site, tag_name: 'sorry-not-a-pensions')
+        create(
+          :page_with_tag,
+          label: 'Page with another tag',
+          site: site,
+          tag_name: 'sorry-not-a-pensions'
+        )
       end
 
       context 'when searching an existent tag' do
@@ -125,6 +130,22 @@ RSpec.describe API::DocumentsController, type: :request do
           expect(documents.size).to be(1)
           expect(documents.first).to include(
             'label' => 'Page with tag'
+          )
+        end
+      end
+
+      context 'when searching multiple tags' do
+        before do
+          get '/api/en/documents', { tag: ['pensions', 'sorry-not-a-pensions'] }, headers
+        end
+
+        it 'returns pages with matching tags' do
+          expect(documents.size).to be(2)
+          expect(documents).to include(
+            hash_including(
+              'label' => 'Page with tag',
+              'label' => 'Page with another tag'
+            )
           )
         end
       end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -30,6 +30,18 @@ FactoryGirl.define do
       end
     end
 
+    factory :page_with_multiple_tags do
+      site { create :site, identifier: 'test-documents' }
+      label 'A page with two tags'
+      after(:create) do |page, evaluator|
+        page.keywords.concat [
+          create(:tag, value: "#{evaluator.tag_name}-2"),
+          create(:tag, value: "#{evaluator.tag_name}-3")
+        ]
+        create :block, identifier: 'content', blockable: page
+      end
+    end
+
     factory :english_article do
       site { create :site, label: 'en' }
       layout { create :layout, identifier: 'article' }
@@ -117,7 +129,7 @@ FactoryGirl.define do
       transient { order_by_date '2017-03-15' }
       after(:create) do |page, evaluator|
         page.keywords << Tag.find_or_create_by(value: 'test')
-        create(:block, identifier: 'content', blockable: page)
+        create :block, identifier: 'content', blockable: page
         create(
           :block,
           :order_by_date,

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -47,6 +47,31 @@ RSpec.describe DocumentProvider do
     end
   end
 
+  describe 'filter_by_tag' do
+    let!(:tagged_page) { create(:page_with_tag, site: site, layout: insight_layout) }
+    let!(:untagged_page) { create(:english_article, site: site, layout: insight_layout) }
+    let(:document_type) { 'insight' }
+
+    context 'with a single tag' do
+      let(:tag) { ['tag'] }
+
+      it 'returns all documents tagged' do
+        expect(subject.size).to eq(1)
+        expect(subject).to match_array([tagged_page])
+      end
+    end
+
+    context 'with multiple tags' do
+      let!(:another_tagged_page) { create(:page_with_multiple_tags, site: site, layout: insight_layout) }
+      let(:tag) { ['tag', 'tag-2'] }
+
+      it 'returns the tagged pages' do
+        expect(subject.size).to eq(2)
+        expect(subject).to match_array([tagged_page, another_tagged_page])
+      end
+    end
+  end
+
   describe 'filter_by_keyword' do
     context 'when a keyword is provided' do
       context 'searching the title' do
@@ -277,7 +302,6 @@ RSpec.describe DocumentProvider do
         order_by_date: '2017-03-16'
       )
     end
-    let(:tag) { ['test'] }
 
     context 'when ordering by "order_by_date"' do
       let(:order_by_date) { 'true' }


### PR DESCRIPTION
- filter_by_tag was not allowing multiple tag.values using
  'value =' instead of 'value IN'.
- News were duplicated if multiple tags were present, so
  a 'uniq' => 'DISTINCT' clause has been added both in
  filter_by_tag and order_documents filters.