### PR TITLE
[DEV APPROVED] [10142] - Ruby upgrade to 2.5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     algoliasearch (1.19.1)
       httpclient (~> 2.8.3)
@@ -704,7 +704,7 @@ GEM
       chronic (>= 0.6.3)
     xml-simple (1.1.5)
     xmlrpc (0.3.0)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,7 +7,11 @@ require 'capybara/poltergeist'
 require 'aruba/cucumber'
 require 'database_cleaner/cucumber'
 
-DatabaseCleaner.strategy = :truncation
+begin
+  DatabaseCleaner.strategy = :truncation
+rescue NameError
+  raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
+end
 
 Around do |scenario, block|
   DatabaseCleaner.cleaning(&block)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,6 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-
   config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
@@ -53,7 +52,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction 
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
+
   config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
@@ -52,7 +53,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.strategy = :transaction 
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
[Tp Card](https://moneyadviceservice.tpondemand.com/entity/10142-upgrade-cms-repo-to-ruby-253)

## Context

- The main issue with this upgrade was the Cucumber suite. I had non-deterministic failures (~ 25% of the times: Deadlock in Mysql) which were quite tricky to track. After some digging it seems to be due to a mix of configuration and dependencies:

- `Capybara` was locked to a fairly outdated version, and this seems to be part of the issue. Main source of information [here](https://github.com/teamcapybara/capybara/issues/1089)

- `database_cleaner` was not configure to clean Around each feature which might have created concurrencies problems in the db (as far as I can see, a new spec trying to write while DC was still cleaning)

## Test results

- After these changes, I had a successful 15+ full runs on cucumber so I am quite confident to proceed (I am still testing and still have to encounter a failure, so even in case of a false positives chances are very low)

## Other small changes

- More info in the commits messages (i.e: I have added a fail-fast option to cucumber, so the dev doesn't have to wait for the full suite in case of issues)