### PR TITLE
Lock Ruby Parser to v3.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'rails', '4.2.10'
 gem 'remotipart', '~> 1.2'
 gem 'responders', '~> 2.0'
 gem 'reverse_markdown'
+gem 'ruby_parser', '~> 3.11.0' # Locked as 3.12 bump broke tests at Go Pipeline
 gem 'sass-rails', '~> 4.0.3'
 gem 'terminal-table'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -519,7 +519,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-prof (0.16.2)
     ruby-progressbar (1.10.0)
-    ruby_parser (3.12.0)
+    ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
     safe_yaml (1.0.4)
     sass (3.2.19)
@@ -659,6 +659,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 0.59)
   ruby-prof
+  ruby_parser (~> 3.11.0)
   sass-rails (~> 4.0.3)
   seedbank
   shoulda-matchers


### PR DESCRIPTION
Upgrade to v3.12 that came with the PACS v2.2 bump seems to break go pipelines tests as trims
the expected return carriages when parsing HTML blocks.