### PR TITLE
[DEV APPROVED] Use UTF-8 encoding to avoid incompatibilities

### DIFF
--- a/lib/cms/audit/pages.rb
+++ b/lib/cms/audit/pages.rb
@@ -20,7 +20,7 @@ module Cms
         'Language'
       ].freeze
       DEFAULT_FILE = '/tmp/audit.csv'.freeze
-      ENCODING = 'ISO-8859-1'.freeze
+      ENCODING = 'UTF-8'.freeze
 
       def self.all
         Comfy::Cms::Page

--- a/spec/lib/cms/audit/pages_spec.rb
+++ b/spec/lib/cms/audit/pages_spec.rb
@@ -87,6 +87,10 @@ describe Cms::Audit::Pages do
         ]
       end
 
+      it 'used UTF-8 encoding' do
+        expect(described_class::ENCODING).to eq 'UTF-8'
+      end
+
       it 'creates a file with correct headers' do
         expect(parse_csv.first).to eq Cms::Audit::Pages::HEADERS
       end


### PR DESCRIPTION
Related to: [TP Card](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=userstory/10162/silent)

- After deployment I have tested the task and discovered
  incompatibilities with the encoding. Using UTF-8 fixes the issue

- Generated file attached to the TP Card