### PR TITLE
[DEV APPROVED] - Add an API route for clumps

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   apipie
-  
+
   devise_for :users, class_name: 'Comfy::Cms::User'
 
   resources :word_documents
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
   namespace :api do
     scope ":locale", locale: /en|cy/ do
       resources :documents, only: :index
+      resources :clumps, only: :index
     end
 
     get '/:locale/latest_news' => 'documents#index'

--- a/spec/controllers/api/clumps_controller_spec.rb
+++ b/spec/controllers/api/clumps_controller_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe API::ClumpsController, type: :request do
+  describe 'GET /api/:locale/clumps' do
+    before do
+      FactoryGirl.create(:clump, name_en: 'Debt', name_cy: 'Debt-cy')
+      FactoryGirl.create(:clump, name_en: 'Retirement', name_cy: 'Retirement-cy')
+    end
+
+    context 'en locale' do
+      before { FactoryGirl.create(:site, path: 'en') }
+
+      it 'returns all clumps using the appropriate locale' do
+        get '/api/en/clumps'
+
+        expect(response).to have_http_status :ok
+        response_body = JSON.parse(response.body)
+        expect(response_body.length).to eq 2
+        expect(response_body.map { |clump| clump['name'] }).to eq(%w(Debt Retirement))
+      end
+    end
+
+    context 'cy locale' do
+      before { FactoryGirl.create(:site, path: 'cy') }
+
+      it 'returns all clumps using the appropriate locale' do
+        get '/api/cy/clumps'
+
+        expect(response).to have_http_status :ok
+        response_body = JSON.parse(response.body)
+        expect(response_body.length).to eq 2
+        expect(response_body.map { |clump| clump['name'] }).to eq(%w(Debt-cy Retirement-cy))
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/8217-make-the-cms-clumps-api-url)

Clumps are currently exposed via the path /en/clumps.json, which is
inconsistent with other API resources such as categories and news. For
consistency, add an additional route for the mas-cms-client gem to point
to. Once the gem and clients have been updated, the old path will be
removed.