### PR TITLE
[DEV APPROVED] Add #field_text at CMS::FormBuilder

### DIFF
--- a/lib/cms/form_builder.rb
+++ b/lib/cms/form_builder.rb
@@ -86,6 +86,10 @@ class Cms::FormBuilder < ActionView::Helpers::FormBuilder
     default_tag_field(tag, index)
   end
 
+  def field_text(tag, index)
+    default_tag_field(tag, index)
+  end
+
   def field_name_for(tag)
     tag.blockable.class.name.demodulize.underscore.gsub(/\//, '_')
   end


### PR DESCRIPTION
CONTEXT:

During the work dockerizing CMS for Jenkins CI tests runs, a
"Building Homepage Pages" feature test started failing.
(features/pages_form/mas_homepage_pages.feature)

Error:
undefined method `field_text' for <Cms::FormBuilder:0x0055c3e6eb8688>
Did you mean?  field_date_time (ActionView::Template::Error)
      ./app/helpers/pages_helper.rb:9:in `tag_for_identifier'

This test was sistematically failing in Docker, but running correctly
on developers machines (Macbooks).

As I use Linux as a development machine I actually had the same issue
with this test as Jenkins Docker runs.

Debugging the issue locally, I found that the main issue it comes from
the tag classes differing between Linux and Mac environments:
- Linux "tag.class" returns  ComfortableMexicanSofa::Tag::FieldText
- Mac "tag.class" returns  ComfortableMexicanSofa::Tag::FieldString

Both seems to be valid Tag classes with almost identical definitions
in our comfortable-mexican-sofa gem fork:
- https://github.com/moneyadviceservice/comfortable-mexican-sofa/tree/master/lib/comfortable_mexican_sofa/tags

WHY I TOOK THIS APPROACH:

Seems something in the local runtime makes Linux and Mac machines differ
about what tag class to use between FieldText and FieldString, but in
our CMS::FormBuilder class we only have an implementation for
FieldString tags.

Adding a FieldText implementation in CMS::FormBuilder gives use the same
behaviour independently of the running environment, while won't affect
previous codebase as we're not adding any logic switch, but covering a
further tag that wasn't covered until now.


As an example of how tags are mapped in Linux:
```ruby
2.3.3 (#<#<Class:0x00558b321e1fc8>:0x00558b356a1c18>):0 > tags.map(&:class)
=> [ComfortableMexicanSofa::Tag::PageString,
 ComfortableMexicanSofa::Tag::PageImage,
 ComfortableMexicanSofa::Tag::PageString,
 ComfortableMexicanSofa::Tag::PageString,
 ComfortableMexicanSofa::Tag::PageString,
 ComfortableMexicanSofa::Tag::PageString,
 ComfortableMexicanSofa::Tag::PageString,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageImage,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageImage,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageImage,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageImage,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::PageText,
 ComfortableMexicanSofa::Tag::FieldText,
 ComfortableMexicanSofa::Tag::FieldText]
2.3.3 (#<#<Class:0x00558b321e1fc8>:0x00558b356a1c18>):0 > tags.map(&:identifier)
=> ["raw_heading",
 "raw_hero_image",
 "raw_bullet_1",
 "raw_bullet_2",
 "raw_bullet_3",
 "raw_cta_text",
 "raw_cta_link",
 "raw_tool_1_heading",
 "raw_tool_1_url",
 "raw_tool_1_text",
 "raw_tool_2_heading",
 "raw_tool_2_url",
 "raw_tool_2_text",
 "raw_tool_3_heading",
 "raw_tool_3_url",
 "raw_tool_3_text",
 "raw_tile_1_heading",
 "raw_tile_1_image",
 "raw_tile_1_url",
 "raw_tile_1_label",
 "raw_tile_1_content",
 "raw_tile_2_heading",
 "raw_tile_2_image",
 "raw_tile_2_url",
 "raw_tile_2_label",
 "raw_tile_2_content",
 "raw_tile_3_heading",
 "raw_tile_3_image",
 "raw_tile_3_url",
 "raw_tile_3_label",
 "raw_tile_3_content",
 "raw_tile_4_heading",
 "raw_tile_4_image",
 "raw_tile_4_url",
 "raw_tile_4_label",
 "raw_tile_4_content",
 "raw_text_tile_1_heading",
 "raw_text_tile_1_url",
 "raw_text_tile_1_content",
 "raw_text_tile_2_heading",
 "raw_text_tile_2_url",
 "raw_text_tile_2_content",
 "raw_promo_banner_content",
 "raw_promo_banner_url"]
```

All these `FieldText` would be `FieldString` on Mac environment.