### PR TITLE
Use sfgb-bundle-2.5.3 docker image

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM masdevtestregistry.azurecr.io/jenkins/ruby2.5.3:latest
+FROM masdevtestregistry.azurecr.io/jenkins/sfgb-bundle-2.5.3:latest
 MAINTAINER development.team@moneyadviceservice.org.uk
 
 RUN apt-get -qq update > /dev/null && \
@@ -7,3 +7,5 @@ RUN apt-get -qq update > /dev/null && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY . /var/tmp/app/
+
+WORKDIR /var/tmp/app

--- a/jenkins/test
+++ b/jenkins/test
@@ -14,15 +14,13 @@ export RAILS_ENV=test
 export BUNDLE_WITHOUT=development:build
 export APP_NAME=MAS
 
-exit_code=0
-
 function run {
     declare -a tests_command=("$@")
     echo ''
     echo "=== Running \`${tests_command[*]}\`"
     if ! ${tests_command[*]}; then
         echo "=== These tests failed."
-        exit_code=1
+        exit 1
     fi
 }
 
@@ -45,5 +43,3 @@ run bundle exec cucumber
 run ./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js --single-run
 info brakeman -q --no-pager --ensure-latest
 run bundle exec danger --dangerfile=jenkins/Dangerfile --verbose
-
-exit "$exit_code"


### PR DESCRIPTION
Apply the new base docker image with bundled gems baked into it. 

Jenkins pipeline should be significantly quicker as this reduces duration by around 5-6 mins.

[Builder - Base image PR](https://github.com/moneyadviceservice/builder/pull/68)