### PR TITLE
[DEV APPROVED] Ensure filtering query returns unique pages

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -374,6 +374,7 @@ Style/BlockDelimiters:
 Style/ConditionalAssignment:
   Exclude:
     - 'app/models/comfy/cms/category.rb'
+    - 'app/filters/document_provider.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.

--- a/spec/factories/blocks.rb
+++ b/spec/factories/blocks.rb
@@ -54,6 +54,11 @@ FactoryGirl.define do
       content { 'Young adults (17 - 24)' }
     end
 
+    trait :pensions_and_retirement_topic do
+      identifier { 'topic' }
+      content { 'Pensions and retirement planning' }
+    end
+
     trait :saving_topic do
       identifier { 'topic' }
       content { 'Saving' }

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -92,6 +92,7 @@ FactoryGirl.define do
         create :block, :debt_content, blockable: page
         create :block, :working_age_client_group, blockable: page
         create :block, :saving_topic, blockable: page
+        create :block, :pensions_and_retirement_topic, blockable: page
         create :block, :published_by_uk, blockable: page
       end
     end

--- a/spec/filters/document_provider_spec.rb
+++ b/spec/filters/document_provider_spec.rb
@@ -224,6 +224,26 @@ RSpec.describe DocumentProvider do
         expect(subject.size).to eq(2)
         expect(subject).to match_array([page_with_filter_type1, page_with_filter_type2])
       end
+
+      context 'when there are documents with multiple topic blocks' do
+        let!(:page_with_2_filters) { create(:uk_study_about_work_and_stress, site: site, layout: insight_layout) }
+        let(:filters) do
+          [
+            {
+              identifier: 'topic',
+              value: 'Saving'
+            },
+            {
+              identifier: 'topic',
+              value: 'Pensions and retirement planning'
+            }
+          ]
+        end
+        it 'returns unique documents' do
+          expect(subject.size).to eq(1)
+          expect(subject).to match_array([page_with_2_filters])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
[TP 10209](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=userstory/10209)

#### Bug
When searching documents on the evidence hub by multiple values for Topics or Client Groups, duplicate results are being displayed.

#### Solution
We execute a very complicated sql query in order to allow the user to filter/search documents by keyword, document type and/or various filters. Amend the query to ensure it only returns distinct results.

#### Technical detail
`DocumentProvider` builds the query, which only gets executed in the controller. We need to force the query to load to ensure the mix of raw sql and rails's `activerecord` methods used in the query, are performed in the correct order. 

Specifically, forcing the load ensures the `size` method acts on the results after the `distinct` is executed. 