### PR TITLE
[DEV APPROVED] Remove old clumps route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,8 +78,6 @@ Rails.application.routes.draw do
   end
 
   namespace :api, path: '/' do
-    get '/:locale/clumps(.:format)' => 'clumps#index'
-
     get '/:locale/categories(.:format)' => 'category_contents#index'
     get '/:locale/categories/(*id)(.:format)' => 'category_contents#show'
     get '/preview/:locale/(*slug)(.:format)' => 'content#preview'


### PR DESCRIPTION
This route is no longer used, now that Frontend has been updated to use v1.19 of the mas-cms-client (pointing it to `/api/:locale/clumps` for all its clump-based needs). No other client appears to use this feature, so the older route can now be removed.